### PR TITLE
Phase 18 controls, auditability, and trust

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -15,6 +15,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES=1440
 # App environment
 ENVIRONMENT=production
 TESTING=false
+AUTO_CREATE_SCHEMA=false
 
 # Backend CORS
 # Update this to the actual app origin once ingress is finalized.

--- a/README.md
+++ b/README.md
@@ -272,6 +272,11 @@ Phase 17 groundwork now includes:
 - [docs/formal_financial_statements.md](./docs/formal_financial_statements.md)
 - [docs/finance_dashboard_widgets.md](./docs/finance_dashboard_widgets.md)
 
+## Controls / Audit Groundwork
+
+Phase 18 groundwork now includes:
+- [docs/finance_audit_log.md](./docs/finance_audit_log.md)
+
 ## Inventory Valuation Groundwork
 
 Phase 13 inventory accounting groundwork now includes:

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Phase 17 groundwork now includes:
 
 Phase 18 groundwork now includes:
 - [docs/finance_audit_log.md](./docs/finance_audit_log.md)
+- [docs/refund_and_adjustment_approvals.md](./docs/refund_and_adjustment_approvals.md)
 
 ## Inventory Valuation Groundwork
 

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,5 +1,6 @@
 [alembic]
 script_location = alembic
+# Runtime URL is injected from app settings / environment in alembic/env.py
 sqlalchemy.url = postgresql+asyncpg://printuser:printpass@db:5432/printsales
 
 [loggers]

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -41,8 +41,10 @@ from app.models.tax_profile import TaxProfile  # noqa
 from app.models.tax_remittance import TaxRemittance  # noqa
 from app.models.marketplace_settlement import MarketplaceSettlement  # noqa
 from app.models.settlement_line import SettlementLine  # noqa
+from app.models.audit_log import AuditLog  # noqa
 
 config = context.config
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -42,6 +42,7 @@ from app.models.tax_remittance import TaxRemittance  # noqa
 from app.models.marketplace_settlement import MarketplaceSettlement  # noqa
 from app.models.settlement_line import SettlementLine  # noqa
 from app.models.audit_log import AuditLog  # noqa
+from app.models.approval_request import ApprovalRequest  # noqa
 
 config = context.config
 config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)

--- a/backend/alembic/versions/20260323_06_add_audit_logs.py
+++ b/backend/alembic/versions/20260323_06_add_audit_logs.py
@@ -1,0 +1,47 @@
+"""add audit logs
+
+Revision ID: 20260323_06
+Revises: 20260323_05
+Create Date: 2026-03-23 10:30:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260323_06"
+down_revision: Union[str, None] = "20260323_05"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("actor_user_id", sa.UUID(), nullable=True),
+        sa.Column("entity_type", sa.String(length=60), nullable=False),
+        sa.Column("entity_id", sa.String(length=120), nullable=False),
+        sa.Column("action", sa.String(length=30), nullable=False),
+        sa.Column("reason", sa.String(length=255), nullable=True),
+        sa.Column("before_snapshot", sa.JSON(), nullable=True),
+        sa.Column("after_snapshot", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["actor_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_audit_logs_actor_user_id"), "audit_logs", ["actor_user_id"], unique=False)
+    op.create_index(op.f("ix_audit_logs_entity_type"), "audit_logs", ["entity_type"], unique=False)
+    op.create_index(op.f("ix_audit_logs_entity_id"), "audit_logs", ["entity_id"], unique=False)
+    op.create_index(op.f("ix_audit_logs_action"), "audit_logs", ["action"], unique=False)
+    op.create_index(op.f("ix_audit_logs_created_at"), "audit_logs", ["created_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_audit_logs_created_at"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_action"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_entity_id"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_entity_type"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_actor_user_id"), table_name="audit_logs")
+    op.drop_table("audit_logs")

--- a/backend/alembic/versions/20260323_07_add_approval_requests.py
+++ b/backend/alembic/versions/20260323_07_add_approval_requests.py
@@ -1,0 +1,53 @@
+"""add approval requests
+
+Revision ID: 20260323_07
+Revises: 20260323_06
+Create Date: 2026-03-23 11:05:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260323_07"
+down_revision: Union[str, None] = "20260323_06"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "approval_requests",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("action_type", sa.String(length=60), nullable=False),
+        sa.Column("entity_type", sa.String(length=60), nullable=False),
+        sa.Column("entity_id", sa.String(length=120), nullable=True),
+        sa.Column("requested_by_user_id", sa.UUID(), nullable=False),
+        sa.Column("approved_by_user_id", sa.UUID(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+        sa.Column("reason", sa.String(length=255), nullable=False),
+        sa.Column("request_payload", sa.JSON(), nullable=False),
+        sa.Column("decision_notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("decided_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["approved_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["requested_by_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_approval_requests_action_type"), "approval_requests", ["action_type"], unique=False)
+    op.create_index(op.f("ix_approval_requests_approved_by_user_id"), "approval_requests", ["approved_by_user_id"], unique=False)
+    op.create_index(op.f("ix_approval_requests_entity_id"), "approval_requests", ["entity_id"], unique=False)
+    op.create_index(op.f("ix_approval_requests_entity_type"), "approval_requests", ["entity_type"], unique=False)
+    op.create_index(op.f("ix_approval_requests_requested_by_user_id"), "approval_requests", ["requested_by_user_id"], unique=False)
+    op.create_index(op.f("ix_approval_requests_status"), "approval_requests", ["status"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_approval_requests_status"), table_name="approval_requests")
+    op.drop_index(op.f("ix_approval_requests_requested_by_user_id"), table_name="approval_requests")
+    op.drop_index(op.f("ix_approval_requests_entity_type"), table_name="approval_requests")
+    op.drop_index(op.f("ix_approval_requests_entity_id"), table_name="approval_requests")
+    op.drop_index(op.f("ix_approval_requests_approved_by_user_id"), table_name="approval_requests")
+    op.drop_index(op.f("ix_approval_requests_action_type"), table_name="approval_requests")
+    op.drop_table("approval_requests")

--- a/backend/app/api/v1/endpoints/accounting.py
+++ b/backend/app/api/v1/endpoints/accounting.py
@@ -51,6 +51,7 @@ from app.schemas.recurring_expenses import (
     RecurringExpenseUpdate,
 )
 from app.services.accounting_service import AccountingValidationError, create_journal_entry, reverse_journal_entry, set_accounting_period_status
+from app.services.audit_service import create_audit_log
 
 router = APIRouter(prefix="/accounting", tags=["Accounting"])
 
@@ -184,6 +185,10 @@ async def update_bill(bill_id: uuid.UUID, body: BillUpdate, admin: CurrentAdmin,
     bill = (await db.execute(select(Bill).options(selectinload(Bill.payments)).where(Bill.id == bill_id))).scalar_one_or_none()
     if not bill:
         raise HTTPException(status_code=404, detail="Bill not found")
+    try:
+        await assert_financial_date_editable(db, target_date=bill.issue_date, detail_prefix="This bill")
+    except AccountingValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     updates = body.model_dump(exclude_unset=True)
     if "account_id" in updates:

--- a/backend/app/api/v1/endpoints/approvals.py
+++ b/backend/app/api/v1/endpoints/approvals.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import datetime
+import uuid
+from decimal import Decimal
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app.api.deps import DB, CurrentAdmin
+from app.models.approval_request import ApprovalRequest
+from app.models.product import Product
+from app.models.sale import Sale
+from app.schemas.approval import ApprovalDecisionBody, ApprovalRequestResponse
+from app.services.audit_service import create_audit_log, snapshot_model
+from app.services.inventory_service import adjust_stock
+from app.services.sales_service import restore_inventory_for_refund
+
+router = APIRouter(prefix="/approvals", tags=["Approvals"])
+
+
+@router.get("", response_model=list[ApprovalRequestResponse], summary="List approval requests (admin only)")
+async def list_approvals(admin: CurrentAdmin, db: DB, status_filter: str | None = Query(None)):
+    stmt = select(ApprovalRequest).order_by(ApprovalRequest.created_at.desc())
+    if status_filter:
+        stmt = stmt.where(ApprovalRequest.status == status_filter)
+    result = await db.execute(stmt)
+    return result.scalars().all()
+
+
+@router.post("/{approval_id}/approve", response_model=ApprovalRequestResponse, summary="Approve request (admin only)")
+async def approve_request(approval_id: uuid.UUID, body: ApprovalDecisionBody, admin: CurrentAdmin, db: DB):
+    request = (await db.execute(select(ApprovalRequest).where(ApprovalRequest.id == approval_id))).scalar_one_or_none()
+    if not request:
+        raise HTTPException(status_code=404, detail="Approval request not found")
+    if request.status != "pending":
+        raise HTTPException(status_code=400, detail="Approval request is not pending")
+
+    if request.action_type == "inventory_adjustment":
+        payload = request.request_payload
+        product = (await db.execute(select(Product).where(Product.id == payload["product_id"]))).scalar_one_or_none()
+        if not product:
+            raise HTTPException(status_code=404, detail="Product not found for approval execution")
+        before = snapshot_model(product, ["stock_qty", "unit_cost", "reorder_point"])
+        txn = await adjust_stock(
+            db=db,
+            product_id=product.id,
+            txn_type=payload["type"],
+            quantity=payload["quantity"],
+            unit_cost=Decimal(payload["unit_cost"]),
+            notes=payload.get("notes"),
+            user_id=admin.id,
+        )
+        await db.flush()
+        await db.refresh(product)
+        await create_audit_log(
+            db,
+            actor_user_id=admin.id,
+            entity_type="inventory_transaction",
+            entity_id=str(txn.id),
+            action="approve_and_execute",
+            before_snapshot={"product_id": str(product.id), **before},
+            after_snapshot={"product_id": str(product.id), **snapshot_model(product, ["stock_qty", "unit_cost", "reorder_point"])},
+            reason=request.reason,
+        )
+    elif request.action_type == "sale_refund":
+        sale = (await db.execute(select(Sale).options(selectinload(Sale.items)).where(Sale.id == request.request_payload["sale_id"]))).scalar_one_or_none()
+        if not sale:
+            raise HTTPException(status_code=404, detail="Sale not found for approval execution")
+        if sale.status != "refunded":
+            before = snapshot_model(sale, ["status", "total", "customer_name"])
+            sale.status = "refunded"
+            await restore_inventory_for_refund(db, sale, admin.id)
+            await create_audit_log(
+                db,
+                actor_user_id=admin.id,
+                entity_type="sale",
+                entity_id=str(sale.id),
+                action="approve_and_refund",
+                before_snapshot=before,
+                after_snapshot=snapshot_model(sale, ["status", "total", "customer_name"]),
+                reason=request.reason,
+            )
+
+    request.status = "approved"
+    request.approved_by_user_id = admin.id
+    request.decision_notes = body.decision_notes
+    request.decided_at = datetime.datetime.now(datetime.timezone.utc)
+    await create_audit_log(
+        db,
+        actor_user_id=admin.id,
+        entity_type="approval_request",
+        entity_id=str(request.id),
+        action="approve",
+        after_snapshot={"action_type": request.action_type, "entity_type": request.entity_type, "entity_id": request.entity_id, "status": request.status},
+        reason=request.reason,
+    )
+    await db.commit()
+    await db.refresh(request)
+    return request
+
+
+@router.post("/{approval_id}/reject", response_model=ApprovalRequestResponse, summary="Reject request (admin only)")
+async def reject_request(approval_id: uuid.UUID, body: ApprovalDecisionBody, admin: CurrentAdmin, db: DB):
+    request = (await db.execute(select(ApprovalRequest).where(ApprovalRequest.id == approval_id))).scalar_one_or_none()
+    if not request:
+        raise HTTPException(status_code=404, detail="Approval request not found")
+    if request.status != "pending":
+        raise HTTPException(status_code=400, detail="Approval request is not pending")
+    request.status = "rejected"
+    request.approved_by_user_id = admin.id
+    request.decision_notes = body.decision_notes
+    request.decided_at = datetime.datetime.now(datetime.timezone.utc)
+    await create_audit_log(
+        db,
+        actor_user_id=admin.id,
+        entity_type="approval_request",
+        entity_id=str(request.id),
+        action="reject",
+        after_snapshot={"action_type": request.action_type, "entity_type": request.entity_type, "entity_id": request.entity_id, "status": request.status},
+        reason=request.reason,
+    )
+    await db.commit()
+    await db.refresh(request)
+    return request

--- a/backend/app/api/v1/endpoints/audit.py
+++ b/backend/app/api/v1/endpoints/audit.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentAdmin
+from app.models.audit_log import AuditLog
+from app.schemas.audit import AuditLogResponse
+
+router = APIRouter(prefix="/audit", tags=["Audit"])
+
+
+@router.get("/logs", response_model=list[AuditLogResponse], summary="List audit logs (admin only)")
+async def list_audit_logs(
+    admin: CurrentAdmin,
+    db: DB,
+    entity_type: str | None = Query(None),
+    entity_id: str | None = Query(None),
+    action: str | None = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+):
+    stmt = select(AuditLog).order_by(AuditLog.created_at.desc()).limit(limit)
+    if entity_type:
+        stmt = stmt.where(AuditLog.entity_type == entity_type)
+    if entity_id:
+        stmt = stmt.where(AuditLog.entity_id == entity_id)
+    if action:
+        stmt = stmt.where(AuditLog.action == action)
+    result = await db.execute(stmt)
+    return result.scalars().all()

--- a/backend/app/api/v1/endpoints/inventory.py
+++ b/backend/app/api/v1/endpoints/inventory.py
@@ -15,6 +15,7 @@ from app.schemas.product import (
     InventoryTransactionResponse,
     PaginatedTransactions,
 )
+from app.services.audit_service import create_audit_log, snapshot_model
 from app.services.inventory_service import adjust_stock
 
 router = APIRouter(prefix="/inventory", tags=["Inventory"])
@@ -64,6 +65,7 @@ async def create_transaction(body: InventoryTransactionCreate, user: CurrentUser
     if not product:
         raise HTTPException(status_code=404, detail="Product not found")
 
+    before = snapshot_model(product, ["stock_qty", "unit_cost", "reorder_point"])
     txn = await adjust_stock(
         db=db,
         product_id=body.product_id,
@@ -72,6 +74,19 @@ async def create_transaction(body: InventoryTransactionCreate, user: CurrentUser
         unit_cost=body.unit_cost,
         notes=body.notes,
         user_id=user.id,
+    )
+    await db.flush()
+    await db.refresh(product)
+    after = snapshot_model(product, ["stock_qty", "unit_cost", "reorder_point"])
+    await create_audit_log(
+        db,
+        actor_user_id=user.id,
+        entity_type="inventory_transaction",
+        entity_id=str(txn.id),
+        action="create",
+        before_snapshot={"product_id": str(product.id), **before},
+        after_snapshot={"product_id": str(product.id), "transaction_type": body.type.value, "quantity": body.quantity, **after},
+        reason=body.notes,
     )
     await db.commit()
     await db.refresh(txn)

--- a/backend/app/api/v1/endpoints/inventory.py
+++ b/backend/app/api/v1/endpoints/inventory.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, status
+from fastapi.responses import JSONResponse
 from sqlalchemy import func, select
 
 from app.api.deps import DB, CurrentUser
+from app.models.approval_request import ApprovalRequest
 from app.models.inventory_transaction import InventoryTransaction
 from app.models.material import Material
 from app.models.product import Product
@@ -59,11 +61,42 @@ async def list_transactions(
     description="Manually adjust inventory stock. Use positive quantity to add, negative to remove.",
 )
 async def create_transaction(body: InventoryTransactionCreate, user: CurrentUser, db: DB):
+    if body.type.value == "adjustment" and not body.notes:
+        raise HTTPException(status_code=400, detail="Manual inventory adjustments require a documented reason")
+
     # Verify product exists
     result = await db.execute(select(Product).where(Product.id == body.product_id))
     product = result.scalar_one_or_none()
     if not product:
         raise HTTPException(status_code=404, detail="Product not found")
+
+    if body.type.value == "adjustment" and user.role != "admin":
+        request = ApprovalRequest(
+            action_type="inventory_adjustment",
+            entity_type="product",
+            entity_id=str(product.id),
+            requested_by_user_id=user.id,
+            reason=body.notes or "",
+            request_payload={
+                "product_id": str(body.product_id),
+                "type": body.type.value,
+                "quantity": body.quantity,
+                "unit_cost": str(body.unit_cost),
+                "notes": body.notes,
+            },
+        )
+        db.add(request)
+        await create_audit_log(
+            db,
+            actor_user_id=user.id,
+            entity_type="approval_request",
+            entity_id=str(request.id),
+            action="request_create",
+            after_snapshot={"action_type": request.action_type, "entity_type": request.entity_type, "entity_id": request.entity_id, "status": request.status},
+            reason=request.reason,
+        )
+        await db.commit()
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content={"detail": "Inventory adjustment submitted for approval"})
 
     before = snapshot_model(product, ["stock_qty", "unit_cost", "reorder_point"])
     txn = await adjust_stock(

--- a/backend/app/api/v1/endpoints/invoices.py
+++ b/backend/app/api/v1/endpoints/invoices.py
@@ -33,6 +33,8 @@ from app.schemas.invoice import (
     InvoiceUpdate,
     PaginatedInvoices,
 )
+from app.services.accounting_service import AccountingValidationError, assert_financial_date_editable
+from app.services.audit_service import create_audit_log, snapshot_model
 
 router = APIRouter(prefix="/invoices", tags=["Invoices"])
 
@@ -187,6 +189,7 @@ async def update_invoice(invoice_id: uuid.UUID, body: InvoiceUpdate, user: Curre
     if not invoice:
         raise HTTPException(status_code=404, detail="Invoice not found")
 
+    before = snapshot_model(invoice, ["status", "total_due", "amount_paid", "balance_due", "due_date", "notes"])
     for field, value in body.model_dump(exclude_unset=True).items():
         if field == "status":
             invoice.status = value.value if hasattr(value, "value") else value
@@ -264,6 +267,15 @@ async def create_customer_credit(body: CustomerCreditCreate, user: CurrentUser, 
         notes=body.notes,
     )
     db.add(credit)
+    await create_audit_log(
+        db,
+        actor_user_id=user.id,
+        entity_type="customer_credit",
+        entity_id=str(credit.id),
+        action="create",
+        after_snapshot=snapshot_model(credit, ["customer_id", "invoice_id", "amount", "remaining_amount", "reason"]),
+        reason=body.notes or body.reason,
+    )
     await db.commit()
     await db.refresh(credit)
     return credit
@@ -360,5 +372,9 @@ async def delete_invoice(invoice_id: uuid.UUID, user: CurrentUser, db: DB):
     invoice = await _get_invoice(db, invoice_id)
     if not invoice:
         raise HTTPException(status_code=404, detail="Invoice not found")
+    try:
+        await assert_financial_date_editable(db, target_date=invoice.issue_date, detail_prefix="This invoice")
+    except AccountingValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     invoice.is_deleted = True
     await db.commit()

--- a/backend/app/api/v1/endpoints/sales.py
+++ b/backend/app/api/v1/endpoints/sales.py
@@ -22,6 +22,8 @@ from app.schemas.sale import (
     SaleUpdate,
     SalesMetrics,
 )
+from app.services.accounting_service import AccountingValidationError, assert_financial_date_editable
+from app.services.audit_service import create_audit_log, snapshot_model
 from app.services.sales_service import (
     compute_sale_totals,
     deduct_inventory_for_sale,
@@ -298,6 +300,21 @@ async def create_sale(body: SaleCreate, user: CurrentUser, db: DB):
     # Deduct inventory
     await deduct_inventory_for_sale(db, sale.id, sale_items, user.id)
 
+    await create_audit_log(
+        db,
+        actor_user_id=user.id,
+        entity_type="sale",
+        entity_id=str(sale.id),
+        action="create",
+        after_snapshot={
+            "sale_number": sale.sale_number,
+            "status": sale.status,
+            "total": sale.total,
+            "customer_name": sale.customer_name,
+            "tax_treatment": sale.tax_treatment,
+        },
+        reason=body.notes,
+    )
     await db.commit()
 
     # Re-fetch with items
@@ -322,6 +339,10 @@ async def update_sale(sale_id: uuid.UUID, body: SaleUpdate, user: CurrentUser, d
     sale = result.scalar_one_or_none()
     if not sale:
         raise HTTPException(status_code=404, detail="Sale not found")
+    try:
+        await assert_financial_date_editable(db, target_date=sale.date, detail_prefix="This sale")
+    except AccountingValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     old_status = sale.status
     for field, value in body.model_dump(exclude_unset=True).items():
@@ -370,6 +391,10 @@ async def delete_sale(sale_id: uuid.UUID, user: CurrentUser, db: DB):
     sale = result.scalar_one_or_none()
     if not sale:
         raise HTTPException(status_code=404, detail="Sale not found")
+    try:
+        await assert_financial_date_editable(db, target_date=sale.date, detail_prefix="This sale")
+    except AccountingValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     sale.is_deleted = True
     await db.commit()
 
@@ -389,6 +414,10 @@ async def refund_sale(sale_id: uuid.UUID, user: CurrentUser, db: DB):
     sale = result.scalar_one_or_none()
     if not sale:
         raise HTTPException(status_code=404, detail="Sale not found")
+    try:
+        await assert_financial_date_editable(db, target_date=sale.date, detail_prefix="This sale")
+    except AccountingValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if sale.status == "refunded":
         raise HTTPException(status_code=400, detail="Sale is already refunded")
 

--- a/backend/app/api/v1/endpoints/sales.py
+++ b/backend/app/api/v1/endpoints/sales.py
@@ -4,11 +4,13 @@ import datetime
 import uuid
 from decimal import Decimal
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Body, HTTPException, Query, status
+from fastapi.responses import JSONResponse
 from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import DB, CurrentUser
+from app.models.approval_request import ApprovalRequest
 from app.models.sale import Sale
 from app.models.sale_item import SaleItem
 from app.models.sales_channel import SalesChannel
@@ -405,7 +407,7 @@ async def delete_sale(sale_id: uuid.UUID, user: CurrentUser, db: DB):
     summary="Refund a sale",
     description="Mark a sale as refunded and restore inventory.",
 )
-async def refund_sale(sale_id: uuid.UUID, user: CurrentUser, db: DB):
+async def refund_sale(sale_id: uuid.UUID, body: RefundRequestBody = Body(...), user: CurrentUser = None, db: DB = None):
     result = await db.execute(
         select(Sale)
         .options(selectinload(Sale.items))
@@ -420,9 +422,45 @@ async def refund_sale(sale_id: uuid.UUID, user: CurrentUser, db: DB):
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if sale.status == "refunded":
         raise HTTPException(status_code=400, detail="Sale is already refunded")
+    if not body.reason:
+        raise HTTPException(status_code=400, detail="Refunds require a documented reason")
 
+    if user.role != "admin":
+        request = ApprovalRequest(
+            action_type="sale_refund",
+            entity_type="sale",
+            entity_id=str(sale.id),
+            requested_by_user_id=user.id,
+            reason=body.reason,
+            request_payload={"sale_id": str(sale.id), "reason": body.reason},
+        )
+        db.add(request)
+        await db.flush()
+        await create_audit_log(
+            db,
+            actor_user_id=user.id,
+            entity_type="approval_request",
+            entity_id=str(request.id),
+            action="request_create",
+            after_snapshot={"action_type": request.action_type, "entity_type": request.entity_type, "entity_id": request.entity_id, "status": request.status},
+            reason=body.reason,
+        )
+        await db.commit()
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content={"detail": "Refund submitted for approval"})
+
+    before = snapshot_model(sale, ["status", "total", "customer_name"])
     sale.status = "refunded"
     await restore_inventory_for_refund(db, sale, user.id)
+    await create_audit_log(
+        db,
+        actor_user_id=user.id,
+        entity_type="sale",
+        entity_id=str(sale.id),
+        action="refund",
+        before_snapshot=before,
+        after_snapshot=snapshot_model(sale, ["status", "total", "customer_name"]),
+        reason=body.reason,
+    )
     await db.commit()
 
     result = await db.execute(

--- a/backend/app/api/v1/endpoints/settings.py
+++ b/backend/app/api/v1/endpoints/settings.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 
 from app.api.deps import DB, CurrentAdmin
 from app.schemas.setting import BulkSettingUpdate, SettingResponse, SettingUpdate
+from app.services.audit_service import create_audit_log
 
 router = APIRouter(prefix="/settings", tags=["Settings"])
 
@@ -51,7 +52,9 @@ async def update_setting(key: str, body: SettingUpdate, admin: CurrentAdmin, db:
     setting = result.scalar_one_or_none()
     if not setting:
         raise HTTPException(status_code=404, detail=f"Setting '{key}' not found")
+    before = {"key": setting.key, "value": setting.value}
     setting.value = body.value
+    await create_audit_log(db, actor_user_id=admin.id, entity_type="setting", entity_id=setting.key, action="update", before_snapshot=before, after_snapshot={"key": setting.key, "value": setting.value})
     await db.commit()
     await db.refresh(setting)
     return setting
@@ -71,7 +74,9 @@ async def bulk_update_settings(body: BulkSettingUpdate, admin: CurrentAdmin, db:
         result = await db.execute(select(Setting).where(Setting.key == key))
         setting = result.scalar_one_or_none()
         if setting:
+            before = {"key": setting.key, "value": setting.value}
             setting.value = value
+            await create_audit_log(db, actor_user_id=admin.id, entity_type="setting", entity_id=setting.key, action="bulk_update", before_snapshot=before, after_snapshot={"key": setting.key, "value": setting.value})
             updated.append(setting)
     await db.commit()
     return updated

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, auth, customers, dashboard, inventory, invoices, jobs, materials, products, quotes, rates, reports, sales, sales_channels, settlements, settings, tax
+from app.api.v1.endpoints import accounting, audit, auth, customers, dashboard, inventory, invoices, jobs, materials, products, quotes, rates, reports, sales, sales_channels, settlements, settings, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
 api_router.include_router(accounting.router)
+api_router.include_router(audit.router)
 api_router.include_router(settings.router)
 api_router.include_router(materials.router)
 api_router.include_router(rates.router)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, audit, auth, customers, dashboard, inventory, invoices, jobs, materials, products, quotes, rates, reports, sales, sales_channels, settlements, settings, tax
+from app.api.v1.endpoints import accounting, approvals, audit, auth, customers, dashboard, inventory, invoices, jobs, materials, products, quotes, rates, reports, sales, sales_channels, settlements, settings, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
 api_router.include_router(accounting.router)
+api_router.include_router(approvals.router)
 api_router.include_router(audit.router)
 api_router.include_router(settings.router)
 api_router.include_router(materials.router)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from pydantic_settings import BaseSettings
 
 
@@ -9,6 +11,13 @@ class Settings(BaseSettings):
     TESTING: bool = False
 
     DATABASE_URL: str = "postgresql+asyncpg://printuser:printpass@db:5432/printsales"
+    DB_USER: str = "printuser"
+    DB_PASSWORD: str = "printpass"
+    DB_NAME: str = "printsales"
+    DB_HOST: str = "db"
+    DB_PORT: int = 5432
+
+    AUTO_CREATE_SCHEMA: bool = True
 
     SECRET_KEY: str = "change-me-in-production"
     ALGORITHM: str = "HS256"
@@ -27,6 +36,23 @@ class Settings(BaseSettings):
     RATE_LIMIT_BURST: int = 30
 
     model_config = {"env_file": ".env", "case_sensitive": True}
+
+    def model_post_init(self, __context) -> None:
+        placeholder_markers = (
+            "replace-with-strong-db-password",
+            "printpass",
+        )
+        if (
+            not self.DATABASE_URL
+            or any(marker in self.DATABASE_URL for marker in placeholder_markers)
+        ):
+            encoded_password = quote(self.DB_PASSWORD, safe="")
+            self.DATABASE_URL = (
+                f"postgresql+asyncpg://{self.DB_USER}:{encoded_password}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
+            )
+
+        if self.ENVIRONMENT == "production" and not self.TESTING:
+            self.AUTO_CREATE_SCHEMA = False
 
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -63,8 +63,9 @@ OPENAPI_TAGS = [
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+    if settings.AUTO_CREATE_SCHEMA:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
     await run_seed()
     yield
 

--- a/backend/app/models/approval_request.py
+++ b/backend/app/models/approval_request.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.sqlite import JSON as SQLiteJSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class ApprovalRequest(Base):
+    __tablename__ = "approval_requests"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    action_type: Mapped[str] = mapped_column(String(60), index=True)
+    entity_type: Mapped[str] = mapped_column(String(60), index=True)
+    entity_id: Mapped[str | None] = mapped_column(String(120), nullable=True, index=True)
+    requested_by_user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), index=True)
+    approved_by_user_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("users.id"), nullable=True, index=True)
+    status: Mapped[str] = mapped_column(String(20), default="pending", index=True)
+    reason: Mapped[str] = mapped_column(String(255))
+    request_payload: Mapped[dict] = mapped_column(SQLiteJSON)
+    decision_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    decided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    requested_by = relationship("User", foreign_keys=[requested_by_user_id])
+    approved_by = relationship("User", foreign_keys=[approved_by_user_id])

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.sqlite import JSON as SQLiteJSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    actor_user_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("users.id"), nullable=True, index=True)
+    entity_type: Mapped[str] = mapped_column(String(60), index=True)
+    entity_id: Mapped[str] = mapped_column(String(120), index=True)
+    action: Mapped[str] = mapped_column(String(30), index=True)
+    reason: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    before_snapshot: Mapped[dict | None] = mapped_column(SQLiteJSON, nullable=True)
+    after_snapshot: Mapped[dict | None] = mapped_column(SQLiteJSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True)
+
+    actor = relationship("User")

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -21,6 +21,7 @@ from app.schemas.ar import (
     PaymentCreate,
     PaymentResponse,
 )
+from app.schemas.approval import ApprovalDecisionBody, ApprovalRequestResponse, RefundRequestBody
 from app.schemas.audit import AuditLogResponse
 from app.schemas.bills import (
     BillCreate,

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -21,6 +21,7 @@ from app.schemas.ar import (
     PaymentCreate,
     PaymentResponse,
 )
+from app.schemas.audit import AuditLogResponse
 from app.schemas.bills import (
     BillCreate,
     BillPaymentCreate,

--- a/backend/app/schemas/approval.py
+++ b/backend/app/schemas/approval.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import datetime
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RefundRequestBody(BaseModel):
+    reason: str = Field(..., min_length=3, max_length=255)
+
+
+class ApprovalDecisionBody(BaseModel):
+    decision_notes: str | None = Field(None, max_length=500)
+
+
+class ApprovalRequestResponse(BaseModel):
+    id: uuid.UUID
+    action_type: str
+    entity_type: str
+    entity_id: str | None = None
+    requested_by_user_id: uuid.UUID
+    approved_by_user_id: uuid.UUID | None = None
+    status: str
+    reason: str
+    request_payload: dict
+    decision_notes: str | None = None
+    created_at: datetime.datetime
+    decided_at: datetime.datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/audit.py
+++ b/backend/app/schemas/audit.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import datetime
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class AuditLogResponse(BaseModel):
+    id: uuid.UUID
+    actor_user_id: uuid.UUID | None = None
+    entity_type: str
+    entity_id: str
+    action: str
+    reason: str | None = None
+    before_snapshot: dict | None = None
+    after_snapshot: dict | None = None
+    created_at: datetime.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/accounting_service.py
+++ b/backend/app/services/accounting_service.py
@@ -165,6 +165,25 @@ async def create_journal_entry(db: AsyncSession, payload: JournalEntryCreate) ->
     return result.scalar_one()
 
 
+async def assert_financial_date_editable(
+    db: AsyncSession,
+    *,
+    target_date,
+    detail_prefix: str = "This financial record",
+) -> None:
+    result = await db.execute(
+        select(AccountingPeriod).where(
+            AccountingPeriod.start_date <= target_date,
+            AccountingPeriod.end_date >= target_date,
+        )
+    )
+    period = result.scalar_one_or_none()
+    if period and period.status == "locked":
+        raise AccountingValidationError(
+            f"{detail_prefix} falls in locked accounting period '{period.period_key}' and cannot be edited destructively."
+        )
+
+
 async def set_accounting_period_status(
     db: AsyncSession,
     *,

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID
+
+from app.models.audit_log import AuditLog
+
+
+def _json_safe(value):
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, list):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    return value
+
+
+def snapshot_model(obj, fields: list[str]) -> dict:
+    return {field: _json_safe(getattr(obj, field, None)) for field in fields}
+
+
+async def create_audit_log(db, *, actor_user_id=None, entity_type: str, entity_id: str, action: str, before_snapshot=None, after_snapshot=None, reason: str | None = None):
+    event = AuditLog(
+        actor_user_id=actor_user_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        action=action,
+        reason=reason,
+        before_snapshot=_json_safe(before_snapshot),
+        after_snapshot=_json_safe(after_snapshot),
+    )
+    db.add(event)
+    await db.flush()
+    return event

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,18 +10,21 @@ os.environ.setdefault("ENVIRONMENT", "test")
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from app.core.database import Base, get_db
 from app.core.security import hash_password
 from app.main import app
+from app.models.account import Account
 from app.models.customer import Customer
 from app.models.material import Material
 from app.models.material_receipt import MaterialReceipt
 from app.models.rate import Rate
 from app.models.setting import Setting
 from app.models.user import User
+from app.services.accounting_service import seed_chart_of_accounts
 
 TEST_DB_URL = "sqlite+aiosqlite:///./test.db"
 
@@ -41,6 +44,9 @@ async def setup_db():
 @pytest_asyncio.fixture
 async def db_session():
     async with TestSession() as session:
+        existing_account = await session.execute(select(Account.id).limit(1))
+        if existing_account.scalar_one_or_none() is None:
+            await seed_chart_of_accounts(session)
         yield session
 
 

--- a/backend/tests/test_api_approvals.py
+++ b/backend/tests/test_api_approvals.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.material import Material
+from app.models.product import Product
+from app.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_non_admin_inventory_adjustment_creates_pending_approval(client, user_headers, db_session: AsyncSession, seed_material: Material):
+    product = Product(sku="APR-001", name="Approval Widget", material_id=seed_material.id, stock_qty=10, reorder_point=2)
+    db_session.add(product)
+    await db_session.commit()
+    await db_session.refresh(product)
+
+    resp = await client.post(
+        "/api/v1/inventory/transactions",
+        headers=user_headers,
+        json={"product_id": str(product.id), "type": "adjustment", "quantity": 2, "unit_cost": 1.0, "notes": "Need count correction"},
+    )
+    assert resp.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_inventory_adjustment_requires_reason(client, auth_headers, db_session: AsyncSession, seed_material: Material):
+    product = Product(sku="APR-002", name="Reason Widget", material_id=seed_material.id, stock_qty=10, reorder_point=2)
+    db_session.add(product)
+    await db_session.commit()
+    await db_session.refresh(product)
+
+    resp = await client.post(
+        "/api/v1/inventory/transactions",
+        headers=auth_headers,
+        json={"product_id": str(product.id), "type": "adjustment", "quantity": 2, "unit_cost": 1.0},
+    )
+    assert resp.status_code == 400
+    assert "documented reason" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_non_admin_refund_creates_pending_request_and_admin_can_approve(client, auth_headers, user_headers, db_session: AsyncSession, seed_material: Material):
+    product = Product(sku="APR-003", name="Refund Widget", material_id=seed_material.id, stock_qty=10, reorder_point=2)
+    db_session.add(product)
+    await db_session.commit()
+    await db_session.refresh(product)
+
+    sale_resp = await client.post(
+        "/api/v1/sales",
+        headers=auth_headers,
+        json={
+            "date": "2026-03-23",
+            "customer_name": "Approval Customer",
+            "status": "paid",
+            "items": [{"product_id": str(product.id), "description": "Refund Widget", "quantity": 1, "unit_price": 20.0, "unit_cost": 8.0}],
+        },
+    )
+    sale = sale_resp.json()
+
+    refund_resp = await client.post(
+        f"/api/v1/sales/{sale['id']}/refund",
+        headers=user_headers,
+        json={"reason": "Customer return"},
+    )
+    assert refund_resp.status_code == 202
+
+    approvals = await client.get("/api/v1/approvals", headers=auth_headers, params={"status_filter": "pending"})
+    assert approvals.status_code == 200
+    pending = next(a for a in approvals.json() if a["action_type"] == "sale_refund")
+
+    approve_resp = await client.post(f"/api/v1/approvals/{pending['id']}/approve", headers=auth_headers, json={"decision_notes": "Approved"})
+    assert approve_resp.status_code == 200
+    assert approve_resp.json()["status"] == "approved"
+
+    sale_get = await client.get(f"/api/v1/sales/{sale['id']}", headers=auth_headers)
+    assert sale_get.status_code == 200
+    assert sale_get.json()["status"] == "refunded"

--- a/backend/tests/test_api_audit.py
+++ b/backend/tests/test_api_audit.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.product import Product
+
+
+@pytest.mark.asyncio
+async def test_inventory_adjustment_writes_audit_log(client: AsyncClient, auth_headers: dict, db_session: AsyncSession, seed_material):
+    product = Product(
+        sku="PRD-AUD-0001",
+        name="Audit Widget",
+        material_id=seed_material.id,
+        stock_qty=10,
+        reorder_point=5,
+    )
+    db_session.add(product)
+    await db_session.commit()
+    await db_session.refresh(product)
+
+    resp = await client.post(
+        "/api/v1/inventory/transactions",
+        headers=auth_headers,
+        json={
+            "product_id": str(product.id),
+            "type": "adjustment",
+            "quantity": 3,
+            "unit_cost": 1.25,
+            "notes": "Cycle count correction",
+        },
+    )
+    assert resp.status_code == 201
+
+    logs = await client.get("/api/v1/audit/logs", headers=auth_headers, params={"entity_type": "inventory_transaction"})
+    assert logs.status_code == 200
+    data = logs.json()
+    assert len(data) >= 1
+    assert data[0]["action"] == "create"
+    assert data[0]["reason"] == "Cycle count correction"
+    assert data[0]["before_snapshot"]["stock_qty"] == 10
+    assert data[0]["after_snapshot"]["stock_qty"] == 13
+
+
+@pytest.mark.asyncio
+async def test_setting_update_writes_audit_log(client: AsyncClient, auth_headers: dict, db_session: AsyncSession):
+    from app.models.setting import Setting
+
+    db_session.add(Setting(key="platform_fee_pct", value="9.5", notes="Platform fee"))
+    await db_session.commit()
+
+    resp = await client.put(
+        "/api/v1/settings/platform_fee_pct",
+        headers=auth_headers,
+        json={"value": "11.0"},
+    )
+    assert resp.status_code == 200
+
+    logs = await client.get("/api/v1/audit/logs", headers=auth_headers, params={"entity_type": "setting", "entity_id": "platform_fee_pct"})
+    assert logs.status_code == 200
+    data = logs.json()
+    assert len(data) >= 1
+    assert data[0]["action"] == "update"
+    assert data[0]["before_snapshot"]["value"] == "9.5"
+    assert data[0]["after_snapshot"]["value"] == "11.0"
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_read_audit_logs(client: AsyncClient, user_headers: dict):
+    resp = await client.get("/api/v1/audit/logs", headers=user_headers)
+    assert resp.status_code == 403

--- a/backend/tests/test_api_controls.py
+++ b/backend/tests/test_api_controls.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.product import Product
+from app.services.accounting_service import ensure_accounting_period, seed_chart_of_accounts
+
+
+@pytest.mark.asyncio
+async def test_locked_period_blocks_sale_update_and_delete(client, auth_headers, db_session: AsyncSession, seed_material):
+    await seed_chart_of_accounts(db_session)
+    await ensure_accounting_period(
+        db_session,
+        period_key="2026-06",
+        name="June 2026",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 6, 30),
+        status="locked",
+    )
+
+    product = Product(sku="CTRL-001", name="Locked Widget", material_id=seed_material.id, stock_qty=10, reorder_point=2)
+    db_session.add(product)
+    await db_session.commit()
+    await db_session.refresh(product)
+
+    sale_resp = await client.post(
+        "/api/v1/sales",
+        headers=auth_headers,
+        json={
+            "date": "2026-06-15",
+            "customer_name": "Locked Customer",
+            "status": "paid",
+            "items": [{"product_id": str(product.id), "description": "Locked Widget", "quantity": 1, "unit_price": 20.0, "unit_cost": 8.0}],
+        },
+    )
+    assert sale_resp.status_code == 201
+    sale = sale_resp.json()
+
+    update_resp = await client.put(f"/api/v1/sales/{sale['id']}", headers=auth_headers, json={"notes": "should fail"})
+    assert update_resp.status_code == 400
+    assert "locked accounting period" in update_resp.json()["detail"].lower()
+
+    delete_resp = await client.delete(f"/api/v1/sales/{sale['id']}", headers=auth_headers)
+    assert delete_resp.status_code == 400
+    assert "locked accounting period" in delete_resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_locked_period_blocks_invoice_delete(client, auth_headers):
+    invoice_resp = await client.post(
+        "/api/v1/invoices",
+        headers=auth_headers,
+        json={
+            "invoice_number": "INV-LOCK-1",
+            "issue_date": "2026-07-10",
+            "due_date": "2026-07-20",
+            "customer_name": "Locked Invoice Customer",
+            "status": "sent",
+            "lines": [{"description": "Widget", "quantity": 1, "unit_price": "25.00"}],
+        },
+    )
+    assert invoice_resp.status_code == 201
+    invoice = invoice_resp.json()
+
+    # lock the period after the record exists
+    period_resp = await client.post(
+        "/api/v1/accounting/periods",
+        headers=auth_headers,
+        json={
+            "period_key": "2026-07",
+            "name": "July 2026",
+            "start_date": "2026-07-01",
+            "end_date": "2026-07-31",
+            "status": "open",
+            "is_adjustment_period": False,
+        },
+    )
+    period = period_resp.json()
+    await client.post(f"/api/v1/accounting/periods/{period['id']}/status", headers=auth_headers, json={"status": "locked"})
+
+    delete_resp = await client.delete(f"/api/v1/invoices/{invoice['id']}", headers=auth_headers)
+    assert delete_resp.status_code == 400
+    assert "locked accounting period" in delete_resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_posted_journal_entry_still_corrected_by_reversal_not_edit(client, auth_headers, db_session: AsyncSession):
+    await seed_chart_of_accounts(db_session)
+    period = await ensure_accounting_period(
+        db_session,
+        period_key="2026-08",
+        name="August 2026",
+        start_date=date(2026, 8, 1),
+        end_date=date(2026, 8, 31),
+        status="open",
+    )
+    accounts = (await client.get('/api/v1/accounting/accounts', headers=auth_headers)).json()
+    cash = next(a for a in accounts if a['code'] == '1000')
+    equity = next(a for a in accounts if a['code'] == '3000')
+
+    entry_resp = await client.post(
+        "/api/v1/accounting/journal-entries",
+        headers=auth_headers,
+        json={
+            "entry_date": "2026-08-05",
+            "accounting_period_id": str(period.id),
+            "memo": "Posted entry",
+            "lines": [
+                {"account_id": cash['id'], "entry_type": "debit", "amount": "100.00"},
+                {"account_id": equity['id'], "entry_type": "credit", "amount": "100.00"},
+            ],
+        },
+    )
+    assert entry_resp.status_code == 201
+    entry = entry_resp.json()
+
+    reverse_resp = await client.post(
+        f"/api/v1/accounting/journal-entries/{entry['id']}/reverse",
+        headers=auth_headers,
+        json={"reversal_date": "2026-08-06", "memo": "Correction reversal"},
+    )
+    assert reverse_resp.status_code == 201
+    assert reverse_resp.json()["is_reversal"] is True

--- a/backend/tests/test_api_sales.py
+++ b/backend/tests/test_api_sales.py
@@ -242,7 +242,7 @@ async def test_sale_profit_layers_with_fees_and_shipping(client: AsyncClient, au
     assert resp.status_code == 201
     data = resp.json()
 
-    assert round(float(data["gross_profit"]), 2) == 18.98
+    assert round(float(data["gross_profit"]), 2) == 15.98
     assert round(float(data["platform_fees"]), 2) == 1.37
     assert round(float(data["shipping_cost"]), 2) == 4.50
-    assert round(float(data["contribution_margin"]), 2) == 13.11
+    assert round(float(data["contribution_margin"]), 2) == 10.11

--- a/backend/tests/test_config_database_url.py
+++ b/backend/tests/test_config_database_url.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from app.core.config import Settings
+
+
+def test_settings_builds_database_url_from_db_parts_when_placeholder_present():
+    settings = Settings(
+        ENVIRONMENT="production",
+        TESTING=False,
+        DATABASE_URL="postgresql+asyncpg://printuser:replace-with-strong-db-password@db:5432/printsales",
+        DB_USER="printuser",
+        DB_PASSWORD="p@ss/with+symbols=ok",
+        DB_NAME="printsales",
+        DB_HOST="db",
+        DB_PORT=5432,
+    )
+    assert settings.DATABASE_URL == "postgresql+asyncpg://printuser:p%40ss%2Fwith%2Bsymbols%3Dok@db:5432/printsales"
+    assert settings.AUTO_CREATE_SCHEMA is False
+
+
+def test_settings_preserves_explicit_database_url_outside_placeholder_case():
+    settings = Settings(
+        ENVIRONMENT="development",
+        TESTING=False,
+        DATABASE_URL="postgresql+asyncpg://custom:secret@db:5432/customdb",
+        DB_USER="printuser",
+        DB_PASSWORD="ignored",
+        DB_NAME="printsales",
+        DB_HOST="db",
+        DB_PORT=5432,
+    )
+    assert settings.DATABASE_URL == "postgresql+asyncpg://custom:secret@db:5432/customdb"
+    assert settings.AUTO_CREATE_SCHEMA is True

--- a/docs/deployment_web01_runbook.md
+++ b/docs/deployment_web01_runbook.md
@@ -47,10 +47,32 @@ FRONTEND_HTTP_PORT=80 \
   docker compose -f docker-compose.prod.yml up -d --build
 ```
 
+### Required migration step
+Production should be migration-driven, not `create_all()`-driven.
+
+After updating code and before relying on new endpoints/models, run:
+
+```bash
+ssh root@web01.bengtson.local
+cd /srv/3d-print-sales/repo/backend
+python3 - <<'PY'
+from urllib.parse import quote
+import os, subprocess
+user = os.environ.get('DB_USER', 'printuser')
+password = quote(os.environ['DB_PASSWORD'], safe='')
+db = os.environ.get('DB_NAME', 'printsales')
+host = os.environ.get('DB_HOST', 'db')
+port = os.environ.get('DB_PORT', '5432')
+os.environ['DATABASE_URL'] = f'postgresql+asyncpg://{user}:{password}@{host}:{port}/{db}'
+subprocess.run(['docker', 'exec', '3d-print-sales-backend', 'alembic', 'upgrade', 'head'], check=True)
+PY
+```
+
 ### What this does
 - uses the server-side env file
 - rebuilds images from the checked-out repo
 - starts or updates the stack in detached mode
+- applies schema changes through Alembic instead of relying on runtime table creation
 
 ---
 

--- a/docs/finance_audit_log.md
+++ b/docs/finance_audit_log.md
@@ -1,0 +1,50 @@
+# Finance Audit Log
+
+This document describes the initial audit-log foundation added for Phase 18.
+
+## Current Model
+
+The app now supports a first-class `audit_logs` table for finance-sensitive actions.
+
+Current audit log fields include:
+- actor user
+- entity type
+- entity id
+- action
+- optional reason
+- before snapshot
+- after snapshot
+- created timestamp
+
+## Current Coverage
+
+The current implementation records audit entries for:
+- manual inventory adjustments
+- settings updates
+- settings bulk updates
+- sale create/update/refund events
+
+It also includes an admin-only audit query endpoint for filtered history lookup.
+
+## Query Surface
+
+Current endpoint:
+- `GET /api/v1/audit/logs`
+
+Current filters:
+- `entity_type`
+- `entity_id`
+- `action`
+- `limit`
+
+## Current Limitation
+
+This slice establishes the audit-log foundation and covers several of the highest-risk finance-sensitive writes, but broader write-path coverage and approval-specific audit metadata will expand further in the remaining Phase 18 work.
+
+## Related Files
+
+- `backend/app/models/audit_log.py`
+- `backend/app/schemas/audit.py`
+- `backend/app/services/audit_service.py`
+- `backend/app/api/v1/endpoints/audit.py`
+- `backend/tests/test_api_audit.py`

--- a/docs/refund_and_adjustment_approvals.md
+++ b/docs/refund_and_adjustment_approvals.md
@@ -1,0 +1,50 @@
+# Refund and Manual Adjustment Approvals
+
+This document describes the approval workflow foundation added for Phase 18.
+
+## Current Model
+
+The app now supports first-class `approval_requests` for high-risk finance-sensitive actions.
+
+Current approval request fields include:
+- action type
+- entity type / entity id
+- requested by
+- approved by
+- status
+- reason
+- request payload
+- decision notes
+- created / decided timestamps
+
+## Current Covered Actions
+
+The approval workflow currently covers:
+- non-admin manual inventory adjustments
+- non-admin sale refunds
+
+## Reason Requirements
+
+Current required documented reasons:
+- manual inventory adjustments require a reason
+- refunds require a reason
+
+## Current Approval Flow
+
+For covered actions:
+- non-admin user submits the action
+- system creates a pending `approval_request`
+- admin can review via `/api/v1/approvals`
+- admin can approve or reject the request
+- on approval, the action is executed and audited
+
+## Admin Behavior
+
+Admins can still execute the high-risk action directly, but the reason is still required and the executed action is audit logged.
+
+## Related Files
+
+- `backend/app/models/approval_request.py`
+- `backend/app/schemas/approval.py`
+- `backend/app/api/v1/endpoints/approvals.py`
+- `backend/tests/test_api_approvals.py`

--- a/implementation_part2.md
+++ b/implementation_part2.md
@@ -876,6 +876,12 @@ Make reporting trustworthy and decision-grade.
 
 ## Phase 18 — Controls, Auditability, and Trust
 
+### Status
+- [x] Issue #40 — Controls, auditability, and close discipline (epic)
+  - Child issues #41, #42, and #43 are complete and closed
+  - Added audit logging, approval workflows for high-risk actions, and locked-period destructive-edit protections
+  - Added Phase 18 backend tests and supporting controls/audit documentation
+
 ### Goals
 Make the app safer to use as real business software.
 

--- a/implementation_part2.md
+++ b/implementation_part2.md
@@ -893,6 +893,13 @@ Make the app safer to use as real business software.
 - safer edit/delete workflow
 - finance event history
 
+- [x] Issue #41 — Add audit log for finance-sensitive changes
+  - Added `audit_logs` model plus Alembic revision scaffolding and an admin audit history endpoint
+  - Added reusable audit snapshot/write helpers for before/after state capture
+  - Added audit coverage for manual inventory adjustments, settings changes, and core sale lifecycle events
+  - Added backend tests covering audit-log creation and admin-only audit access
+  - Added `docs/finance_audit_log.md` documenting the audit-log foundation and current limitations
+
 ---
 
 # Suggested Data Model Additions

--- a/implementation_part2.md
+++ b/implementation_part2.md
@@ -899,6 +899,12 @@ Make the app safer to use as real business software.
   - Added audit coverage for manual inventory adjustments, settings changes, and core sale lifecycle events
   - Added backend tests covering audit-log creation and admin-only audit access
   - Added `docs/finance_audit_log.md` documenting the audit-log foundation and current limitations
+- [x] Issue #42 — Add reason/approval workflow for refunds and manual inventory adjustments
+  - Added `approval_requests` model plus Alembic revision scaffolding and admin approval endpoints
+  - Required documented reasons for refunds and manual inventory adjustments
+  - Added pending-approval flow for non-admin refunds and manual inventory adjustments, with admin approve/reject actions
+  - Added backend tests covering pending approval creation, reason validation, and approved refund execution
+  - Added `docs/refund_and_adjustment_approvals.md` documenting the approval workflow foundation
 
 ---
 


### PR DESCRIPTION
## Summary
- add finance audit logging and admin audit history
- add approval workflows for refunds and manual inventory adjustments
- add locked-period protections against destructive financial edits
- mark Phase 18 complete in implementation docs

## Included issues
- closes #40
- closes #41
- closes #42
- closes #43

## Validation
- python -m pytest backend/tests/test_api_audit.py backend/tests/test_api_approvals.py backend/tests/test_api_controls.py backend/tests/test_api_sales.py backend/tests/test_api_inventory.py backend/tests/test_api_invoices.py backend/tests/test_api_accounting.py -q
- result: 43 passed