### PR TITLE
fix(api): import refund request schema for OpenAPI

### DIFF
--- a/backend/app/api/v1/endpoints/sales.py
+++ b/backend/app/api/v1/endpoints/sales.py
@@ -15,6 +15,7 @@ from app.models.sale import Sale
 from app.models.sale_item import SaleItem
 from app.models.sales_channel import SalesChannel
 from app.models.tax_profile import TaxProfile
+from app.schemas.approval import RefundRequestBody
 from app.schemas.sale import (
     PaginatedSales,
     SaleCreate,


### PR DESCRIPTION
## Summary
- import RefundRequestBody in the sales endpoint module
- fix FastAPI/Pydantic OpenAPI generation for the refund route
- restore /api/v1/openapi.json and docs rendering

## Verification
- local app.openapi() generation succeeds
- refund route appears in generated schema

Fixes production docs/OpenAPI failure discovered after deploy.