### PR TITLE
feat: auto-generate job numbers by date sequence

### DIFF
--- a/backend/app/api/v1/endpoints/jobs.py
+++ b/backend/app/api/v1/endpoints/jobs.py
@@ -77,6 +77,18 @@ async def list_jobs(
 
 
 @router.get(
+    "/next-number",
+    summary="Get next job number",
+    description="Preview the next available job number for the provided job date using YYYY.MM.DD.NNN sequencing.",
+)
+async def get_next_job_number(
+    db: DB,
+    date: datetime.date = Query(..., description="Job date to generate the next sequence for"),
+):
+    return {"job_number": await generate_job_number(db, date)}
+
+
+@router.get(
     "/{job_id}",
     response_model=JobResponse,
     summary="Get job by ID",
@@ -100,10 +112,12 @@ async def get_job(job_id: uuid.UUID, db: DB):
     description="Create a new print job. All cost fields (electricity, material, labor, etc.) are automatically calculated from the input parameters and current business settings/rates.",
 )
 async def create_job(body: JobCreate, user: CurrentUser, db: DB):
+    job_number = body.job_number or await generate_job_number(db, body.date)
+
     # Check for duplicate job number
-    existing = await db.execute(select(Job.id).where(Job.job_number == body.job_number))
+    existing = await db.execute(select(Job.id).where(Job.job_number == job_number))
     if existing.scalar_one_or_none():
-        raise HTTPException(status_code=409, detail=f"Job number '{body.job_number}' already exists")
+        raise HTTPException(status_code=409, detail=f"Job number '{job_number}' already exists")
 
     calc = CostCalculator(db)
     costs = await calc.calculate(
@@ -119,6 +133,7 @@ async def create_job(body: JobCreate, user: CurrentUser, db: DB):
     )
     # Exclude shipping_cost from body since it's included in calculated costs
     body_data = body.model_dump(exclude={"shipping_cost"})
+    body_data["job_number"] = job_number
     job = Job(
         **body_data,
         total_pieces=body.qty_per_plate * body.num_plates,

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -16,7 +16,7 @@ class JobStatus(str, Enum):
 
 
 class JobCreate(BaseModel):
-    job_number: str = Field(..., min_length=1, max_length=50, examples=["2026.3.4.001"])
+    job_number: str | None = Field(None, min_length=1, max_length=50, examples=["2026.03.04.001"])
     date: datetime.date = Field(..., examples=["2026-03-04"])
     customer_id: uuid.UUID | None = None
     customer_name: str | None = Field(None, max_length=200, examples=["Sample Customer"])

--- a/backend/app/services/job_service.py
+++ b/backend/app/services/job_service.py
@@ -1,24 +1,40 @@
 from __future__ import annotations
 
+import re
 from datetime import date
 from decimal import Decimal
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.job import Job
 from app.schemas.job import JobCreate
 
+_SEQUENCE_RE = re.compile(r"^(\d{4}\.\d{2}\.\d{2})\.(\d{3})$")
+
+
+def build_job_number_prefix(job_date: date) -> str:
+    return job_date.strftime("%Y.%m.%d.")
+
 
 async def generate_job_number(db: AsyncSession, job_date: date | None = None) -> str:
-    """Generate a unique job number in format J-YYYY-NNNN."""
+    """Generate the next job number in YYYY.MM.DD.NNN format."""
     target_date = job_date or date.today()
-    prefix = f"J-{target_date.year}-"
-    result = await db.execute(
-        select(func.count()).select_from(Job).where(Job.job_number.like(f"{prefix}%"))
-    )
-    count = result.scalar() or 0
-    return f"{prefix}{count + 1:04d}"
+    prefix = build_job_number_prefix(target_date)
+
+    result = await db.execute(select(Job.job_number).where(Job.job_number.like(f"{prefix}%")))
+    existing_numbers = result.scalars().all()
+
+    max_sequence = 0
+    for job_number in existing_numbers:
+        match = _SEQUENCE_RE.match(job_number)
+        if not match:
+            continue
+        if match.group(1) != prefix[:-1]:
+            continue
+        max_sequence = max(max_sequence, int(match.group(2)))
+
+    return f"{prefix}{max_sequence + 1:03d}"
 
 
 def build_duplicate_job_create(source: Job, *, job_number: str, job_date: date | None = None) -> JobCreate:

--- a/backend/tests/test_api_jobs.py
+++ b/backend/tests/test_api_jobs.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 import pytest
 from sqlalchemy import select
 
@@ -32,6 +34,49 @@ async def test_create_job(client, seed_settings, seed_rates, seed_material, auth
     assert data["total_pieces"] == 1
     assert float(data["total_cost"]) > 0
     assert float(data["net_profit"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_create_job_auto_generates_number(client, seed_settings, seed_rates, seed_material, auth_headers):
+    resp = await client.post(
+        "/api/v1/jobs",
+        json={
+            "date": "2026-03-24",
+            "product_name": "Auto Numbered Job",
+            "qty_per_plate": 1,
+            "num_plates": 1,
+            "material_id": str(seed_material.id),
+            "material_per_plate_g": 45,
+            "print_time_per_plate_hrs": 2.5,
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["job_number"] == "2026.03.24.001"
+
+
+@pytest.mark.asyncio
+async def test_next_job_number_ignores_malformed_numbers(client, seed_settings, seed_rates, seed_material, auth_headers):
+    for job_number in ["2026.03.24.001", "2026.03.24.bad", "2026.03.24.007", "OTHER-001"]:
+        await client.post(
+            "/api/v1/jobs",
+            json={
+                "job_number": job_number,
+                "date": "2026-03-24",
+                "product_name": f"Job {job_number}",
+                "qty_per_plate": 1,
+                "num_plates": 1,
+                "material_id": str(seed_material.id),
+                "material_per_plate_g": 45,
+                "print_time_per_plate_hrs": 2.5,
+            },
+            headers=auth_headers,
+        )
+
+    resp = await client.get("/api/v1/jobs/next-number", params={"date": "2026-03-24"}, headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["job_number"] == "2026.03.24.008"
 
 
 @pytest.mark.asyncio
@@ -240,7 +285,7 @@ async def test_duplicate_job_creates_new_draft(client, seed_settings, seed_rates
 
     assert data["id"] != source["id"]
     assert data["job_number"] != source["job_number"]
-    assert data["job_number"].startswith("J-")
+    assert re.match(r"^\d{4}\.\d{2}\.\d{2}\.\d{3}$", data["job_number"])
     assert data["status"] == "draft"
     assert data["inventory_added"] is False
     assert data["product_name"] == source["product_name"]

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -86,6 +86,7 @@ export default function JobFormPage() {
   const [preview, setPreview] = useState<CalculateResponse | null>(null);
   const [saving, setSaving] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [jobNumberTouched, setJobNumberTouched] = useState(false);
   const [showCreateProduct, setShowCreateProduct] = useState(false);
   const [creatingProduct, setCreatingProduct] = useState(false);
   const [productForm, setProductForm] = useState(emptyProductForm);
@@ -93,6 +94,7 @@ export default function JobFormPage() {
 
   useEffect(() => {
     if (existingJob) {
+      setJobNumberTouched(true);
       setForm({
         job_number: existingJob.job_number,
         date: existingJob.date,
@@ -112,6 +114,24 @@ export default function JobFormPage() {
       });
     }
   }, [existingJob]);
+
+  useEffect(() => {
+    if (isEdit || jobNumberTouched || !form.date) return;
+
+    const timer = setTimeout(async () => {
+      try {
+        const { data } = await api.get('/jobs/next-number', { params: { date: form.date } });
+        setForm((current) => {
+          if (current.job_number && jobNumberTouched) return current;
+          return { ...current, job_number: data.job_number };
+        });
+      } catch {
+        // ignore preview fetch failures; backend still generates on create
+      }
+    }, 200);
+
+    return () => clearTimeout(timer);
+  }, [isEdit, jobNumberTouched, form.date]);
 
   // Live cost preview
   useEffect(() => {
@@ -142,6 +162,7 @@ export default function JobFormPage() {
 
   const update = (field: string, value: string | number) => {
     setForm((f) => ({ ...f, [field]: value }));
+    if (field === 'job_number') setJobNumberTouched(true);
     setErrors((e) => ({ ...e, [field]: '' }));
   };
 
@@ -201,7 +222,7 @@ export default function JobFormPage() {
 
   const validate = () => {
     const errs: Record<string, string> = {};
-    if (!form.job_number) errs.job_number = 'Required';
+    if (isEdit && !form.job_number) errs.job_number = 'Required';
     if (!form.product_name) errs.product_name = 'Required';
     if (!form.material_id) errs.material_id = 'Select a material';
     if (form.qty_per_plate < 1) errs.qty_per_plate = 'Must be at least 1';
@@ -321,7 +342,14 @@ export default function JobFormPage() {
           <div className="bg-card border border-border rounded-lg p-6">
             <h3 className="text-lg font-semibold mb-4">Job Info</h3>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <Field label="Job Number" field="job_number" value={form.job_number} error={errors.job_number} onChange={update} placeholder="2026.3.4.001" />
+              <div>
+                <Field label="Job Number" field="job_number" value={form.job_number} error={errors.job_number} onChange={update} placeholder="2026.03.24.001" />
+                {!isEdit && (
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {jobNumberTouched ? 'Manual override enabled' : 'Auto-generated from selected date'}
+                  </p>
+                )}
+              </div>
               <Field label="Date" field="date" type="date" value={form.date} error={errors.date} onChange={update} />
               <Field label="Customer" field="customer_name" value={form.customer_name} error={errors.customer_name} onChange={update} placeholder="Optional" />
               <Field label="Product Name" field="product_name" value={form.product_name} error={errors.product_name} onChange={update} placeholder="Phone Stand" />


### PR DESCRIPTION
Closes #78

## Summary
- add YYYY.MM.DD.NNN job number generation
- add next-number preview endpoint for job forms
- auto-fill new job numbers based on selected date with manual override support
- add backend tests for generation and malformed historical numbers

## Validation
- ./.venv/bin/python -m pytest backend/tests/test_api_jobs.py -q
- cd frontend && npm run build