### PR TITLE
Phase 13 inventory accounting groundwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ See `.env.example` for all configuration options. Key variables:
 
 See [docs/finance_metric_naming.md](./docs/finance_metric_naming.md) for the canonical glossary, naming matrix, formulas, and operational-vs-financial metric definitions used by the app.
 
+## Inventory Valuation Groundwork
+
+Phase 13 raw-material valuation groundwork now includes material receipt / lot tracking and landed cost documentation:
+- [docs/material_receipts_valuation.md](./docs/material_receipts_valuation.md)
+
 ## Accounting Foundation Status
 
 Phase 12 groundwork now includes initial accounting-domain tables, services, and APIs for:

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ See [docs/finance_metric_naming.md](./docs/finance_metric_naming.md) for the can
 Phase 13 inventory accounting groundwork now includes:
 - raw-material receipt / lot tracking and landed cost documentation in [docs/material_receipts_valuation.md](./docs/material_receipts_valuation.md)
 - production and sales posting behavior documentation in [docs/inventory_accounting_postings.md](./docs/inventory_accounting_postings.md)
+- scrap / waste / failed-print workflow documentation in [docs/scrap_and_waste_workflows.md](./docs/scrap_and_waste_workflows.md)
 
 ## Accounting Foundation Status
 

--- a/README.md
+++ b/README.md
@@ -247,8 +247,9 @@ See [docs/finance_metric_naming.md](./docs/finance_metric_naming.md) for the can
 
 ## Inventory Valuation Groundwork
 
-Phase 13 raw-material valuation groundwork now includes material receipt / lot tracking and landed cost documentation:
-- [docs/material_receipts_valuation.md](./docs/material_receipts_valuation.md)
+Phase 13 inventory accounting groundwork now includes:
+- raw-material receipt / lot tracking and landed cost documentation in [docs/material_receipts_valuation.md](./docs/material_receipts_valuation.md)
+- production and sales posting behavior documentation in [docs/inventory_accounting_postings.md](./docs/inventory_accounting_postings.md)
 
 ## Accounting Foundation Status
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -26,6 +26,7 @@ from app.models.account import Account  # noqa
 from app.models.accounting_period import AccountingPeriod  # noqa
 from app.models.journal_entry import JournalEntry  # noqa
 from app.models.journal_line import JournalLine  # noqa
+from app.models.material_receipt import MaterialReceipt  # noqa
 
 config = context.config
 if config.config_file_name is not None:

--- a/backend/alembic/versions/20260322_01_add_material_receipts.py
+++ b/backend/alembic/versions/20260322_01_add_material_receipts.py
@@ -1,0 +1,49 @@
+"""add material receipts
+
+Revision ID: 20260322_01
+Revises: 20260321_01
+Create Date: 2026-03-22 06:40:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260322_01"
+down_revision: Union[str, None] = "20260321_01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "material_receipts",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("material_id", sa.UUID(), nullable=False),
+        sa.Column("vendor_name", sa.String(length=120), nullable=False),
+        sa.Column("purchase_date", sa.Date(), nullable=False),
+        sa.Column("receipt_number", sa.String(length=60), nullable=True),
+        sa.Column("quantity_purchased_g", sa.Numeric(12, 2), nullable=False),
+        sa.Column("quantity_remaining_g", sa.Numeric(12, 2), nullable=False),
+        sa.Column("unit_cost_per_g", sa.Numeric(12, 6), nullable=False),
+        sa.Column("landed_cost_total", sa.Numeric(12, 2), nullable=False, server_default="0"),
+        sa.Column("landed_cost_per_g", sa.Numeric(12, 6), nullable=False, server_default="0"),
+        sa.Column("total_cost", sa.Numeric(12, 2), nullable=False),
+        sa.Column("valuation_method", sa.String(length=20), nullable=False, server_default="lot"),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["material_id"], ["materials.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_material_receipts_material_id"), "material_receipts", ["material_id"], unique=False)
+    op.create_index(op.f("ix_material_receipts_vendor_name"), "material_receipts", ["vendor_name"], unique=False)
+    op.create_index(op.f("ix_material_receipts_purchase_date"), "material_receipts", ["purchase_date"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_material_receipts_purchase_date"), table_name="material_receipts")
+    op.drop_index(op.f("ix_material_receipts_vendor_name"), table_name="material_receipts")
+    op.drop_index(op.f("ix_material_receipts_material_id"), table_name="material_receipts")
+    op.drop_table("material_receipts")

--- a/backend/app/api/v1/endpoints/materials.py
+++ b/backend/app/api/v1/endpoints/materials.py
@@ -8,7 +8,10 @@ from sqlalchemy import func, select
 
 from app.api.deps import DB, CurrentUser
 from app.models.material import Material
+from app.models.material_receipt import MaterialReceipt
 from app.schemas.material import MaterialCreate, MaterialResponse, MaterialUpdate
+from app.schemas.material_receipt import MaterialReceiptCreate, MaterialReceiptResponse
+from app.services.material_receipt_service import create_material_receipt
 
 router = APIRouter(prefix="/materials", tags=["Materials"])
 
@@ -84,6 +87,37 @@ async def update_material(material_id: uuid.UUID, body: MaterialUpdate, user: Cu
     await db.commit()
     await db.refresh(mat)
     return mat
+
+
+@router.get(
+    "/{material_id}/receipts",
+    response_model=list[MaterialReceiptResponse],
+    summary="List material receipts/lots",
+)
+async def list_material_receipts(material_id: uuid.UUID, db: DB):
+    material = (await db.execute(select(Material).where(Material.id == material_id))).scalar_one_or_none()
+    if not material:
+        raise HTTPException(status_code=404, detail="Material not found")
+    result = await db.execute(
+        select(MaterialReceipt)
+        .where(MaterialReceipt.material_id == material_id)
+        .order_by(MaterialReceipt.purchase_date.desc(), MaterialReceipt.created_at.desc())
+    )
+    return result.scalars().all()
+
+
+@router.post(
+    "/{material_id}/receipts",
+    response_model=MaterialReceiptResponse,
+    status_code=201,
+    summary="Create material receipt/lot",
+)
+async def create_receipt(material_id: uuid.UUID, body: MaterialReceiptCreate, user: CurrentUser, db: DB):
+    material = (await db.execute(select(Material).where(Material.id == material_id))).scalar_one_or_none()
+    if not material:
+        raise HTTPException(status_code=404, detail="Material not found")
+    receipt = await create_material_receipt(db, material=material, payload=body)
+    return receipt
 
 
 @router.delete(

--- a/backend/app/models/material.py
+++ b/backend/app/models/material.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 
 from sqlalchemy import Boolean, DateTime, Integer, Numeric, String, Text
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
 
@@ -32,3 +32,5 @@ class Material(Base):
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
+
+    receipts = relationship("MaterialReceipt", back_populates="material", cascade="all, delete-orphan")

--- a/backend/app/models/material_receipt.py
+++ b/backend/app/models/material_receipt.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import Date, DateTime, ForeignKey, Numeric, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class MaterialReceipt(Base):
+    __tablename__ = "material_receipts"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    material_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("materials.id"), index=True)
+    vendor_name: Mapped[str] = mapped_column(String(120), index=True)
+    purchase_date: Mapped[date] = mapped_column(Date, index=True)
+    receipt_number: Mapped[str | None] = mapped_column(String(60), nullable=True)
+    quantity_purchased_g: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    quantity_remaining_g: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    unit_cost_per_g: Mapped[Decimal] = mapped_column(Numeric(12, 6))
+    landed_cost_total: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    landed_cost_per_g: Mapped[Decimal] = mapped_column(Numeric(12, 6), default=0)
+    total_cost: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    valuation_method: Mapped[str] = mapped_column(String(20), default="lot")
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    material = relationship("Material", back_populates="receipts")

--- a/backend/app/schemas/material_receipt.py
+++ b/backend/app/schemas/material_receipt.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import datetime
+import uuid
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+class MaterialReceiptCreate(BaseModel):
+    vendor_name: str = Field(..., min_length=1, max_length=120)
+    purchase_date: datetime.date
+    receipt_number: str | None = Field(None, max_length=60)
+    quantity_purchased_g: Decimal = Field(..., gt=0)
+    unit_cost_per_g: Decimal = Field(..., gt=0)
+    landed_cost_total: Decimal = Field(0, ge=0)
+    valuation_method: str = Field("lot", pattern="^(lot|average)$")
+    notes: str | None = Field(None, max_length=500)
+
+
+class MaterialReceiptResponse(BaseModel):
+    id: uuid.UUID
+    material_id: uuid.UUID
+    vendor_name: str
+    purchase_date: datetime.date
+    receipt_number: str | None = None
+    quantity_purchased_g: Decimal
+    quantity_remaining_g: Decimal
+    unit_cost_per_g: Decimal
+    landed_cost_total: Decimal
+    landed_cost_per_g: Decimal
+    total_cost: Decimal
+    valuation_method: str
+    notes: str | None = None
+    created_at: datetime.datetime | None = None
+    updated_at: datetime.datetime | None = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/inventory_accounting_service.py
+++ b/backend/app/services/inventory_accounting_service.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account
+from app.models.job import Job
+from app.models.journal_entry import JournalEntry
+from app.models.material_receipt import MaterialReceipt
+from app.models.sale import Sale
+from app.models.sale_item import SaleItem
+from app.schemas.accounting import JournalEntryCreate, JournalLineCreate
+from app.services.accounting_service import create_journal_entry
+
+
+async def _get_account_by_code(db: AsyncSession, code: str) -> Account:
+    result = await db.execute(select(Account).where(Account.code == code))
+    account = result.scalar_one_or_none()
+    if not account:
+        raise ValueError(f"Required account with code {code} not found")
+    return account
+
+
+async def _journal_entry_exists(db: AsyncSession, source_type: str, source_id: str) -> bool:
+    result = await db.execute(
+        select(JournalEntry.id).where(
+            JournalEntry.source_type == source_type,
+            JournalEntry.source_id == source_id,
+        )
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def consume_material_receipts_for_job(db: AsyncSession, job: Job) -> None:
+    if not job.material_id:
+        return
+
+    total_material_g = Decimal(job.material_per_plate_g) * job.num_plates
+    if total_material_g <= 0:
+        return
+
+    receipts = (
+        await db.execute(
+            select(MaterialReceipt)
+            .where(
+                MaterialReceipt.material_id == job.material_id,
+                MaterialReceipt.quantity_remaining_g > 0,
+            )
+            .order_by(MaterialReceipt.purchase_date.asc(), MaterialReceipt.created_at.asc())
+        )
+    ).scalars().all()
+
+    remaining = total_material_g
+    for receipt in receipts:
+        if remaining <= 0:
+            break
+        available = Decimal(receipt.quantity_remaining_g)
+        consume = min(available, remaining)
+        receipt.quantity_remaining_g = available - consume
+        remaining -= consume
+
+
+async def post_finished_goods_from_job(db: AsyncSession, job: Job) -> None:
+    source_id = str(job.id)
+    if await _journal_entry_exists(db, "job_production", source_id):
+        return
+
+    finished_goods = await _get_account_by_code(db, "1400")
+    wip = await _get_account_by_code(db, "1300")
+    total_value = Decimal(job.cost_per_piece) * job.total_pieces
+    if total_value <= 0:
+        return
+
+    await create_journal_entry(
+        db,
+        JournalEntryCreate(
+            entry_date=job.date,
+            source_type="job_production",
+            source_id=source_id,
+            memo=f"Production completion for job {job.job_number}",
+            lines=[
+                JournalLineCreate(account_id=finished_goods.id, entry_type="debit", amount=total_value),
+                JournalLineCreate(account_id=wip.id, entry_type="credit", amount=total_value),
+            ],
+        ),
+    )
+    await consume_material_receipts_for_job(db, job)
+
+
+async def post_cogs_for_sale(db: AsyncSession, sale: Sale, items: list[SaleItem]) -> None:
+    source_id = str(sale.id)
+    if await _journal_entry_exists(db, "sale_cogs", source_id):
+        return
+
+    finished_goods = await _get_account_by_code(db, "1400")
+    material_cogs = await _get_account_by_code(db, "5000")
+    total_cogs = sum(Decimal(item.unit_cost or 0) * item.quantity for item in items if item.product_id)
+    if total_cogs <= 0:
+        return
+
+    await create_journal_entry(
+        db,
+        JournalEntryCreate(
+            entry_date=sale.date,
+            source_type="sale_cogs",
+            source_id=source_id,
+            memo=f"COGS recognition for sale {sale.sale_number}",
+            lines=[
+                JournalLineCreate(account_id=material_cogs.id, entry_type="debit", amount=total_cogs),
+                JournalLineCreate(account_id=finished_goods.id, entry_type="credit", amount=total_cogs),
+            ],
+        ),
+    )

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -7,8 +7,10 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.inventory_transaction import InventoryTransaction
+from app.models.job import Job
 from app.models.material import Material
 from app.models.product import Product
+from app.services.inventory_accounting_service import post_finished_goods_from_job
 
 
 async def generate_sku(db: AsyncSession, material_id: uuid.UUID) -> str:
@@ -58,6 +60,10 @@ async def add_inventory_from_job(
         if new_qty > 0:
             product.unit_cost = (old_total_cost + new_total_cost) / new_qty
         product.stock_qty = new_qty
+
+    job = (await db.execute(select(Job).where(Job.id == job_id))).scalar_one_or_none()
+    if job:
+        await post_finished_goods_from_job(db, job)
 
     return txn
 

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -68,6 +68,39 @@ async def add_inventory_from_job(
     return txn
 
 
+async def record_scrap_inventory(
+    db: AsyncSession,
+    *,
+    product: Product,
+    quantity: int,
+    event_type: str,
+    reason: str,
+    notes: str | None = None,
+    unit_cost: Decimal | None = None,
+    user_id: uuid.UUID | None = None,
+) -> InventoryTransaction:
+    if quantity <= 0:
+        raise ValueError("Scrap quantity must be greater than zero.")
+    if event_type not in {"scrap", "failed_print", "writeoff", "rework"}:
+        raise ValueError("Unsupported scrap event type.")
+
+    resolved_cost = unit_cost if unit_cost is not None else product.unit_cost
+    txn = InventoryTransaction(
+        product_id=product.id,
+        type=event_type,
+        quantity=-quantity,
+        unit_cost=resolved_cost,
+        notes=f"{reason}" + (f" | {notes}" if notes else ""),
+        created_by=user_id,
+    )
+    db.add(txn)
+    product.stock_qty = max(0, product.stock_qty - quantity)
+    await db.commit()
+    await db.refresh(txn)
+    await db.refresh(product)
+    return txn
+
+
 async def adjust_stock(
     db: AsyncSession,
     product_id: uuid.UUID,

--- a/backend/app/services/material_receipt_service.py
+++ b/backend/app/services/material_receipt_service.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.material import Material
+from app.models.material_receipt import MaterialReceipt
+from app.schemas.material_receipt import MaterialReceiptCreate
+
+
+async def create_material_receipt(
+    db: AsyncSession,
+    *,
+    material: Material,
+    payload: MaterialReceiptCreate,
+) -> MaterialReceipt:
+    landed_cost_per_g = (payload.landed_cost_total / payload.quantity_purchased_g) if payload.quantity_purchased_g > 0 else Decimal("0")
+    total_cost = (payload.unit_cost_per_g * payload.quantity_purchased_g) + payload.landed_cost_total
+
+    receipt = MaterialReceipt(
+        material_id=material.id,
+        vendor_name=payload.vendor_name,
+        purchase_date=payload.purchase_date,
+        receipt_number=payload.receipt_number,
+        quantity_purchased_g=payload.quantity_purchased_g,
+        quantity_remaining_g=payload.quantity_purchased_g,
+        unit_cost_per_g=payload.unit_cost_per_g,
+        landed_cost_total=payload.landed_cost_total,
+        landed_cost_per_g=landed_cost_per_g,
+        total_cost=total_cost,
+        valuation_method=payload.valuation_method,
+        notes=payload.notes,
+    )
+    db.add(receipt)
+
+    # keep the material's current cost basis grounded in receipt data
+    all_receipts_stmt = select(
+        func.coalesce(func.sum(MaterialReceipt.total_cost), 0),
+        func.coalesce(func.sum(MaterialReceipt.quantity_purchased_g), 0),
+    ).where(MaterialReceipt.material_id == material.id)
+    current_total_cost, current_total_qty = (await db.execute(all_receipts_stmt)).one()
+    new_total_cost = Decimal(current_total_cost) + total_cost
+    new_total_qty = Decimal(current_total_qty) + payload.quantity_purchased_g
+    if new_total_qty > 0:
+        material.cost_per_g = new_total_cost / new_total_qty
+        material.spool_price = total_cost
+        material.net_usable_g = payload.quantity_purchased_g
+        material.spool_weight_g = payload.quantity_purchased_g
+        material.spools_in_stock = max(material.spools_in_stock, 1)
+
+    await db.commit()
+    await db.refresh(receipt)
+    await db.refresh(material)
+    return receipt

--- a/backend/app/services/sales_service.py
+++ b/backend/app/services/sales_service.py
@@ -11,6 +11,7 @@ from app.models.sale_item import SaleItem
 from app.models.sales_channel import SalesChannel
 from app.models.product import Product
 from app.models.inventory_transaction import InventoryTransaction
+from app.services.inventory_accounting_service import post_cogs_for_sale
 
 
 async def generate_sale_number(db: AsyncSession) -> str:
@@ -80,6 +81,10 @@ async def deduct_inventory_for_sale(
         )
         db.add(txn)
         product.stock_qty = max(0, product.stock_qty - item.quantity)
+
+    sale = (await db.execute(select(Sale).where(Sale.id == sale_id))).scalar_one_or_none()
+    if sale:
+        await post_cogs_for_sale(db, sale, items)
 
 
 async def restore_inventory_for_refund(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,6 +18,7 @@ from app.core.security import hash_password
 from app.main import app
 from app.models.customer import Customer
 from app.models.material import Material
+from app.models.material_receipt import MaterialReceipt
 from app.models.rate import Rate
 from app.models.setting import Setting
 from app.models.user import User

--- a/backend/tests/test_api_materials.py
+++ b/backend/tests/test_api_materials.py
@@ -96,6 +96,39 @@ async def test_update_material(client, seed_material, auth_headers):
 
 
 @pytest.mark.asyncio
+async def test_create_and_list_material_receipts(client, seed_material, auth_headers):
+    create_resp = await client.post(
+        f"/api/v1/materials/{seed_material.id}/receipts",
+        json={
+            "vendor_name": "MatterHackers",
+            "purchase_date": "2026-03-22",
+            "receipt_number": "PO-1001",
+            "quantity_purchased_g": "1000",
+            "unit_cost_per_g": "0.020000",
+            "landed_cost_total": "5.00",
+            "valuation_method": "lot",
+            "notes": "Initial stocked spool",
+        },
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+    created = create_resp.json()
+    assert float(created["landed_cost_per_g"]) == pytest.approx(0.005, rel=1e-5)
+    assert float(created["total_cost"]) == pytest.approx(25.0, rel=1e-5)
+    assert float(created["quantity_remaining_g"]) == pytest.approx(1000.0, rel=1e-5)
+
+    list_resp = await client.get(f"/api/v1/materials/{seed_material.id}/receipts")
+    assert list_resp.status_code == 200
+    receipts = list_resp.json()
+    assert len(receipts) == 1
+    assert receipts[0]["vendor_name"] == "MatterHackers"
+
+    material_resp = await client.get(f"/api/v1/materials/{seed_material.id}")
+    assert material_resp.status_code == 200
+    assert float(material_resp.json()["cost_per_g"]) == pytest.approx(0.025, rel=1e-5)
+
+
+@pytest.mark.asyncio
 async def test_delete_material(client, seed_material, auth_headers):
     resp = await client.delete(
         f"/api/v1/materials/{seed_material.id}", headers=auth_headers

--- a/backend/tests/test_inventory_accounting.py
+++ b/backend/tests/test_inventory_accounting.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account
+from app.models.inventory_transaction import InventoryTransaction
+from app.models.job import Job
+from app.models.journal_entry import JournalEntry
+from app.models.material import Material
+from app.models.material_receipt import MaterialReceipt
+from app.models.product import Product
+from app.models.sale import Sale
+from app.models.sale_item import SaleItem
+from app.services.accounting_service import seed_chart_of_accounts
+from app.services.inventory_accounting_service import post_cogs_for_sale, post_finished_goods_from_job
+from app.services.material_receipt_service import create_material_receipt
+from app.schemas.material_receipt import MaterialReceiptCreate
+
+
+@pytest_asyncio.fixture
+async def seed_product(db_session: AsyncSession, seed_material: Material) -> Product:
+    product = Product(
+        sku="INV-ACCT-001",
+        name="Inventory Accounted Product",
+        material_id=seed_material.id,
+        unit_cost=Decimal("4.00"),
+        unit_price=Decimal("12.00"),
+        stock_qty=10,
+        reorder_point=2,
+        is_active=True,
+    )
+    db_session.add(product)
+    await db_session.commit()
+    await db_session.refresh(product)
+    return product
+
+
+@pytest.mark.asyncio
+async def test_post_finished_goods_from_job_creates_inventory_journal_and_consumes_receipts(db_session: AsyncSession, seed_material: Material, seed_product: Product):
+    await seed_chart_of_accounts(db_session)
+    await create_material_receipt(
+        db_session,
+        material=seed_material,
+        payload=MaterialReceiptCreate(
+            vendor_name="Vendor A",
+            purchase_date=date(2026, 3, 22),
+            quantity_purchased_g=Decimal("1000"),
+            unit_cost_per_g=Decimal("0.020000"),
+            landed_cost_total=Decimal("0.00"),
+            valuation_method="lot",
+        ),
+    )
+
+    job = Job(
+        job_number="JOB-ACCT-001",
+        date=date(2026, 3, 22),
+        material_id=seed_material.id,
+        product_id=seed_product.id,
+        product_name=seed_product.name,
+        qty_per_plate=2,
+        num_plates=3,
+        material_per_plate_g=Decimal("100"),
+        print_time_per_plate_hrs=Decimal("1.0"),
+        labor_mins=10,
+        design_time_hrs=Decimal("0"),
+        shipping_cost=Decimal("0"),
+        target_margin_pct=Decimal("25"),
+        total_pieces=6,
+        material_cost=Decimal("12.00"),
+        labor_cost=Decimal("2.00"),
+        design_cost=Decimal("0.00"),
+        machine_cost=Decimal("3.00"),
+        electricity_cost=Decimal("1.00"),
+        overhead=Decimal("2.00"),
+        total_cost=Decimal("20.00"),
+        cost_per_piece=Decimal("3.3333"),
+        total_revenue=Decimal("30.00"),
+        platform_fees=Decimal("0.00"),
+        net_profit=Decimal("10.00"),
+        profit_per_piece=Decimal("1.6667"),
+        price_per_piece=Decimal("5.00"),
+        status="completed",
+        inventory_added=True,
+    )
+    db_session.add(job)
+    await db_session.commit()
+    await db_session.refresh(job)
+
+    await post_finished_goods_from_job(db_session, job)
+
+    entry = (await db_session.execute(select(JournalEntry).where(JournalEntry.source_type == "job_production", JournalEntry.source_id == str(job.id)))).scalar_one()
+    assert entry is not None
+
+    receipt = (await db_session.execute(select(MaterialReceipt).where(MaterialReceipt.material_id == seed_material.id))).scalar_one()
+    assert float(receipt.quantity_remaining_g) == pytest.approx(700.0, rel=1e-5)
+
+
+@pytest.mark.asyncio
+async def test_post_cogs_for_sale_creates_cogs_journal_entry(db_session: AsyncSession, seed_product: Product):
+    await seed_chart_of_accounts(db_session)
+
+    sale = Sale(
+        sale_number="S-2026-ACCT-001",
+        date=date(2026, 3, 22),
+        status="paid",
+        subtotal=Decimal("25.00"),
+        shipping_charged=Decimal("0.00"),
+        shipping_cost=Decimal("0.00"),
+        platform_fees=Decimal("0.00"),
+        tax_collected=Decimal("0.00"),
+        total=Decimal("25.00"),
+        net_revenue=Decimal("15.00"),
+    )
+    db_session.add(sale)
+    await db_session.flush()
+    item = SaleItem(
+        sale_id=sale.id,
+        product_id=seed_product.id,
+        description="Test product",
+        quantity=2,
+        unit_price=Decimal("12.50"),
+        unit_cost=Decimal("4.00"),
+        line_total=Decimal("25.00"),
+    )
+    db_session.add(item)
+    await db_session.commit()
+    await db_session.refresh(sale)
+
+    await post_cogs_for_sale(db_session, sale, [item])
+
+    entry = (await db_session.execute(select(JournalEntry).where(JournalEntry.source_type == "sale_cogs", JournalEntry.source_id == str(sale.id)))).scalar_one()
+    assert entry is not None

--- a/backend/tests/test_inventory_scrap.py
+++ b/backend/tests/test_inventory_scrap.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.product import Product
+from app.models.material import Material
+from app.services.inventory_service import record_scrap_inventory
+
+
+@pytest_asyncio.fixture
+async def scrap_material(db_session: AsyncSession) -> Material:
+    material = Material(
+        name="PLA Gray",
+        cost_per_g=Decimal("0.025"),
+        spool_weight_g=1000,
+        spool_price=Decimal("25.00"),
+        net_usable_g=1000,
+        spools_in_stock=1,
+        reorder_point=1,
+        active=True,
+    )
+    db_session.add(material)
+    await db_session.commit()
+    await db_session.refresh(material)
+    return material
+
+
+@pytest_asyncio.fixture
+async def scrap_product(db_session: AsyncSession, scrap_material: Material) -> Product:
+    product = Product(
+        sku="SCRAP-001",
+        name="Scrap Test Product",
+        material_id=scrap_material.id,
+        unit_cost=Decimal("4.50"),
+        unit_price=Decimal("12.00"),
+        stock_qty=10,
+        reorder_point=2,
+        is_active=True,
+    )
+    db_session.add(product)
+    await db_session.commit()
+    await db_session.refresh(product)
+    return product
+
+
+@pytest.mark.asyncio
+async def test_record_scrap_inventory_reduces_stock_and_creates_txn(db_session: AsyncSession, scrap_product: Product):
+    txn = await record_scrap_inventory(
+        db_session,
+        product=scrap_product,
+        quantity=3,
+        event_type="scrap",
+        reason="Warped prints from bad bed adhesion",
+    )
+
+    assert txn.type == "scrap"
+    assert txn.quantity == -3
+    assert float(txn.unit_cost) == pytest.approx(4.5)
+    assert "Warped prints" in (txn.notes or "")
+    assert scrap_product.stock_qty == 7
+
+
+@pytest.mark.asyncio
+async def test_record_failed_print_uses_override_cost(db_session: AsyncSession, scrap_product: Product):
+    txn = await record_scrap_inventory(
+        db_session,
+        product=scrap_product,
+        quantity=2,
+        event_type="failed_print",
+        reason="Nozzle clog",
+        notes="Batch 2 overnight run",
+        unit_cost=Decimal("5.25"),
+    )
+
+    assert txn.type == "failed_print"
+    assert float(txn.unit_cost) == pytest.approx(5.25)
+    assert "Nozzle clog" in (txn.notes or "")
+    assert "Batch 2 overnight run" in (txn.notes or "")
+    assert scrap_product.stock_qty == 8
+
+
+@pytest.mark.asyncio
+async def test_record_scrap_rejects_invalid_quantity(db_session: AsyncSession, scrap_product: Product):
+    with pytest.raises(ValueError, match="greater than zero"):
+        await record_scrap_inventory(
+            db_session,
+            product=scrap_product,
+            quantity=0,
+            event_type="scrap",
+            reason="Invalid quantity",
+        )

--- a/backend/tests/test_inventory_scrap.py
+++ b/backend/tests/test_inventory_scrap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+import uuid
 
 import pytest
 import pytest_asyncio
@@ -32,7 +33,7 @@ async def scrap_material(db_session: AsyncSession) -> Material:
 @pytest_asyncio.fixture
 async def scrap_product(db_session: AsyncSession, scrap_material: Material) -> Product:
     product = Product(
-        sku="SCRAP-001",
+        sku=f"SCRAP-{uuid.uuid4().hex[:8]}",
         name="Scrap Test Product",
         material_id=scrap_material.id,
         unit_cost=Decimal("4.50"),

--- a/backend/tests/test_material_receipts.py
+++ b/backend/tests/test_material_receipts.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.material import Material
+from app.models.material_receipt import MaterialReceipt
+from app.schemas.material_receipt import MaterialReceiptCreate
+from app.services.material_receipt_service import create_material_receipt
+
+
+@pytest.mark.asyncio
+async def test_create_material_receipt_calculates_landed_cost_and_remaining_qty(db_session: AsyncSession, seed_material: Material):
+    receipt = await create_material_receipt(
+        db_session,
+        material=seed_material,
+        payload=MaterialReceiptCreate(
+            vendor_name="MatterHackers",
+            purchase_date=date(2026, 3, 22),
+            receipt_number="PO-1001",
+            quantity_purchased_g=Decimal("1000"),
+            unit_cost_per_g=Decimal("0.020000"),
+            landed_cost_total=Decimal("5.00"),
+            valuation_method="lot",
+        ),
+    )
+
+    assert receipt.quantity_remaining_g == Decimal("1000")
+    assert receipt.landed_cost_per_g == Decimal("0.005")
+    assert receipt.total_cost == Decimal("25.00")
+
+
+@pytest.mark.asyncio
+async def test_material_receipt_updates_material_average_cost(db_session: AsyncSession, seed_material: Material):
+    await create_material_receipt(
+        db_session,
+        material=seed_material,
+        payload=MaterialReceiptCreate(
+            vendor_name="Vendor A",
+            purchase_date=date(2026, 3, 22),
+            quantity_purchased_g=Decimal("1000"),
+            unit_cost_per_g=Decimal("0.020000"),
+            landed_cost_total=Decimal("0.00"),
+            valuation_method="average",
+        ),
+    )
+    await create_material_receipt(
+        db_session,
+        material=seed_material,
+        payload=MaterialReceiptCreate(
+            vendor_name="Vendor B",
+            purchase_date=date(2026, 3, 23),
+            quantity_purchased_g=Decimal("500"),
+            unit_cost_per_g=Decimal("0.030000"),
+            landed_cost_total=Decimal("5.00"),
+            valuation_method="average",
+        ),
+    )
+
+    refreshed = (await db_session.execute(select(Material).where(Material.id == seed_material.id))).scalar_one()
+    assert float(refreshed.cost_per_g) == pytest.approx(45 / 1500, rel=1e-4)
+
+
+@pytest.mark.asyncio
+async def test_receipts_are_persisted_by_material(db_session: AsyncSession, seed_material: Material):
+    await create_material_receipt(
+        db_session,
+        material=seed_material,
+        payload=MaterialReceiptCreate(
+            vendor_name="Vendor A",
+            purchase_date=date(2026, 3, 22),
+            quantity_purchased_g=Decimal("1000"),
+            unit_cost_per_g=Decimal("0.020000"),
+            landed_cost_total=Decimal("2.00"),
+            valuation_method="lot",
+        ),
+    )
+
+    receipts = (await db_session.execute(select(MaterialReceipt).where(MaterialReceipt.material_id == seed_material.id))).scalars().all()
+    assert len(receipts) == 1
+    assert receipts[0].vendor_name == "Vendor A"

--- a/docs/inventory_accounting_postings.md
+++ b/docs/inventory_accounting_postings.md
@@ -1,0 +1,61 @@
+# Inventory Accounting Postings
+
+This document describes the current production and sales inventory accounting posting behavior.
+
+## Scope
+
+This is the Phase 13 posting foundation for:
+- production completion into finished goods
+- sales-time COGS recognition
+
+## Production Completion Posting
+
+When finished goods are added from a completed job, the app posts:
+- **Debit** `1400 Finished Goods Inventory`
+- **Credit** `1300 Work In Progress Inventory`
+
+### Source
+- source type: `job_production`
+- source id: job UUID
+
+### Valuation basis
+Current value posted:
+- `job.cost_per_piece * job.total_pieces`
+
+### Receipt consumption
+If the job references a material and material receipts exist, the app currently reduces receipt `quantity_remaining_g` using FIFO by purchase date.
+
+Material used is currently derived as:
+- `job.material_per_plate_g * job.num_plates`
+
+## Sales COGS Posting
+
+When product inventory is deducted for a sale, the app posts:
+- **Debit** `5000 Material COGS`
+- **Credit** `1400 Finished Goods Inventory`
+
+### Source
+- source type: `sale_cogs`
+- source id: sale UUID
+
+### Valuation basis
+Current value posted:
+- `sum(sale_item.unit_cost * quantity)` for sale items linked to products
+
+## Duplicate Posting Protection
+
+The app checks for an existing journal entry with the same source type/source id before creating another posting for the same production completion or sale COGS event.
+
+## Current Limitations
+
+- posting currently uses seeded default account codes rather than per-product/per-material account mappings
+- COGS debit currently uses `Material COGS` as the seeded default account
+- raw-material consumption updates receipt remaining quantity but does not yet create separate raw-material-to-WIP journal entries
+- deeper WIP / inventory subledger behavior will likely evolve in later inventory/accounting phases
+
+## Related Files
+
+- `backend/app/services/inventory_accounting_service.py`
+- `backend/app/services/inventory_service.py`
+- `backend/app/services/sales_service.py`
+- `backend/tests/test_inventory_accounting.py`

--- a/docs/material_receipts_valuation.md
+++ b/docs/material_receipts_valuation.md
@@ -1,0 +1,70 @@
+# Material Receipts and Valuation
+
+This document explains the raw material receipt / lot costing approach introduced for inventory accounting groundwork.
+
+## Current Valuation Approach
+
+The app now supports recording raw material purchases as **material receipts** tied to a material.
+
+Each receipt stores:
+- vendor name
+- purchase date
+- receipt/reference number
+- purchased quantity in grams
+- remaining quantity in grams
+- direct unit cost per gram
+- landed cost total
+- landed cost per gram
+- total receipt cost
+- valuation method marker
+
+## Selected Method
+
+Current implementation supports documenting:
+- `lot`
+- `average`
+
+Operationally, the current stored receipt model is **lot-aware**, because each purchase is stored separately with its own remaining quantity.
+
+For the material master record’s current `cost_per_g`, the app currently updates that value using an **aggregate weighted average across recorded receipts**.
+
+### Practical interpretation
+- receipt records preserve lot-level detail
+- material-level current cost basis is updated from receipt data using weighted average logic
+
+This is a reasonable bridge step before deeper Phase 13/14 inventory accounting work.
+
+## Landed Cost Logic
+
+For each receipt:
+
+- `landed_cost_per_g = landed_cost_total / quantity_purchased_g`
+- `total_cost = (unit_cost_per_g * quantity_purchased_g) + landed_cost_total`
+
+Example:
+- quantity purchased: `1000 g`
+- direct unit cost: `0.020000/g`
+- landed cost total: `5.00`
+
+Then:
+- direct material cost = `20.00`
+- landed cost per g = `0.005000`
+- total cost = `25.00`
+
+## Current Limitation
+
+The current implementation does **not yet consume/deplete receipts automatically** through production usage or material issue transactions.
+
+That comes later when Phase 13 inventory postings and COGS recognition are implemented.
+
+So for now, receipt records provide:
+- real purchase history
+- lot-level traceability
+- a better material cost basis than manual-only spool settings
+
+## Related Files
+
+- `backend/app/models/material_receipt.py`
+- `backend/app/services/material_receipt_service.py`
+- `backend/app/api/v1/endpoints/materials.py`
+- `backend/tests/test_material_receipts.py`

--- a/docs/scrap_and_waste_workflows.md
+++ b/docs/scrap_and_waste_workflows.md
@@ -1,0 +1,42 @@
+# Scrap, Waste, and Failed-Print Workflows
+
+This document describes the current scrap/waste workflow foundation added for inventory accounting.
+
+## Supported Event Types
+
+The app now supports dedicated inventory transaction event types for:
+- `scrap`
+- `failed_print`
+- `writeoff`
+- `rework`
+
+## Current Behavior
+
+A scrap/waste event:
+- creates an `inventory_transactions` record with a negative quantity
+- reduces product stock quantity
+- records a reason and optional notes
+- uses either the product's current `unit_cost` or an explicitly supplied override cost
+
+## Example Use Cases
+
+### Scrap
+Use when finished inventory is damaged or unusable.
+
+### Failed Print
+Use when a print run fails before it can be sold as usable finished goods.
+
+### Writeoff
+Use when inventory is being intentionally removed from stock for accounting/operational cleanup.
+
+### Rework
+Use when inventory is taken out of normal available stock because it requires correction or rework.
+
+## Current Limitation
+
+This foundation records the inventory-side event and stock impact, but it does not yet create a dedicated scrap-expense journal posting. That can be expanded in a later accounting phase if desired.
+
+## Related Files
+
+- `backend/app/services/inventory_service.py`
+- `backend/tests/test_inventory_scrap.py`

--- a/implementation_part2.md
+++ b/implementation_part2.md
@@ -92,6 +92,18 @@
   - Documented deploy, update, restart, rollback, backup, restore, logs, health checks, env changes, firewall checks, and troubleshooting commands specific to `web01.bengtson.local`
   - Linked the runbook from README and deployment planning docs
 
+### Phase 13 Planned / Starting
+- [ ] Issue #21 — Inventory accounting for raw materials, WIP, finished goods, and COGS (epic)
+  - Child issues #22, #23, and #24 will be tracked directly for implementation work
+  - Recommended execution order:
+    1. #22 — raw material purchase receipts / lot costing / landed cost tracking
+    2. #23 — production and sales inventory accounting postings with COGS recognition
+    3. #24 — scrap, waste, and failed-print costing workflows
+  - Rationale:
+    - lot/receipt costing needs to exist before inventory depletion and valuation flows are reliable
+    - production/sales postings depend on inventory value inputs
+    - scrap/waste flows should build on the valuation/posting foundation rather than invent it in parallel
+
 ### Maintenance Completed
 - [x] Issue #44 — Fix backend test environment and API rate-limit failures in local/CI test runs
   - Added repo-level `.python-version` pinned to Python 3.13

--- a/implementation_part2.md
+++ b/implementation_part2.md
@@ -103,6 +103,12 @@
     - lot/receipt costing needs to exist before inventory depletion and valuation flows are reliable
     - production/sales postings depend on inventory value inputs
     - scrap/waste flows should build on the valuation/posting foundation rather than invent it in parallel
+- [x] Issue #22 — Add raw material purchase receipts, lot costing, and landed cost tracking
+  - Added `material_receipts` model, schema, service logic, API endpoints, and Alembic revision scaffolding
+  - Added landed-cost and total-cost calculations per receipt/lot plus remaining quantity tracking
+  - Updated material-level current cost basis from recorded receipt data using weighted-average logic
+  - Added backend tests covering landed cost allocation, material valuation update behavior, and receipt persistence/API flows
+  - Added `docs/material_receipts_valuation.md` documenting the selected valuation approach and current limitations
 
 ### Maintenance Completed
 - [x] Issue #44 — Fix backend test environment and API rate-limit failures in local/CI test runs

--- a/implementation_part2.md
+++ b/implementation_part2.md
@@ -115,6 +115,11 @@
   - Added FIFO receipt quantity depletion for material usage on completed jobs
   - Added backend tests covering production posting, receipt depletion, and sale COGS journal creation
   - Added `docs/inventory_accounting_postings.md` documenting current posting behavior and limitations
+- [x] Issue #24 — Add scrap, waste, and failed-print costing workflows
+  - Added dedicated inventory event handling for `scrap`, `failed_print`, `writeoff`, and `rework`
+  - Added service logic to reduce stock, capture reason/notes, and store the event at product cost or override cost
+  - Added backend tests covering scrap reduction, failed-print override cost, and validation behavior
+  - Added `docs/scrap_and_waste_workflows.md` documenting the workflow and current accounting limitations
 
 ### Maintenance Completed
 - [x] Issue #44 — Fix backend test environment and API rate-limit failures in local/CI test runs

--- a/implementation_part2.md
+++ b/implementation_part2.md
@@ -109,6 +109,12 @@
   - Updated material-level current cost basis from recorded receipt data using weighted-average logic
   - Added backend tests covering landed cost allocation, material valuation update behavior, and receipt persistence/API flows
   - Added `docs/material_receipts_valuation.md` documenting the selected valuation approach and current limitations
+- [x] Issue #23 — Implement production and sales inventory accounting postings with COGS recognition
+  - Added inventory accounting posting service for production completion and sale-time COGS recognition
+  - Added finished-goods posting flow (Finished Goods Inventory debit / WIP credit) and sale COGS flow (Material COGS debit / Finished Goods credit)
+  - Added FIFO receipt quantity depletion for material usage on completed jobs
+  - Added backend tests covering production posting, receipt depletion, and sale COGS journal creation
+  - Added `docs/inventory_accounting_postings.md` documenting current posting behavior and limitations
 
 ### Maintenance Completed
 - [x] Issue #44 — Fix backend test environment and API rate-limit failures in local/CI test runs

--- a/implementation_part2.md
+++ b/implementation_part2.md
@@ -92,17 +92,11 @@
   - Documented deploy, update, restart, rollback, backup, restore, logs, health checks, env changes, firewall checks, and troubleshooting commands specific to `web01.bengtson.local`
   - Linked the runbook from README and deployment planning docs
 
-### Phase 13 Planned / Starting
-- [ ] Issue #21 — Inventory accounting for raw materials, WIP, finished goods, and COGS (epic)
-  - Child issues #22, #23, and #24 will be tracked directly for implementation work
-  - Recommended execution order:
-    1. #22 — raw material purchase receipts / lot costing / landed cost tracking
-    2. #23 — production and sales inventory accounting postings with COGS recognition
-    3. #24 — scrap, waste, and failed-print costing workflows
-  - Rationale:
-    - lot/receipt costing needs to exist before inventory depletion and valuation flows are reliable
-    - production/sales postings depend on inventory value inputs
-    - scrap/waste flows should build on the valuation/posting foundation rather than invent it in parallel
+### Phase 13 Completed
+- [x] Issue #21 — Inventory accounting for raw materials, WIP, finished goods, and COGS (epic)
+  - Child issues #22, #23, and #24 are complete and closed
+  - Added material receipt / lot costing, landed cost tracking, inventory accounting postings, COGS recognition, and scrap/waste workflow foundations
+  - Added Alembic revision scaffolding, backend tests, and Phase 13 inventory-accounting documentation
 - [x] Issue #22 — Add raw material purchase receipts, lot costing, and landed cost tracking
   - Added `material_receipts` model, schema, service logic, API endpoints, and Alembic revision scaffolding
   - Added landed-cost and total-cost calculations per receipt/lot plus remaining quantity tracking


### PR DESCRIPTION
## Summary
Completes the Phase 13 inventory accounting groundwork across raw material receipts, inventory postings, and scrap/waste workflows.

### Closes
- Closes #21
- Closes #22
- Closes #23
- Closes #24

## What changed
- added raw material receipt / lot tracking with landed-cost support
- added material receipt APIs and weighted-average material cost updates
- added inventory accounting posting service for:
  - production completion into finished goods
  - sale-time COGS recognition
- added FIFO receipt depletion on completed jobs
- added scrap / failed-print / writeoff / rework inventory workflow foundation
- added Phase 13 docs for receipt valuation, posting behavior, and scrap/waste workflows
- added Alembic revision scaffolding for material receipts
- updated implementation tracking docs

## Validation
- focused Phase 13 backend tests passed during final cleanup:
  - `backend/tests/test_material_receipts.py`
  - `backend/tests/test_inventory_accounting.py`
  - `backend/tests/test_inventory_scrap.py`

## Notes
This is groundwork for deeper inventory subledger, raw-material-to-WIP postings, and future financial statement expansion.
