### PR TITLE
feat(frontend): add printer assignment to job UI (#84)

### DIFF
--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -107,6 +107,16 @@ export default function JobDetailPage() {
           <Printer className="w-5 h-5 text-muted-foreground" />
           <div><p className="text-xs text-muted-foreground">Print Time</p><p className="font-medium">{Number(job.print_time_per_plate_hrs).toFixed(1)}h x {job.num_plates} plates</p></div>
         </div>
+        <div className="bg-card border border-border rounded-lg p-4 flex items-center gap-3">
+          <Printer className="w-5 h-5 text-muted-foreground" />
+          <div>
+            <p className="text-xs text-muted-foreground">Assigned Printer</p>
+            <p className="font-medium">{job.printer?.name || 'Unassigned'}</p>
+            {job.printer && (
+              <p className="text-xs text-muted-foreground">{job.printer.status}{job.printer.location ? ` · ${job.printer.location}` : ''}</p>
+            )}
+          </div>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -5,7 +5,7 @@ import { Plus, X } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
-import type { Material, Job, CalculateResponse, PaginatedProducts, Product } from '@/types';
+import type { Material, Job, CalculateResponse, PaginatedProducts, PaginatedPrinters, Product } from '@/types';
 
 interface FieldProps {
   label: string;
@@ -59,6 +59,11 @@ export default function JobFormPage() {
     queryFn: () => api.get('/products?is_active=true&limit=100').then((r) => r.data),
   });
 
+  const { data: printersData } = useQuery<PaginatedPrinters>({
+    queryKey: ['printers', 'active'],
+    queryFn: () => api.get('/printers?is_active=true&limit=100').then((r) => r.data),
+  });
+
   const { data: existingJob } = useQuery<Job>({
     queryKey: ['job', id],
     queryFn: () => api.get(`/jobs/${id}`).then((r) => r.data),
@@ -80,6 +85,7 @@ export default function JobFormPage() {
     shipping_cost: 0,
     target_margin_pct: 40,
     product_id: '',
+    printer_id: '',
     status: 'completed',
   });
 
@@ -110,6 +116,7 @@ export default function JobFormPage() {
         shipping_cost: existingJob.shipping_cost,
         target_margin_pct: existingJob.target_margin_pct,
         product_id: existingJob.product_id || '',
+        printer_id: existingJob.printer_id || '',
         status: existingJob.status,
       });
     }
@@ -243,6 +250,7 @@ export default function JobFormPage() {
         customer_name: form.customer_name || null,
         design_time_hrs: form.design_time_hrs || 0,
         product_id: form.product_id || null,
+        printer_id: form.printer_id || null,
       };
       if (isEdit) {
         await api.put(`/jobs/${id}`, payload);
@@ -365,6 +373,22 @@ export default function JobFormPage() {
                   <option value="completed">Completed</option>
                   <option value="cancelled">Cancelled</option>
                 </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1.5">Assign Printer (optional)</label>
+                <select
+                  value={form.printer_id}
+                  onChange={(e) => update('printer_id', e.target.value)}
+                  className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                >
+                  <option value="">Unassigned</option>
+                  {printersData?.items?.map((printer) => (
+                    <option key={printer.id} value={printer.id}>
+                      {printer.name} ({printer.status}){printer.location ? ` — ${printer.location}` : ''}
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs text-muted-foreground mt-1">Optional printer assignment for the physical machine running this job.</p>
               </div>
               <div>
                 <div className="flex items-center justify-between mb-1.5">

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -106,6 +106,7 @@ export default function JobsPage() {
                   <th className="px-4 py-3 font-medium">Date</th>
                   <th className="px-4 py-3 font-medium">Customer</th>
                   <th className="px-4 py-3 font-medium">Product</th>
+                  <th className="px-4 py-3 font-medium">Printer</th>
                   <th className="px-4 py-3 font-medium text-right">Pieces</th>
                   <th className="px-4 py-3 font-medium text-right">Revenue</th>
                   <th className="px-4 py-3 font-medium text-right">Profit</th>
@@ -124,6 +125,7 @@ export default function JobsPage() {
                     <td className="px-4 py-3">{job.date}</td>
                     <td className="px-4 py-3">{job.customer_name || '—'}</td>
                     <td className="px-4 py-3">{job.product_name}</td>
+                    <td className="px-4 py-3 text-xs text-muted-foreground">{job.printer?.name || '—'}</td>
                     <td className="px-4 py-3 text-right">{job.total_pieces}</td>
                     <td className="px-4 py-3 text-right">{formatCurrency(job.total_revenue)}</td>
                     <td className="px-4 py-3 text-right">
@@ -150,7 +152,7 @@ export default function JobsPage() {
                 ))}
                 {jobs.length === 0 && (
                   <tr>
-                    <td colSpan={9} className="px-4 py-12 text-center text-muted-foreground">
+                    <td colSpan={10} className="px-4 py-12 text-center text-muted-foreground">
                       No jobs found. {!search && !status && 'Create your first job to get started.'}
                     </td>
                   </tr>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -36,6 +36,28 @@ export interface Customer {
   job_count: number;
 }
 
+export interface Printer {
+  id: string;
+  name: string;
+  slug: string;
+  manufacturer: string | null;
+  model: string | null;
+  serial_number: string | null;
+  location: string | null;
+  status: string;
+  is_active: boolean;
+  notes: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface PaginatedPrinters {
+  items: Printer[];
+  total: number;
+  skip: number;
+  limit: number;
+}
+
 export interface Job {
   id: string;
   job_number: string;
@@ -70,6 +92,8 @@ export interface Job {
   net_profit: number;
   profit_per_piece: number;
   product_id: string | null;
+  printer_id: string | null;
+  printer: Printer | null;
   inventory_added: boolean;
   status: string;
 }


### PR DESCRIPTION
## Summary\n- add printer selection support to the job form\n- show assigned printer details on the job detail page\n- surface printer info in the jobs list\n- extend frontend types for job/printer assignment data\n\n## Testing\n- manual UI verification\n\nCloses #84