### PR TITLE
feat: add inventory workbench phase 1

### DIFF
--- a/backend/app/api/v1/endpoints/inventory.py
+++ b/backend/app/api/v1/endpoints/inventory.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import datetime
 import uuid
 
 from fastapi import APIRouter, HTTPException, Query, status
 from fastapi.responses import JSONResponse
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 
 from app.api.deps import DB, CurrentUser
 from app.models.approval_request import ApprovalRequest
@@ -13,6 +14,8 @@ from app.models.material import Material
 from app.models.product import Product
 from app.schemas.product import (
     InventoryAlert,
+    InventoryReconcileRequest,
+    InventoryReconcileResponse,
     InventoryTransactionCreate,
     InventoryTransactionResponse,
     PaginatedTransactions,
@@ -33,14 +36,31 @@ async def list_transactions(
     db: DB,
     product_id: uuid.UUID | None = Query(None, description="Filter by product ID"),
     type: str | None = Query(None, description="Filter by transaction type"),
+    date_from: datetime.date | None = Query(None, description="Start date (inclusive)"),
+    date_to: datetime.date | None = Query(None, description="End date (inclusive)"),
+    search: str | None = Query(None, description="Search by product name or SKU"),
     skip: int = Query(0, ge=0, description="Number of records to skip"),
     limit: int = Query(50, ge=1, le=100, description="Max records to return"),
 ):
-    base = select(InventoryTransaction)
+    base = (
+        select(
+            InventoryTransaction,
+            Product.name.label("product_name"),
+            Product.sku.label("product_sku"),
+        )
+        .join(Product, Product.id == InventoryTransaction.product_id)
+    )
     if product_id:
         base = base.where(InventoryTransaction.product_id == product_id)
     if type:
         base = base.where(InventoryTransaction.type == type)
+    if date_from:
+        base = base.where(func.date(InventoryTransaction.created_at) >= date_from)
+    if date_to:
+        base = base.where(func.date(InventoryTransaction.created_at) <= date_to)
+    if search:
+        pattern = f"%{search}%"
+        base = base.where(or_(Product.name.ilike(pattern), Product.sku.ilike(pattern)))
 
     count_stmt = select(func.count()).select_from(base.subquery())
     total = (await db.execute(count_stmt)).scalar() or 0
@@ -48,7 +68,24 @@ async def list_transactions(
     result = await db.execute(
         base.order_by(InventoryTransaction.created_at.desc()).offset(skip).limit(limit)
     )
-    items = result.scalars().all()
+    rows = result.all()
+
+    items = [
+        InventoryTransactionResponse(
+            id=row.InventoryTransaction.id,
+            product_id=row.InventoryTransaction.product_id,
+            product_name=row.product_name,
+            product_sku=row.product_sku,
+            job_id=row.InventoryTransaction.job_id,
+            type=row.InventoryTransaction.type,
+            quantity=row.InventoryTransaction.quantity,
+            unit_cost=row.InventoryTransaction.unit_cost,
+            notes=row.InventoryTransaction.notes,
+            created_by=row.InventoryTransaction.created_by,
+            created_at=row.InventoryTransaction.created_at,
+        )
+        for row in rows
+    ]
 
     return PaginatedTransactions(items=items, total=total, skip=skip, limit=limit)
 
@@ -124,6 +161,123 @@ async def create_transaction(body: InventoryTransactionCreate, user: CurrentUser
     await db.commit()
     await db.refresh(txn)
     return txn
+
+
+@router.post(
+    "/reconcile",
+    response_model=InventoryReconcileResponse,
+    status_code=200,
+    summary="Reconcile inventory from physical count",
+    description="Compare counted stock to current stock and create the required variance adjustment through the existing audit/approval flow.",
+)
+async def reconcile_inventory(body: InventoryReconcileRequest, user: CurrentUser, db: DB):
+    result = await db.execute(select(Product).where(Product.id == body.product_id))
+    product = result.scalar_one_or_none()
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+
+    current_qty = product.stock_qty
+    variance = body.counted_qty - current_qty
+    reason_text = body.reason.strip()
+    combined_notes = reason_text if not body.notes else f"{reason_text} | {body.notes.strip()}"
+
+    if variance == 0:
+        return InventoryReconcileResponse(
+            product_id=product.id,
+            current_qty=current_qty,
+            counted_qty=body.counted_qty,
+            variance=0,
+            approval_required=False,
+            detail="No stock adjustment needed",
+            transaction=None,
+        )
+
+    if user.role != "admin":
+        request = ApprovalRequest(
+            action_type="inventory_adjustment",
+            entity_type="product",
+            entity_id=str(product.id),
+            requested_by_user_id=user.id,
+            reason=reason_text,
+            request_payload={
+                "product_id": str(product.id),
+                "type": "adjustment",
+                "quantity": variance,
+                "unit_cost": str(product.unit_cost),
+                "notes": combined_notes,
+                "counted_qty": body.counted_qty,
+                "current_qty": current_qty,
+            },
+        )
+        db.add(request)
+        await create_audit_log(
+            db,
+            actor_user_id=user.id,
+            entity_type="approval_request",
+            entity_id=str(request.id),
+            action="request_create",
+            after_snapshot={"action_type": request.action_type, "entity_type": request.entity_type, "entity_id": request.entity_id, "status": request.status},
+            reason=request.reason,
+        )
+        await db.commit()
+        return InventoryReconcileResponse(
+            product_id=product.id,
+            current_qty=current_qty,
+            counted_qty=body.counted_qty,
+            variance=variance,
+            approval_required=True,
+            detail="Inventory reconciliation submitted for approval",
+            transaction=None,
+        )
+
+    before = snapshot_model(product, ["stock_qty", "unit_cost", "reorder_point"])
+    txn = await adjust_stock(
+        db=db,
+        product_id=product.id,
+        txn_type="adjustment",
+        quantity=variance,
+        unit_cost=product.unit_cost,
+        notes=combined_notes,
+        user_id=user.id,
+    )
+    await db.flush()
+    await db.refresh(product)
+    after = snapshot_model(product, ["stock_qty", "unit_cost", "reorder_point"])
+    await create_audit_log(
+        db,
+        actor_user_id=user.id,
+        entity_type="inventory_transaction",
+        entity_id=str(txn.id),
+        action="create",
+        before_snapshot={"product_id": str(product.id), "counted_qty": body.counted_qty, **before},
+        after_snapshot={"product_id": str(product.id), "transaction_type": "adjustment", "quantity": variance, "counted_qty": body.counted_qty, **after},
+        reason=combined_notes,
+    )
+    await db.commit()
+    await db.refresh(txn)
+
+    response_txn = InventoryTransactionResponse(
+        id=txn.id,
+        product_id=txn.product_id,
+        product_name=product.name,
+        product_sku=product.sku,
+        job_id=txn.job_id,
+        type=txn.type,
+        quantity=txn.quantity,
+        unit_cost=txn.unit_cost,
+        notes=txn.notes,
+        created_by=txn.created_by,
+        created_at=txn.created_at,
+    )
+    return InventoryReconcileResponse(
+        product_id=product.id,
+        current_qty=current_qty,
+        counted_qty=body.counted_qty,
+        variance=variance,
+        approval_required=False,
+        detail="Inventory reconciled successfully",
+        transaction=response_txn,
+    )
 
 
 @router.get(

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -76,12 +76,15 @@ class InventoryTransactionCreate(BaseModel):
 class InventoryTransactionResponse(BaseModel):
     id: uuid.UUID
     product_id: uuid.UUID
+    product_name: str | None = None
+    product_sku: str | None = None
     job_id: uuid.UUID | None = None
     type: str
     quantity: int
     unit_cost: Decimal
     notes: str | None = None
     created_by: uuid.UUID | None = None
+    created_by_name: str | None = None
     created_at: datetime | None = None
 
     model_config = {"from_attributes": True}
@@ -92,6 +95,23 @@ class PaginatedTransactions(BaseModel):
     total: int
     skip: int
     limit: int
+
+
+class InventoryReconcileRequest(BaseModel):
+    product_id: uuid.UUID
+    counted_qty: int = Field(..., ge=0)
+    reason: str = Field(..., min_length=3, max_length=255)
+    notes: str | None = Field(None, max_length=500)
+
+
+class InventoryReconcileResponse(BaseModel):
+    product_id: uuid.UUID
+    current_qty: int
+    counted_qty: int
+    variance: int
+    approval_required: bool = False
+    detail: str
+    transaction: InventoryTransactionResponse | None = None
 
 
 class InventoryAlert(BaseModel):

--- a/backend/tests/test_api_inventory.py
+++ b/backend/tests/test_api_inventory.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import pytest
 import pytest_asyncio
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+from uuid import UUID
 
 from app.models.material import Material
 from app.models.product import Product
@@ -98,6 +100,7 @@ async def test_list_transactions(
                 "product_id": str(seed_product.id),
                 "type": "adjustment",
                 "quantity": qty,
+                "notes": f"Adjustment {qty}",
             },
         )
     resp = await client.get(
@@ -107,6 +110,63 @@ async def test_list_transactions(
     assert resp.status_code == 200
     data = resp.json()
     assert data["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_list_transactions_supports_date_and_search_filters(
+    client: AsyncClient, auth_headers: dict, seed_product: Product, db_session: AsyncSession
+):
+    first = await client.post(
+        "/api/v1/inventory/transactions",
+        headers=auth_headers,
+        json={
+            "product_id": str(seed_product.id),
+            "type": "production",
+            "quantity": 3,
+            "notes": "Older production batch",
+        },
+    )
+    assert first.status_code == 201
+
+    second = await client.post(
+        "/api/v1/inventory/transactions",
+        headers=auth_headers,
+        json={
+            "product_id": str(seed_product.id),
+            "type": "waste",
+            "quantity": -1,
+            "notes": "Recent waste",
+        },
+    )
+    assert second.status_code == 201
+
+    from app.models.inventory_transaction import InventoryTransaction
+
+    first_txn = await db_session.get(InventoryTransaction, UUID(first.json()["id"]))
+    second_txn = await db_session.get(InventoryTransaction, UUID(second.json()["id"]))
+    first_txn.created_at = datetime.now(timezone.utc) - timedelta(days=3)
+    second_txn.created_at = datetime.now(timezone.utc)
+    await db_session.commit()
+
+    search_resp = await client.get("/api/v1/inventory/transactions", params={"search": "Test Widget"})
+    assert search_resp.status_code == 200
+    search_data = search_resp.json()
+    assert search_data["total"] >= 2
+    assert search_data["items"][0]["product_name"] == "Test Widget"
+    assert search_data["items"][0]["product_sku"] == "PRD-PLA-0001"
+
+    type_resp = await client.get("/api/v1/inventory/transactions", params={"type": "production"})
+    assert type_resp.status_code == 200
+    assert all(item["type"] == "production" for item in type_resp.json()["items"])
+
+    date_resp = await client.get(
+        "/api/v1/inventory/transactions",
+        params={"date_from": (datetime.now(timezone.utc) - timedelta(days=1)).date().isoformat()},
+    )
+    assert date_resp.status_code == 200
+    ids = {item["id"] for item in date_resp.json()["items"]}
+    assert second.json()["id"] in ids
+    assert first.json()["id"] not in ids
 
 
 @pytest.mark.asyncio
@@ -184,3 +244,50 @@ async def test_job_auto_inventory(
     # Verify product stock increased by total_pieces (4*2=8)
     prod_check = await client.get(f"/api/v1/products/{product_id}")
     assert prod_check.json()["stock_qty"] == 8
+
+
+@pytest.mark.asyncio
+async def test_reconcile_inventory_creates_adjustment(
+    client: AsyncClient, auth_headers: dict, seed_product: Product
+):
+    resp = await client.post(
+        "/api/v1/inventory/reconcile",
+        headers=auth_headers,
+        json={
+            "product_id": str(seed_product.id),
+            "counted_qty": 6,
+            "reason": "Cycle count",
+            "notes": "Back shelf recount",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["current_qty"] == 10
+    assert data["counted_qty"] == 6
+    assert data["variance"] == -4
+    assert data["approval_required"] is False
+    assert data["transaction"]["type"] == "adjustment"
+    assert data["transaction"]["quantity"] == -4
+
+    prod_resp = await client.get(f"/api/v1/products/{seed_product.id}")
+    assert prod_resp.json()["stock_qty"] == 6
+
+
+@pytest.mark.asyncio
+async def test_reconcile_inventory_zero_variance_returns_noop(
+    client: AsyncClient, auth_headers: dict, seed_product: Product
+):
+    resp = await client.post(
+        "/api/v1/inventory/reconcile",
+        headers=auth_headers,
+        json={
+            "product_id": str(seed_product.id),
+            "counted_qty": 10,
+            "reason": "Cycle count",
+            "notes": "Matched shelf count",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["variance"] == 0
+    assert data["transaction"] is None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import RatesPage from '@/pages/RatesPage';
 import CustomersPage from '@/pages/CustomersPage';
 import ProductsPage from '@/pages/ProductsPage';
 import ProductDetailPage from '@/pages/ProductDetailPage';
+import InventoryPage from '@/pages/InventoryPage';
 import SalesPage from '@/pages/SalesPage';
 import SaleDetailPage from '@/pages/SaleDetailPage';
 import SaleFormPage from '@/pages/SaleFormPage';
@@ -55,6 +56,7 @@ export default function App() {
               <Route path="/jobs/:id/edit" element={<JobFormPage />} />
               <Route path="/products" element={<ProductsPage />} />
               <Route path="/products/:id" element={<ProductDetailPage />} />
+              <Route path="/inventory" element={<InventoryPage />} />
               <Route path="/sales" element={<SalesPage />} />
               <Route path="/sales/new" element={<SaleFormPage />} />
               <Route path="/sales/channels" element={<SalesChannelsPage />} />

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -1,0 +1,330 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { X } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import { formatCurrency } from '@/lib/utils';
+import { SkeletonTable } from '@/components/ui/Skeleton';
+import type { InventoryAlert, InventoryReconcileResponse, PaginatedProducts, PaginatedTransactions } from '@/types';
+
+const TYPE_OPTIONS = [
+  { value: '', label: 'All types' },
+  { value: 'production', label: 'Production' },
+  { value: 'sale', label: 'Sale' },
+  { value: 'adjustment', label: 'Adjustment' },
+  { value: 'return', label: 'Return' },
+  { value: 'waste', label: 'Waste' },
+];
+
+const TYPE_COLORS: Record<string, string> = {
+  production: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  sale: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  adjustment: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+  return: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
+  waste: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+};
+
+export default function InventoryPage() {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
+  const [type, setType] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [page, setPage] = useState(0);
+  const [showReconcile, setShowReconcile] = useState(false);
+  const [reconcileSaving, setReconcileSaving] = useState(false);
+  const [reconcileForm, setReconcileForm] = useState({ product_id: '', counted_qty: 0, reason: '', notes: '' });
+  const [showAdjust, setShowAdjust] = useState(false);
+  const [adjustSaving, setAdjustSaving] = useState(false);
+  const [adjustForm, setAdjustForm] = useState({ product_id: '', type: 'adjustment', quantity: 0, notes: '' });
+  const limit = 25;
+
+  const params = useMemo(() => ({
+    skip: page * limit,
+    limit,
+    ...(search ? { search } : {}),
+    ...(type ? { type } : {}),
+    ...(dateFrom ? { date_from: dateFrom } : {}),
+    ...(dateTo ? { date_to: dateTo } : {}),
+  }), [page, limit, search, type, dateFrom, dateTo]);
+
+  const { data, isLoading } = useQuery<PaginatedTransactions>({
+    queryKey: ['inventory-transactions', params],
+    queryFn: () => api.get('/inventory/transactions', { params }).then((r) => r.data),
+  });
+
+  const { data: alerts } = useQuery<InventoryAlert[]>({
+    queryKey: ['inventory-alerts'],
+    queryFn: () => api.get('/inventory/alerts').then((r) => r.data),
+  });
+
+  const { data: productsData } = useQuery<PaginatedProducts>({
+    queryKey: ['products', 'inventory-reconcile'],
+    queryFn: () => api.get('/products?is_active=true&limit=200').then((r) => r.data),
+  });
+
+  const items = data?.items || [];
+  const selectedProduct = productsData?.items.find((product) => product.id === reconcileForm.product_id) || null;
+  const adjustProduct = productsData?.items.find((product) => product.id === adjustForm.product_id) || null;
+  const variance = selectedProduct ? reconcileForm.counted_qty - selectedProduct.stock_qty : 0;
+
+  const openReconcile = (productId?: string) => {
+    setReconcileForm({ product_id: productId || '', counted_qty: 0, reason: '', notes: '' });
+    setShowReconcile(true);
+  };
+
+  const submitReconcile = async () => {
+    if (!reconcileForm.product_id) { toast.error('Select a product'); return; }
+    if (!reconcileForm.reason.trim()) { toast.error('Reason is required'); return; }
+    setReconcileSaving(true);
+    try {
+      const { data } = await api.post<InventoryReconcileResponse>('/inventory/reconcile', reconcileForm);
+      toast.success(data.detail);
+      setShowReconcile(false);
+      queryClient.invalidateQueries({ queryKey: ['inventory-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['inventory-alerts'] });
+      queryClient.invalidateQueries({ queryKey: ['products'] });
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Failed to reconcile inventory');
+    } finally {
+      setReconcileSaving(false);
+    }
+  };
+
+  const openAdjust = (productId?: string) => {
+    setAdjustForm({ product_id: productId || '', type: 'adjustment', quantity: 0, notes: '' });
+    setShowAdjust(true);
+  };
+
+  const submitAdjust = async () => {
+    if (!adjustForm.product_id) { toast.error('Select a product'); return; }
+    if (adjustForm.quantity === 0) { toast.error('Quantity cannot be 0'); return; }
+    if (adjustForm.type === 'adjustment' && !adjustForm.notes.trim()) { toast.error('Adjustment notes are required'); return; }
+    setAdjustSaving(true);
+    try {
+      await api.post('/inventory/transactions', {
+        product_id: adjustForm.product_id,
+        type: adjustForm.type,
+        quantity: adjustForm.quantity,
+        unit_cost: adjustProduct?.unit_cost || 0,
+        notes: adjustForm.notes || null,
+      });
+      toast.success('Stock adjustment submitted');
+      setShowAdjust(false);
+      queryClient.invalidateQueries({ queryKey: ['inventory-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['inventory-alerts'] });
+      queryClient.invalidateQueries({ queryKey: ['products'] });
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Failed to adjust stock');
+    } finally {
+      setAdjustSaving(false);
+    }
+  };
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / limit)) : 1;
+
+  return (
+    <div className="max-w-7xl mx-auto space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold">Inventory</h1>
+          <p className="text-sm text-muted-foreground mt-1">Global stock ledger, recent movements, and low-stock operational view.</p>
+        </div>
+        <button onClick={() => openReconcile()} className="bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90">
+          Reconcile Stock
+        </button>
+      </div>
+
+      {showReconcile && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={(e) => e.target === e.currentTarget && setShowReconcile(false)}>
+          <div className="bg-card border border-border rounded-lg p-6 w-full max-w-lg">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-lg font-semibold">Stock Reconciliation</h2>
+              <button type="button" onClick={() => setShowReconcile(false)} className="p-1 hover:bg-accent rounded-md"><X className="w-5 h-5" /></button>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium mb-1">Product</label>
+                <select value={reconcileForm.product_id} onChange={(e) => setReconcileForm((f) => ({ ...f, product_id: e.target.value }))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring">
+                  <option value="">Select product...</option>
+                  {productsData?.items.map((product) => (
+                    <option key={product.id} value={product.id}>{product.name} ({product.sku})</option>
+                  ))}
+                </select>
+              </div>
+              {selectedProduct && (
+                <div className="grid grid-cols-2 gap-4 text-sm bg-accent/40 rounded-md p-3">
+                  <div>
+                    <p className="text-muted-foreground">Current system qty</p>
+                    <p className="text-lg font-semibold">{selectedProduct.stock_qty}</p>
+                  </div>
+                  <div>
+                    <p className="text-muted-foreground">Variance</p>
+                    <p className={`text-lg font-semibold ${variance > 0 ? 'text-green-600 dark:text-green-400' : variance < 0 ? 'text-red-600 dark:text-red-400' : ''}`}>{variance > 0 ? '+' : ''}{variance}</p>
+                  </div>
+                </div>
+              )}
+              <div>
+                <label className="block text-sm font-medium mb-1">Counted quantity</label>
+                <input type="number" min="0" value={reconcileForm.counted_qty} onChange={(e) => setReconcileForm((f) => ({ ...f, counted_qty: Number(e.target.value) }))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Reason</label>
+                <input value={reconcileForm.reason} onChange={(e) => setReconcileForm((f) => ({ ...f, reason: e.target.value }))} placeholder="Cycle count, shelf recount, received correction..." className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Notes</label>
+                <textarea value={reconcileForm.notes} onChange={(e) => setReconcileForm((f) => ({ ...f, notes: e.target.value }))} rows={3} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+              </div>
+            </div>
+            <div className="flex gap-3 mt-6">
+              <button onClick={submitReconcile} disabled={reconcileSaving} className="flex-1 bg-primary text-primary-foreground py-2 rounded-md font-medium hover:opacity-90 disabled:opacity-50">{reconcileSaving ? 'Submitting...' : 'Submit Reconciliation'}</button>
+              <button onClick={() => setShowReconcile(false)} className="px-4 py-2 border border-border rounded-md hover:bg-accent">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showAdjust && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={(e) => e.target === e.currentTarget && setShowAdjust(false)}>
+          <div className="bg-card border border-border rounded-lg p-6 w-full max-w-md">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-lg font-semibold">Quick Stock Adjustment</h2>
+              <button type="button" onClick={() => setShowAdjust(false)} className="p-1 hover:bg-accent rounded-md"><X className="w-5 h-5" /></button>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium mb-1">Product</label>
+                <select value={adjustForm.product_id} onChange={(e) => setAdjustForm((f) => ({ ...f, product_id: e.target.value }))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring">
+                  <option value="">Select product...</option>
+                  {productsData?.items.map((product) => (
+                    <option key={product.id} value={product.id}>{product.name} ({product.sku})</option>
+                  ))}
+                </select>
+              </div>
+              {adjustProduct && (
+                <div className="text-sm bg-accent/40 rounded-md p-3">
+                  <p className="text-muted-foreground">Current stock</p>
+                  <p className="text-lg font-semibold">{adjustProduct.stock_qty}</p>
+                </div>
+              )}
+              <div>
+                <label className="block text-sm font-medium mb-1">Type</label>
+                <select value={adjustForm.type} onChange={(e) => setAdjustForm((f) => ({ ...f, type: e.target.value }))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring">
+                  {TYPE_OPTIONS.filter((option) => option.value).map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Quantity</label>
+                <input type="number" value={adjustForm.quantity} onChange={(e) => setAdjustForm((f) => ({ ...f, quantity: Number(e.target.value) }))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" placeholder="Positive to add, negative to remove" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Notes</label>
+                <textarea value={adjustForm.notes} onChange={(e) => setAdjustForm((f) => ({ ...f, notes: e.target.value }))} rows={3} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" placeholder="Reason for adjustment" />
+              </div>
+            </div>
+            <div className="flex gap-3 mt-6">
+              <button onClick={submitAdjust} disabled={adjustSaving} className="flex-1 bg-primary text-primary-foreground py-2 rounded-md font-medium hover:opacity-90 disabled:opacity-50">{adjustSaving ? 'Submitting...' : 'Submit Adjustment'}</button>
+              <button onClick={() => setShowAdjust(false)} className="px-4 py-2 border border-border rounded-md hover:bg-accent">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="bg-card border border-border rounded-lg p-4 grid grid-cols-1 md:grid-cols-4 gap-4">
+        <input
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); setPage(0); }}
+          placeholder="Search product name or SKU"
+          className="px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <select value={type} onChange={(e) => { setType(e.target.value); setPage(0); }} className="px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring">
+          {TYPE_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+        </select>
+        <input type="date" value={dateFrom} onChange={(e) => { setDateFrom(e.target.value); setPage(0); }} className="px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+        <input type="date" value={dateTo} onChange={(e) => { setDateTo(e.target.value); setPage(0); }} className="px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+      </div>
+
+      <div className="bg-card border border-border rounded-lg p-4">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-lg font-semibold">Low-stock alerts</h2>
+          <span className="text-xs text-muted-foreground">Quick links only for now; reconcile flow comes next.</span>
+        </div>
+        {!alerts?.length ? (
+          <p className="text-sm text-muted-foreground">No low-stock alerts.</p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {alerts.map((alert) => (
+              <div key={`${alert.type}-${alert.id}`} className="border border-border rounded-md p-3 flex items-center justify-between gap-4">
+                <div>
+                  <p className="font-medium">{alert.name}</p>
+                  <p className="text-xs text-muted-foreground">{alert.type === 'product' ? (alert.sku || 'No SKU') : 'Material'} · Stock {alert.current_stock} / Reorder {alert.reorder_point}</p>
+                </div>
+                <div className="flex gap-2 text-sm">
+                  {alert.type === 'product' ? (
+                    <>
+                      <button type="button" onClick={() => openAdjust(alert.id)} className="text-primary hover:underline">Adjust</button>
+                      <button type="button" onClick={() => openReconcile(alert.id)} className="text-primary hover:underline">Reconcile</button>
+                      <Link className="text-primary hover:underline" to={`/products/${alert.id}`}>View product</Link>
+                    </>
+                  ) : (
+                    <Link className="text-primary hover:underline" to="/materials">View materials</Link>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {isLoading ? (
+        <SkeletonTable rows={8} cols={8} />
+      ) : !items.length ? (
+        <div className="bg-card border border-border rounded-lg p-8 text-center text-muted-foreground">No inventory transactions found</div>
+      ) : (
+        <div className="overflow-x-auto bg-card border border-border rounded-lg">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-muted-foreground">
+                <th className="px-4 py-3 font-medium">Date</th>
+                <th className="px-4 py-3 font-medium">Product</th>
+                <th className="px-4 py-3 font-medium">SKU</th>
+                <th className="px-4 py-3 font-medium">Type</th>
+                <th className="px-4 py-3 font-medium text-right">Qty</th>
+                <th className="px-4 py-3 font-medium text-right">Unit Cost</th>
+                <th className="px-4 py-3 font-medium">Job</th>
+                <th className="px-4 py-3 font-medium">Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((t) => (
+                <tr key={t.id} className="border-b border-border last:border-0 hover:bg-accent/50">
+                  <td className="px-4 py-3 text-xs">{t.created_at ? new Date(t.created_at).toLocaleString() : '-'}</td>
+                  <td className="px-4 py-3">
+                    {t.product_name ? <Link className="font-medium hover:underline" to={`/products/${t.product_id}`}>{t.product_name}</Link> : t.product_id}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs">{t.product_sku || '-'}</td>
+                  <td className="px-4 py-3"><span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${TYPE_COLORS[t.type] || ''}`}>{t.type}</span></td>
+                  <td className={`px-4 py-3 text-right font-medium ${t.quantity > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>{t.quantity > 0 ? '+' : ''}{t.quantity}</td>
+                  <td className="px-4 py-3 text-right">{formatCurrency(t.unit_cost)}</td>
+                  <td className="px-4 py-3 font-mono text-xs">{t.job_id || '-'}</td>
+                  <td className="px-4 py-3 text-xs text-muted-foreground">{t.notes || '-'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between text-sm">
+        <p className="text-muted-foreground">Page {page + 1} of {totalPages}</p>
+        <div className="flex gap-2">
+          <button onClick={() => setPage((p) => Math.max(0, p - 1))} disabled={page === 0} className="px-3 py-2 border border-border rounded-md disabled:opacity-50 hover:bg-accent">Previous</button>
+          <button onClick={() => setPage((p) => (p + 1 < totalPages ? p + 1 : p))} disabled={page + 1 >= totalPages} className="px-3 py-2 border border-border rounded-md disabled:opacity-50 hover:bg-accent">Next</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -174,12 +174,15 @@ export interface PaginatedProducts {
 export interface InventoryTransaction {
   id: string;
   product_id: string;
+  product_name: string | null;
+  product_sku: string | null;
   job_id: string | null;
   type: string;
   quantity: number;
   unit_cost: number;
   notes: string | null;
   created_by: string | null;
+  created_by_name: string | null;
   created_at: string | null;
 }
 
@@ -188,6 +191,16 @@ export interface PaginatedTransactions {
   total: number;
   skip: number;
   limit: number;
+}
+
+export interface InventoryReconcileResponse {
+  product_id: string;
+  current_qty: number;
+  counted_qty: number;
+  variance: number;
+  approval_required: boolean;
+  detail: string;
+  transaction: InventoryTransaction | null;
 }
 
 export interface InventoryAlert {


### PR DESCRIPTION
Implements the first inventory workbench slice from epic #69.

## Includes
- #70 extend inventory transactions API with date/search filters and ledger display data
- #71 add `/inventory` global inventory ledger page
- #72 add stock reconciliation endpoint and UI flow
- #73 add low-stock quick actions for adjust/reconcile/view-product

## Validation
- ./.venv/bin/python -m pytest backend/tests/test_api_inventory.py -q
- cd frontend && npm run build