### PR TITLE
feat: create and link product from job form

### DIFF
--- a/backend/app/api/v1/endpoints/jobs.py
+++ b/backend/app/api/v1/endpoints/jobs.py
@@ -20,6 +20,7 @@ from app.schemas.job import (
 )
 from app.services.cost_calculator import CostCalculator
 from app.services.inventory_service import add_inventory_from_job
+from app.services.job_service import build_duplicate_job_create, generate_job_number
 
 router = APIRouter(prefix="/jobs", tags=["Jobs"])
 
@@ -203,6 +204,50 @@ async def update_job(job_id: uuid.UUID, body: JobUpdate, user: CurrentUser, db: 
         )
         job.inventory_added = True
 
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+@router.post(
+    "/{job_id}/duplicate",
+    response_model=JobResponse,
+    status_code=201,
+    summary="Duplicate a job",
+    description="Create a new draft job by copying the editable inputs from an existing job and generating a new job number.",
+)
+async def duplicate_job(job_id: uuid.UUID, user: CurrentUser, db: DB):
+    result = await db.execute(
+        select(Job).where(Job.id == job_id, Job.is_deleted == False)
+    )
+    source_job = result.scalar_one_or_none()
+    if not source_job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    new_job_number = await generate_job_number(db)
+    duplicate_body = build_duplicate_job_create(source_job, job_number=new_job_number)
+
+    calc = CostCalculator(db)
+    costs = await calc.calculate(
+        material_id=duplicate_body.material_id,
+        qty_per_plate=duplicate_body.qty_per_plate,
+        num_plates=duplicate_body.num_plates,
+        material_per_plate_g=duplicate_body.material_per_plate_g,
+        print_time_per_plate_hrs=duplicate_body.print_time_per_plate_hrs,
+        labor_mins=duplicate_body.labor_mins,
+        design_time_hrs=duplicate_body.design_time_hrs or Decimal(0),
+        shipping_cost=duplicate_body.shipping_cost,
+        target_margin_pct=duplicate_body.target_margin_pct,
+    )
+
+    body_data = duplicate_body.model_dump(exclude={"shipping_cost"})
+    job = Job(
+        **body_data,
+        total_pieces=duplicate_body.qty_per_plate * duplicate_body.num_plates,
+        inventory_added=False,
+        **costs,
+    )
+    db.add(job)
     await db.commit()
     await db.refresh(job)
     return job

--- a/backend/app/services/job_service.py
+++ b/backend/app/services/job_service.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.job import Job
+from app.schemas.job import JobCreate
+
+
+async def generate_job_number(db: AsyncSession, job_date: date | None = None) -> str:
+    """Generate a unique job number in format J-YYYY-NNNN."""
+    target_date = job_date or date.today()
+    prefix = f"J-{target_date.year}-"
+    result = await db.execute(
+        select(func.count()).select_from(Job).where(Job.job_number.like(f"{prefix}%"))
+    )
+    count = result.scalar() or 0
+    return f"{prefix}{count + 1:04d}"
+
+
+def build_duplicate_job_create(source: Job, *, job_number: str, job_date: date | None = None) -> JobCreate:
+    """Map a source job into a new draft JobCreate payload."""
+    return JobCreate(
+        job_number=job_number,
+        date=job_date or date.today(),
+        customer_id=source.customer_id,
+        customer_name=source.customer_name,
+        product_name=source.product_name,
+        qty_per_plate=source.qty_per_plate,
+        num_plates=source.num_plates,
+        material_id=source.material_id,
+        material_per_plate_g=source.material_per_plate_g,
+        print_time_per_plate_hrs=source.print_time_per_plate_hrs,
+        labor_mins=source.labor_mins,
+        design_time_hrs=source.design_time_hrs if source.design_time_hrs is not None else Decimal(0),
+        shipping_cost=source.shipping_cost,
+        target_margin_pct=source.target_margin_pct,
+        product_id=source.product_id,
+        status="draft",
+    )

--- a/backend/tests/test_api_jobs.py
+++ b/backend/tests/test_api_jobs.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import select
+
+from app.models.inventory_transaction import InventoryTransaction
 
 
 @pytest.mark.asyncio
@@ -205,6 +208,88 @@ async def test_update_job(client, seed_settings, seed_rates, seed_material, auth
     assert resp.status_code == 200
     assert resp.json()["total_pieces"] == 3
     assert float(resp.json()["total_cost"]) > original_cost
+
+
+@pytest.mark.asyncio
+async def test_duplicate_job_creates_new_draft(client, seed_settings, seed_rates, seed_material, auth_headers):
+    create_resp = await client.post(
+        "/api/v1/jobs",
+        json={
+            "job_number": "COPY-001",
+            "date": "2026-03-01",
+            "customer_name": "Repeat Customer",
+            "product_name": "Repeat Widget",
+            "qty_per_plate": 2,
+            "num_plates": 3,
+            "material_id": str(seed_material.id),
+            "material_per_plate_g": 45,
+            "print_time_per_plate_hrs": 2.5,
+            "labor_mins": 15,
+            "design_time_hrs": 0.5,
+            "shipping_cost": 4,
+            "target_margin_pct": 40,
+            "status": "completed",
+        },
+        headers=auth_headers,
+    )
+    source = create_resp.json()
+
+    duplicate_resp = await client.post(f"/api/v1/jobs/{source['id']}/duplicate", headers=auth_headers)
+    assert duplicate_resp.status_code == 201
+    data = duplicate_resp.json()
+
+    assert data["id"] != source["id"]
+    assert data["job_number"] != source["job_number"]
+    assert data["job_number"].startswith("J-")
+    assert data["status"] == "draft"
+    assert data["inventory_added"] is False
+    assert data["product_name"] == source["product_name"]
+    assert data["customer_name"] == source["customer_name"]
+    assert data["qty_per_plate"] == source["qty_per_plate"]
+    assert data["num_plates"] == source["num_plates"]
+    assert data["total_pieces"] == source["total_pieces"]
+    assert float(data["total_cost"]) > 0
+    assert float(data["net_profit"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_duplicate_completed_job_does_not_create_inventory_transaction(
+    client, seed_settings, seed_rates, seed_material, auth_headers, db_session
+):
+    product_resp = await client.post(
+        "/api/v1/products",
+        json={"name": "Copy Product", "material_id": str(seed_material.id)},
+        headers=auth_headers,
+    )
+    product_id = product_resp.json()["id"]
+
+    create_resp = await client.post(
+        "/api/v1/jobs",
+        json={
+            "job_number": "COPY-INV-001",
+            "date": "2026-03-01",
+            "product_name": "Copy Product",
+            "qty_per_plate": 2,
+            "num_plates": 2,
+            "material_id": str(seed_material.id),
+            "material_per_plate_g": 45,
+            "print_time_per_plate_hrs": 2.5,
+            "product_id": product_id,
+            "status": "completed",
+        },
+        headers=auth_headers,
+    )
+    source = create_resp.json()
+
+    before_count = len((await db_session.execute(select(InventoryTransaction))).scalars().all())
+    duplicate_resp = await client.post(f"/api/v1/jobs/{source['id']}/duplicate", headers=auth_headers)
+    assert duplicate_resp.status_code == 201
+    data = duplicate_resp.json()
+    after_count = len((await db_session.execute(select(InventoryTransaction))).scalars().all())
+
+    assert data["status"] == "draft"
+    assert data["inventory_added"] is False
+    assert after_count == before_count
 
 
 @pytest.mark.asyncio

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -1,6 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams, Link, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Edit, Calendar, User, Package, Printer } from 'lucide-react';
+import { ArrowLeft, Edit, Calendar, User, Package, Printer, Copy } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { formatCurrency, formatPercent } from '@/lib/utils';
@@ -18,6 +19,8 @@ function CostRow({ label, value }: { label: string; value: number }) {
 export default function JobDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [duplicating, setDuplicating] = useState(false);
 
   const { data: job, isLoading } = useQuery<Job>({
     queryKey: ['job', id],
@@ -32,6 +35,20 @@ export default function JobDetailPage() {
       navigate('/jobs');
     } catch {
       toast.error('Failed to delete job');
+    }
+  };
+
+  const handleDuplicate = async () => {
+    setDuplicating(true);
+    try {
+      const { data } = await api.post(`/jobs/${id}/duplicate`);
+      queryClient.invalidateQueries({ queryKey: ['jobs'] });
+      toast.success('Job copied to draft successfully');
+      navigate(`/jobs/${data.id}`);
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Failed to copy job');
+    } finally {
+      setDuplicating(false);
     }
   };
 
@@ -61,6 +78,9 @@ export default function JobDetailPage() {
           </span>
         </div>
         <div className="flex gap-2">
+          <button onClick={handleDuplicate} disabled={duplicating} className="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium hover:bg-accent transition-colors disabled:opacity-50 cursor-pointer">
+            <Copy className="w-4 h-4" /> {duplicating ? 'Copying...' : 'Copy to New Job'}
+          </button>
           <Link to={`/jobs/${id}/edit`} className="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium hover:bg-accent transition-colors no-underline">
             <Edit className="w-4 h-4" /> Edit
           </Link>

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, X } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
-import type { Material, Job, CalculateResponse, PaginatedProducts } from '@/types';
+import type { Material, Job, CalculateResponse, PaginatedProducts, Product } from '@/types';
 
 interface FieldProps {
   label: string;
@@ -37,6 +38,16 @@ export default function JobFormPage() {
   const isEdit = !!id;
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+
+  const emptyProductForm = {
+    name: '',
+    description: '',
+    material_id: '',
+    unit_cost: 0,
+    unit_price: 0,
+    reorder_point: 5,
+    upc: '',
+  };
 
   const { data: materials } = useQuery<Material[]>({
     queryKey: ['materials', 'active'],
@@ -75,6 +86,10 @@ export default function JobFormPage() {
   const [preview, setPreview] = useState<CalculateResponse | null>(null);
   const [saving, setSaving] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [showCreateProduct, setShowCreateProduct] = useState(false);
+  const [creatingProduct, setCreatingProduct] = useState(false);
+  const [productForm, setProductForm] = useState(emptyProductForm);
+  const [productErrors, setProductErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
     if (existingJob) {
@@ -130,6 +145,60 @@ export default function JobFormPage() {
     setErrors((e) => ({ ...e, [field]: '' }));
   };
 
+  const openCreateProduct = () => {
+    setProductForm({
+      ...emptyProductForm,
+      name: String(form.product_name || ''),
+      material_id: String(form.material_id || ''),
+      unit_cost: Number(preview?.cost_per_piece || 0),
+      unit_price: Number(preview?.price_per_piece || 0),
+    });
+    setProductErrors({});
+    setShowCreateProduct(true);
+  };
+
+  const updateProductForm = (field: string, value: string | number) => {
+    setProductForm((f) => ({ ...f, [field]: value }));
+    setProductErrors((e) => ({ ...e, [field]: '' }));
+  };
+
+  const validateProductForm = () => {
+    const errs: Record<string, string> = {};
+    if (!String(productForm.name).trim()) errs.name = 'Name is required';
+    if (!productForm.material_id) errs.material_id = 'Select a material';
+    setProductErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  const handleCreateProduct = async () => {
+    if (!validateProductForm()) return;
+    setCreatingProduct(true);
+    try {
+      const payload = {
+        name: String(productForm.name).trim(),
+        description: String(productForm.description || '') || null,
+        material_id: productForm.material_id,
+        unit_cost: Number(productForm.unit_cost || 0),
+        unit_price: Number(productForm.unit_price || 0),
+        reorder_point: Number(productForm.reorder_point || 0),
+        upc: String(productForm.upc || '') || null,
+      };
+      const { data } = await api.post<Product>('/products', payload);
+      queryClient.invalidateQueries({ queryKey: ['products'] });
+      setForm((f) => ({
+        ...f,
+        product_id: data.id,
+        product_name: f.product_name || data.name,
+      }));
+      setShowCreateProduct(false);
+      toast.success('Product created and linked to job');
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Failed to create product');
+    } finally {
+      setCreatingProduct(false);
+    }
+  };
+
   const validate = () => {
     const errs: Record<string, string> = {};
     if (!form.job_number) errs.job_number = 'Required';
@@ -176,6 +245,76 @@ export default function JobFormPage() {
     <div className="max-w-5xl mx-auto">
       <h1 className="text-3xl font-bold mb-8">{isEdit ? 'Edit Job' : 'New Job'}</h1>
 
+      {showCreateProduct && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={(e) => e.target === e.currentTarget && setShowCreateProduct(false)}>
+          <div className="bg-card border border-border rounded-lg p-6 w-full max-w-md">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="text-lg font-semibold">Create and Link Product</h3>
+              <button type="button" onClick={() => setShowCreateProduct(false)} className="p-1 hover:bg-accent rounded-md cursor-pointer"><X className="w-5 h-5" /></button>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <label className="block text-sm font-medium mb-1">Name *</label>
+                <input
+                  value={productForm.name}
+                  onChange={(e) => updateProductForm('name', e.target.value)}
+                  className={`w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring ${productErrors.name ? 'border-destructive' : 'border-input'}`}
+                />
+                {productErrors.name && <p className="text-destructive text-xs mt-1">{productErrors.name}</p>}
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Description</label>
+                <input
+                  value={productForm.description}
+                  onChange={(e) => updateProductForm('description', e.target.value)}
+                  className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Material *</label>
+                <select
+                  value={productForm.material_id}
+                  onChange={(e) => updateProductForm('material_id', e.target.value)}
+                  className={`w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring ${productErrors.material_id ? 'border-destructive' : 'border-input'}`}
+                >
+                  <option value="">Select material...</option>
+                  {materials?.map((m) => (
+                    <option key={m.id} value={m.id}>{m.name} ({m.brand})</option>
+                  ))}
+                </select>
+                {productErrors.material_id && <p className="text-destructive text-xs mt-1">{productErrors.material_id}</p>}
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm font-medium mb-1">Unit Cost ($)</label>
+                  <input type="number" min="0" step="0.01" value={productForm.unit_cost} onChange={(e) => updateProductForm('unit_cost', Number(e.target.value))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Unit Price ($)</label>
+                  <input type="number" min="0" step="0.01" value={productForm.unit_price} onChange={(e) => updateProductForm('unit_price', Number(e.target.value))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm font-medium mb-1">Reorder Point</label>
+                  <input type="number" min="0" value={productForm.reorder_point} onChange={(e) => updateProductForm('reorder_point', Number(e.target.value))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">UPC/EAN</label>
+                  <input value={productForm.upc} onChange={(e) => updateProductForm('upc', e.target.value)} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+                </div>
+              </div>
+            </div>
+            <div className="flex gap-3 mt-6">
+              <button type="button" onClick={handleCreateProduct} disabled={creatingProduct} className="flex-1 bg-primary text-primary-foreground py-2 rounded-md font-medium hover:opacity-90 disabled:opacity-50 cursor-pointer">
+                {creatingProduct ? 'Creating...' : 'Create & Link'}
+              </button>
+              <button type="button" onClick={() => setShowCreateProduct(false)} className="px-4 py-2 border border-border rounded-md hover:bg-accent cursor-pointer">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         <form onSubmit={handleSubmit} className="lg:col-span-2 space-y-6">
           {/* Job Info */}
@@ -200,7 +339,16 @@ export default function JobFormPage() {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1.5">Link to Product (optional)</label>
+                <div className="flex items-center justify-between mb-1.5">
+                  <label className="block text-sm font-medium">Link to Product (optional)</label>
+                  <button
+                    type="button"
+                    onClick={openCreateProduct}
+                    className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline cursor-pointer"
+                  >
+                    <Plus className="w-3.5 h-3.5" /> Create product
+                  </button>
+                </div>
                 <select
                   value={form.product_id}
                   onChange={(e) => update('product_id', e.target.value)}

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -1,15 +1,19 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Link } from 'react-router-dom';
-import { Plus, Search, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link, useNavigate } from 'react-router-dom';
+import { Plus, Search, ChevronLeft, ChevronRight, Copy } from 'lucide-react';
+import { toast } from 'sonner';
 import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
-import type { PaginatedJobs } from '@/types';
+import type { Job, PaginatedJobs } from '@/types';
 
 export default function JobsPage() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const [search, setSearch] = useState('');
   const [status, setStatus] = useState('');
   const [page, setPage] = useState(0);
+  const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
   const limit = 20;
 
   const { data, isLoading } = useQuery<PaginatedJobs>({
@@ -33,6 +37,20 @@ export default function JobsPage() {
     in_progress: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
     draft: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
     cancelled: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  };
+
+  const handleDuplicate = async (job: Job) => {
+    setDuplicatingId(job.id);
+    try {
+      const { data } = await api.post(`/jobs/${job.id}/duplicate`);
+      queryClient.invalidateQueries({ queryKey: ['jobs'] });
+      toast.success('Job copied to draft successfully');
+      navigate(`/jobs/${data.id}`);
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Failed to copy job');
+    } finally {
+      setDuplicatingId(null);
+    }
   };
 
   return (
@@ -92,6 +110,7 @@ export default function JobsPage() {
                   <th className="px-4 py-3 font-medium text-right">Revenue</th>
                   <th className="px-4 py-3 font-medium text-right">Profit</th>
                   <th className="px-4 py-3 font-medium">Status</th>
+                  <th className="px-4 py-3 font-medium text-right">Actions</th>
                 </tr>
               </thead>
               <tbody>
@@ -117,11 +136,21 @@ export default function JobsPage() {
                         {job.status.replace('_', ' ')}
                       </span>
                     </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        onClick={() => handleDuplicate(job)}
+                        disabled={duplicatingId === job.id}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-border rounded-md text-xs font-medium hover:bg-accent disabled:opacity-50 cursor-pointer"
+                      >
+                        <Copy className="w-3.5 h-3.5" />
+                        {duplicatingId === job.id ? 'Copying...' : 'Copy'}
+                      </button>
+                    </td>
                   </tr>
                 ))}
                 {jobs.length === 0 && (
                   <tr>
-                    <td colSpan={8} className="px-4 py-12 text-center text-muted-foreground">
+                    <td colSpan={9} className="px-4 py-12 text-center text-muted-foreground">
                       No jobs found. {!search && !status && 'Create your first job to get started.'}
                     </td>
                   </tr>


### PR DESCRIPTION
Closes #63

## Summary
- add create-product modal directly on the job form
- prefill product fields from current job inputs and cost preview
- create product via existing products API and auto-link it to the job

## Validation
- cd frontend && npm run build