### PR TITLE
feat: attach jobs to printers in backend

### DIFF
--- a/backend/alembic/versions/20260324_02_add_printer_assignment_to_jobs.py
+++ b/backend/alembic/versions/20260324_02_add_printer_assignment_to_jobs.py
@@ -1,0 +1,22 @@
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260324_02"
+down_revision: Union[str, None] = "20260324_01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("printer_id", sa.UUID(), nullable=True))
+    op.create_foreign_key("fk_jobs_printer_id_printers", "jobs", "printers", ["printer_id"], ["id"])
+    op.create_index(op.f("ix_jobs_printer_id"), "jobs", ["printer_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_jobs_printer_id"), table_name="jobs")
+    op.drop_constraint("fk_jobs_printer_id_printers", "jobs", type_="foreignkey")
+    op.drop_column("jobs", "printer_id")

--- a/backend/app/api/v1/endpoints/jobs.py
+++ b/backend/app/api/v1/endpoints/jobs.py
@@ -6,9 +6,11 @@ from decimal import Decimal
 
 from fastapi import APIRouter, HTTPException, Query
 from sqlalchemy import func, select
+from sqlalchemy.orm import selectinload
 
 from app.api.deps import DB, CurrentUser
 from app.models.job import Job
+from app.models.printer import Printer
 from app.schemas.job import (
     CalculateRequest,
     CalculateResponse,
@@ -36,6 +38,7 @@ async def list_jobs(
     status: JobStatus | None = Query(None, description="Filter by job status"),
     material_id: uuid.UUID | None = Query(None, description="Filter by material ID"),
     customer_id: uuid.UUID | None = Query(None, description="Filter by customer ID"),
+    printer_id: uuid.UUID | None = Query(None, description="Filter by printer ID"),
     date_from: datetime.date | None = Query(None, description="Start date (inclusive)"),
     date_to: datetime.date | None = Query(None, description="End date (inclusive)"),
     search: str | None = Query(None, description="Search by product name or job number"),
@@ -44,7 +47,7 @@ async def list_jobs(
     skip: int = Query(0, ge=0, description="Number of records to skip"),
     limit: int = Query(50, ge=1, le=100, description="Max records to return"),
 ):
-    base = select(Job).where(Job.is_deleted == False)
+    base = select(Job).options(selectinload(Job.printer)).where(Job.is_deleted == False)
 
     if status:
         base = base.where(Job.status == status.value)
@@ -52,6 +55,8 @@ async def list_jobs(
         base = base.where(Job.material_id == material_id)
     if customer_id:
         base = base.where(Job.customer_id == customer_id)
+    if printer_id:
+        base = base.where(Job.printer_id == printer_id)
     if date_from:
         base = base.where(Job.date >= date_from)
     if date_to:
@@ -96,7 +101,7 @@ async def get_next_job_number(
 )
 async def get_job(job_id: uuid.UUID, db: DB):
     result = await db.execute(
-        select(Job).where(Job.id == job_id, Job.is_deleted == False)
+        select(Job).options(selectinload(Job.printer)).where(Job.id == job_id, Job.is_deleted == False)
     )
     job = result.scalar_one_or_none()
     if not job:
@@ -113,6 +118,11 @@ async def get_job(job_id: uuid.UUID, db: DB):
 )
 async def create_job(body: JobCreate, user: CurrentUser, db: DB):
     job_number = body.job_number or await generate_job_number(db, body.date)
+
+    if body.printer_id:
+        printer_exists = await db.execute(select(Printer.id).where(Printer.id == body.printer_id))
+        if not printer_exists.scalar_one_or_none():
+            raise HTTPException(status_code=404, detail="Printer not found")
 
     # Check for duplicate job number
     existing = await db.execute(select(Job.id).where(Job.job_number == job_number))
@@ -155,8 +165,8 @@ async def create_job(body: JobCreate, user: CurrentUser, db: DB):
         job.inventory_added = True
 
     await db.commit()
-    await db.refresh(job)
-    return job
+    result = await db.execute(select(Job).options(selectinload(Job.printer)).execution_options(populate_existing=True).where(Job.id == job.id))
+    return result.scalar_one()
 
 
 @router.put(
@@ -167,7 +177,7 @@ async def create_job(body: JobCreate, user: CurrentUser, db: DB):
 )
 async def update_job(job_id: uuid.UUID, body: JobUpdate, user: CurrentUser, db: DB):
     result = await db.execute(
-        select(Job).where(Job.id == job_id, Job.is_deleted == False)
+        select(Job).options(selectinload(Job.printer)).where(Job.id == job_id, Job.is_deleted == False)
     )
     job = result.scalar_one_or_none()
     if not job:
@@ -180,6 +190,11 @@ async def update_job(job_id: uuid.UUID, body: JobUpdate, user: CurrentUser, db: 
         )
         if existing.scalar_one_or_none():
             raise HTTPException(status_code=409, detail=f"Job number '{body.job_number}' already exists")
+
+    if body.printer_id:
+        printer_exists = await db.execute(select(Printer.id).where(Printer.id == body.printer_id))
+        if not printer_exists.scalar_one_or_none():
+            raise HTTPException(status_code=404, detail="Printer not found")
 
     old_status = job.status
     for field, value in body.model_dump(exclude_unset=True).items():
@@ -220,8 +235,8 @@ async def update_job(job_id: uuid.UUID, body: JobUpdate, user: CurrentUser, db: 
         job.inventory_added = True
 
     await db.commit()
-    await db.refresh(job)
-    return job
+    result = await db.execute(select(Job).options(selectinload(Job.printer)).execution_options(populate_existing=True).where(Job.id == job.id))
+    return result.scalar_one()
 
 
 @router.post(
@@ -233,7 +248,7 @@ async def update_job(job_id: uuid.UUID, body: JobUpdate, user: CurrentUser, db: 
 )
 async def duplicate_job(job_id: uuid.UUID, user: CurrentUser, db: DB):
     result = await db.execute(
-        select(Job).where(Job.id == job_id, Job.is_deleted == False)
+        select(Job).options(selectinload(Job.printer)).where(Job.id == job_id, Job.is_deleted == False)
     )
     source_job = result.scalar_one_or_none()
     if not source_job:
@@ -264,8 +279,8 @@ async def duplicate_job(job_id: uuid.UUID, user: CurrentUser, db: DB):
     )
     db.add(job)
     await db.commit()
-    await db.refresh(job)
-    return job
+    result = await db.execute(select(Job).options(selectinload(Job.printer)).execution_options(populate_existing=True).where(Job.id == job.id))
+    return result.scalar_one()
 
 
 @router.delete(

--- a/backend/app/models/job.py
+++ b/backend/app/models/job.py
@@ -55,6 +55,9 @@ class Job(Base):
     product_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("products.id"), nullable=True
     )
+    printer_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("printers.id"), nullable=True, index=True
+    )
     inventory_added: Mapped[bool] = mapped_column(Boolean, default=False)
 
     status: Mapped[str] = mapped_column(String(20), default="completed")
@@ -71,3 +74,4 @@ class Job(Base):
     customer = relationship("Customer", back_populates="jobs")
     material = relationship("Material")
     product = relationship("Product")
+    printer = relationship("Printer")

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -7,6 +7,8 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
+from app.schemas.printer import PrinterResponse
+
 
 class JobStatus(str, Enum):
     draft = "draft"
@@ -31,6 +33,7 @@ class JobCreate(BaseModel):
     shipping_cost: Decimal = Field(Decimal(0), ge=0, examples=[0])
     target_margin_pct: Decimal = Field(Decimal(40), ge=0, le=99, examples=[40])
     product_id: uuid.UUID | None = None
+    printer_id: uuid.UUID | None = None
     status: JobStatus = Field(JobStatus.completed, examples=["completed"])
 
 
@@ -50,6 +53,7 @@ class JobUpdate(BaseModel):
     shipping_cost: Decimal | None = Field(None, ge=0)
     target_margin_pct: Decimal | None = Field(None, ge=0, le=99)
     product_id: uuid.UUID | None = None
+    printer_id: uuid.UUID | None = None
     status: JobStatus | None = None
 
 
@@ -120,6 +124,8 @@ class JobResponse(BaseModel):
     net_profit: Decimal
     profit_per_piece: Decimal
     product_id: uuid.UUID | None = None
+    printer_id: uuid.UUID | None = None
+    printer: PrinterResponse | None = None
     inventory_added: bool = False
     status: str
     created_at: datetime.datetime | None = None

--- a/backend/app/services/job_service.py
+++ b/backend/app/services/job_service.py
@@ -55,5 +55,6 @@ def build_duplicate_job_create(source: Job, *, job_number: str, job_date: date |
         shipping_cost=source.shipping_cost,
         target_margin_pct=source.target_margin_pct,
         product_id=source.product_id,
+        printer_id=source.printer_id,
         status="draft",
     )

--- a/backend/tests/test_api_jobs.py
+++ b/backend/tests/test_api_jobs.py
@@ -203,6 +203,55 @@ async def test_list_jobs_filter_by_date(client, seed_settings, seed_rates, seed_
 
 
 @pytest.mark.asyncio
+async def test_create_job_with_printer_assignment(client, seed_settings, seed_rates, seed_material, auth_headers):
+    printer_resp = await client.post(
+        "/api/v1/printers",
+        json={"name": "Farm Printer 1", "slug": "farm-printer-1", "status": "idle"},
+        headers=auth_headers,
+    )
+    printer_id = printer_resp.json()["id"]
+
+    create_resp = await client.post(
+        "/api/v1/jobs",
+        json={
+            "date": "2026-03-24",
+            "product_name": "Printer Assigned Job",
+            "qty_per_plate": 1,
+            "num_plates": 1,
+            "material_id": str(seed_material.id),
+            "material_per_plate_g": 45,
+            "print_time_per_plate_hrs": 2.5,
+            "printer_id": printer_id,
+        },
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+    data = create_resp.json()
+    assert data["printer_id"] == printer_id
+    assert data["printer"]["id"] == printer_id
+    assert data["printer"]["name"] == "Farm Printer 1"
+
+
+@pytest.mark.asyncio
+async def test_create_job_rejects_invalid_printer(client, seed_settings, seed_rates, seed_material, auth_headers):
+    resp = await client.post(
+        "/api/v1/jobs",
+        json={
+            "date": "2026-03-24",
+            "product_name": "Bad Printer Job",
+            "qty_per_plate": 1,
+            "num_plates": 1,
+            "material_id": str(seed_material.id),
+            "material_per_plate_g": 45,
+            "print_time_per_plate_hrs": 2.5,
+            "printer_id": "00000000-0000-0000-0000-000000000999",
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_get_job(client, seed_settings, seed_rates, seed_material, auth_headers):
     create_resp = await client.post(
         "/api/v1/jobs",
@@ -224,6 +273,88 @@ async def test_get_job(client, seed_settings, seed_rates, seed_material, auth_he
     assert resp.status_code == 200
     assert resp.json()["product_name"] == "Get Test"
     assert resp.json()["total_pieces"] == 2
+
+
+@pytest.mark.asyncio
+async def test_update_job_with_printer_assignment(client, seed_settings, seed_rates, seed_material, auth_headers):
+    printer_resp = await client.post(
+        "/api/v1/printers",
+        json={"name": "Farm Printer 2", "slug": "farm-printer-2", "status": "printing"},
+        headers=auth_headers,
+    )
+    printer_id = printer_resp.json()["id"]
+
+    create_resp = await client.post(
+        "/api/v1/jobs",
+        json={
+            "job_number": "UPD-PRN-001",
+            "date": "2026-03-01",
+            "product_name": "Update Printer Test",
+            "qty_per_plate": 1,
+            "num_plates": 1,
+            "material_id": str(seed_material.id),
+            "material_per_plate_g": 45,
+            "print_time_per_plate_hrs": 2.5,
+        },
+        headers=auth_headers,
+    )
+    job_id = create_resp.json()["id"]
+
+    resp = await client.put(
+        f"/api/v1/jobs/{job_id}",
+        json={"printer_id": printer_id, "status": "completed"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["printer_id"] == printer_id
+    assert data["printer"]["slug"] == "farm-printer-2"
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_filter_by_printer(client, seed_settings, seed_rates, seed_material, auth_headers):
+    printer_resp = await client.post(
+        "/api/v1/printers",
+        json={"name": "Farm Printer 3", "slug": "farm-printer-3", "status": "idle"},
+        headers=auth_headers,
+    )
+    printer_id = printer_resp.json()["id"]
+
+    await client.post(
+        "/api/v1/jobs",
+        json={
+            "job_number": "FILTER-PRN-001",
+            "date": "2026-03-01",
+            "product_name": "Filtered Printer Job",
+            "qty_per_plate": 1,
+            "num_plates": 1,
+            "material_id": str(seed_material.id),
+            "material_per_plate_g": 45,
+            "print_time_per_plate_hrs": 2.5,
+            "printer_id": printer_id,
+        },
+        headers=auth_headers,
+    )
+    await client.post(
+        "/api/v1/jobs",
+        json={
+            "job_number": "FILTER-PRN-002",
+            "date": "2026-03-01",
+            "product_name": "Unassigned Job",
+            "qty_per_plate": 1,
+            "num_plates": 1,
+            "material_id": str(seed_material.id),
+            "material_per_plate_g": 45,
+            "print_time_per_plate_hrs": 2.5,
+        },
+        headers=auth_headers,
+    )
+
+    resp = await client.get(f"/api/v1/jobs?printer_id={printer_id}")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) >= 1
+    assert all(item["printer_id"] == printer_id for item in items)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #83

## Summary
- add nullable printer assignment to jobs
- expose printer data in job responses
- validate printer assignment on create/update
- add printer filter to jobs list and carry printer on duplicate
- add backend tests for printer assignment flows

## Validation
- ./.venv/bin/python -m pytest backend/tests/test_api_jobs.py -q