### PR TITLE
feat(printers): add management pages and routes (#85)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,9 @@ import RatesPage from '@/pages/RatesPage';
 import CustomersPage from '@/pages/CustomersPage';
 import ProductsPage from '@/pages/ProductsPage';
 import ProductDetailPage from '@/pages/ProductDetailPage';
+import PrintersPage from '@/pages/PrintersPage';
+import PrinterDetailPage from '@/pages/PrinterDetailPage';
+import PrinterFormPage from '@/pages/PrinterFormPage';
 import InventoryPage from '@/pages/InventoryPage';
 import SalesPage from '@/pages/SalesPage';
 import SaleDetailPage from '@/pages/SaleDetailPage';
@@ -56,6 +59,10 @@ export default function App() {
               <Route path="/jobs/:id/edit" element={<JobFormPage />} />
               <Route path="/products" element={<ProductsPage />} />
               <Route path="/products/:id" element={<ProductDetailPage />} />
+              <Route path="/printers" element={<PrintersPage />} />
+              <Route path="/printers/new" element={<PrinterFormPage />} />
+              <Route path="/printers/:id" element={<PrinterDetailPage />} />
+              <Route path="/printers/:id/edit" element={<PrinterFormPage />} />
               <Route path="/inventory" element={<InventoryPage />} />
               <Route path="/sales" element={<SalesPage />} />
               <Route path="/sales/new" element={<SaleFormPage />} />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -11,6 +11,7 @@ const navLinks = [
   { to: '/materials', label: 'Materials' },
   { to: '/rates', label: 'Rates' },
   { to: '/products', label: 'Products' },
+  { to: '/printers', label: 'Printers' },
   { to: '/sales', label: 'Sales' },
   { to: '/customers', label: 'Customers' },
   { to: '/reports', label: 'Reports' },

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -1,0 +1,201 @@
+import { Link, useParams } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, Edit, Archive, ArchiveRestore } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import { cn, formatCurrency } from '@/lib/utils';
+import { SkeletonTable } from '@/components/ui/Skeleton';
+import type { Job, PaginatedJobs, Printer } from '@/types';
+
+const statusClasses: Record<string, string> = {
+  idle: 'bg-slate-100 text-slate-800 dark:bg-slate-800/60 dark:text-slate-200',
+  printing: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  paused: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+  maintenance: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
+  offline: 'bg-zinc-100 text-zinc-800 dark:bg-zinc-900/50 dark:text-zinc-300',
+  error: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+};
+
+const jobStatusClasses: Record<string, string> = {
+  completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  in_progress: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  draft: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+  cancelled: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+};
+
+function StatusBadge({ status }: { status: string }) {
+  return <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize', statusClasses[status] || 'bg-primary/10 text-primary')}>{status.replace('_', ' ')}</span>;
+}
+
+export default function PrinterDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const queryClient = useQueryClient();
+
+  const { data: printer, isLoading: printerLoading } = useQuery<Printer>({
+    queryKey: ['printer', id],
+    queryFn: () => api.get(`/printers/${id}`).then((response) => response.data),
+    enabled: Boolean(id),
+  });
+
+  const { data: jobs, isLoading: jobsLoading } = useQuery<PaginatedJobs>({
+    queryKey: ['printer-jobs', id],
+    queryFn: () => api.get('/jobs', { params: { printer_id: id, limit: 10 } }).then((response) => response.data),
+    enabled: Boolean(id),
+  });
+
+  const toggleActive = async () => {
+    if (!printer) return;
+    const confirmed = window.confirm(
+      printer.is_active
+        ? `Deactivate ${printer.name}?\n\nThis preserves historical assignments and removes it from active use.`
+        : `Restore ${printer.name} to active printers?`
+    );
+
+    if (!confirmed) return;
+
+    try {
+      if (printer.is_active) {
+        await api.delete(`/printers/${printer.id}`);
+        toast.success(`${printer.name} deactivated`);
+      } else {
+        await api.put(`/printers/${printer.id}`, { is_active: true });
+        toast.success(`${printer.name} restored`);
+      }
+      queryClient.invalidateQueries({ queryKey: ['printers'] });
+      queryClient.invalidateQueries({ queryKey: ['printer', printer.id] });
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Failed to update printer');
+    }
+  };
+
+  if (printerLoading) return <SkeletonTable rows={4} cols={4} />;
+  if (!printer) return <p className="py-16 text-center text-muted-foreground">Printer not found</p>;
+
+  const recentJobs = jobs?.items || [];
+  const activeJob = recentJobs.find((job) => job.status === 'in_progress' || job.status === 'draft');
+
+  return (
+    <div className="max-w-5xl mx-auto">
+      <Link to="/printers" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-4 no-underline">
+        <ArrowLeft className="w-4 h-4" /> Back to Printers
+      </Link>
+
+      <div className="rounded-lg border border-border bg-card p-6 mb-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <div className="flex flex-wrap items-center gap-2 mb-2">
+              <h1 className="text-2xl font-bold">{printer.name}</h1>
+              <StatusBadge status={printer.status} />
+              <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', printer.is_active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400')}>
+                {printer.is_active ? 'Active' : 'Inactive'}
+              </span>
+            </div>
+            <p className="text-sm text-muted-foreground font-mono">{printer.slug}</p>
+            {!printer.is_active && <p className="mt-2 text-sm text-muted-foreground">This printer is inactive. Historical job assignments are still preserved.</p>}
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Link to={`/printers/${printer.id}/edit`} className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 no-underline hover:bg-accent">
+              <Edit className="w-4 h-4" /> Edit
+            </Link>
+            <button onClick={toggleActive} className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border px-4 py-2 hover:bg-accent">
+              {printer.is_active ? <Archive className="w-4 h-4" /> : <ArchiveRestore className="w-4 h-4" />}
+              {printer.is_active ? 'Deactivate' : 'Restore'}
+            </button>
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mt-6">
+          <div>
+            <p className="text-xs text-muted-foreground">Manufacturer</p>
+            <p className="text-lg font-semibold">{printer.manufacturer || '—'}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Model</p>
+            <p className="text-lg font-semibold">{printer.model || '—'}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Location</p>
+            <p className="text-lg font-semibold">{printer.location || '—'}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Serial Number</p>
+            <p className="text-lg font-semibold">{printer.serial_number || '—'}</p>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+          <div className="rounded-lg border border-border bg-background/40 p-4">
+            <p className="text-xs text-muted-foreground mb-1">Notes</p>
+            <p className="text-sm whitespace-pre-wrap">{printer.notes || 'No notes yet.'}</p>
+          </div>
+          <div className="rounded-lg border border-border bg-background/40 p-4">
+            <p className="text-xs text-muted-foreground mb-1">Current / recent assignment</p>
+            {activeJob ? (
+              <div>
+                <p className="font-semibold">{activeJob.job_number}</p>
+                <p className="text-sm text-muted-foreground">{activeJob.product_name}</p>
+                <p className="text-xs text-muted-foreground mt-1">{activeJob.total_pieces} pcs · {activeJob.date}</p>
+              </div>
+            ) : recentJobs[0] ? (
+              <div>
+                <p className="font-semibold">{recentJobs[0].job_number}</p>
+                <p className="text-sm text-muted-foreground">Last assigned: {recentJobs[0].product_name}</p>
+                <p className="text-xs text-muted-foreground mt-1">{recentJobs[0].date}</p>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No jobs assigned yet.</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h2 className="text-xl font-bold">Assigned Jobs</h2>
+            <p className="text-sm text-muted-foreground">Current and recent jobs for this printer.</p>
+          </div>
+          <Link to="/jobs" className="text-sm text-primary no-underline hover:underline">View all jobs</Link>
+        </div>
+
+        {jobsLoading ? (
+          <SkeletonTable rows={5} cols={6} />
+        ) : !recentJobs.length ? (
+          <div className="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">No jobs assigned to this printer yet.</div>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-border bg-card">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-left text-muted-foreground">
+                  <th className="px-4 py-3 font-medium">Job #</th>
+                  <th className="px-4 py-3 font-medium">Date</th>
+                  <th className="px-4 py-3 font-medium">Product</th>
+                  <th className="px-4 py-3 font-medium text-right">Pieces</th>
+                  <th className="px-4 py-3 font-medium text-right">Revenue</th>
+                  <th className="px-4 py-3 font-medium">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recentJobs.map((job: Job) => (
+                  <tr key={job.id} className="border-b border-border last:border-0 hover:bg-accent/50">
+                    <td className="px-4 py-3"><Link to={`/jobs/${job.id}`} className="font-medium text-primary no-underline hover:underline">{job.job_number}</Link></td>
+                    <td className="px-4 py-3">{job.date}</td>
+                    <td className="px-4 py-3">{job.product_name}</td>
+                    <td className="px-4 py-3 text-right">{job.total_pieces}</td>
+                    <td className="px-4 py-3 text-right">{formatCurrency(job.total_revenue)}</td>
+                    <td className="px-4 py-3">
+                      <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', jobStatusClasses[job.status] || 'bg-primary/10 text-primary')}>
+                        {job.status.replace('_', ' ')}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/PrinterFormPage.tsx
+++ b/frontend/src/pages/PrinterFormPage.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams, Link } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import type { Printer } from '@/types';
+
+const STATUS_OPTIONS = ['idle', 'printing', 'paused', 'maintenance', 'offline', 'error'] as const;
+
+const emptyForm = {
+  name: '',
+  slug: '',
+  manufacturer: '',
+  model: '',
+  serial_number: '',
+  location: '',
+  status: 'idle',
+  is_active: true,
+  notes: '',
+};
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 120);
+}
+
+export default function PrinterFormPage() {
+  const { id } = useParams<{ id: string }>();
+  const isEdit = Boolean(id);
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data: printer, isLoading } = useQuery<Printer>({
+    queryKey: ['printer', id],
+    queryFn: () => api.get(`/printers/${id}`).then((response) => response.data),
+    enabled: isEdit,
+  });
+
+  const [form, setForm] = useState(emptyForm);
+  const [slugTouched, setSlugTouched] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!printer) return;
+    setForm({
+      name: printer.name,
+      slug: printer.slug,
+      manufacturer: printer.manufacturer || '',
+      model: printer.model || '',
+      serial_number: printer.serial_number || '',
+      location: printer.location || '',
+      status: printer.status,
+      is_active: printer.is_active,
+      notes: printer.notes || '',
+    });
+    setSlugTouched(true);
+  }, [printer]);
+
+  useEffect(() => {
+    if (slugTouched) return;
+    setForm((current) => ({ ...current, slug: slugify(current.name) }));
+  }, [form.name, slugTouched]);
+
+  const title = useMemo(() => (isEdit ? 'Edit Printer' : 'Add Printer'), [isEdit]);
+
+  const update = (field: string, value: string | boolean) => {
+    setForm((current) => ({ ...current, [field]: value }));
+    setErrors((current) => ({ ...current, [field]: '' }));
+  };
+
+  const validate = () => {
+    const nextErrors: Record<string, string> = {};
+    if (!form.name.trim()) nextErrors.name = 'Name is required';
+    if (!form.slug.trim()) nextErrors.slug = 'Slug is required';
+    if (form.slug && !/^[a-z0-9-]+$/.test(form.slug)) nextErrors.slug = 'Use lowercase letters, numbers, and hyphens only';
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!validate()) return;
+
+    setSaving(true);
+    try {
+      const payload = {
+        ...form,
+        name: form.name.trim(),
+        slug: form.slug.trim(),
+        manufacturer: form.manufacturer.trim() || null,
+        model: form.model.trim() || null,
+        serial_number: form.serial_number.trim() || null,
+        location: form.location.trim() || null,
+        notes: form.notes.trim() || null,
+      };
+
+      if (isEdit) {
+        await api.put(`/printers/${id}`, payload);
+        toast.success('Printer updated');
+        queryClient.invalidateQueries({ queryKey: ['printer', id] });
+      } else {
+        const response = await api.post('/printers', payload);
+        toast.success('Printer created');
+        queryClient.invalidateQueries({ queryKey: ['printers'] });
+        navigate(`/printers/${response.data.id}`);
+        return;
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['printers'] });
+      navigate(`/printers/${id}`);
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Failed to save printer');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (isEdit && isLoading) {
+    return <div className="rounded-lg border border-border bg-card p-6">Loading printer...</div>;
+  }
+
+  if (isEdit && !printer) {
+    return <p className="py-16 text-center text-muted-foreground">Printer not found</p>;
+  }
+
+  const inputClass = (field: string) => `w-full rounded-md border px-3 py-2 bg-background focus:outline-none focus:ring-2 focus:ring-ring ${errors[field] ? 'border-destructive' : 'border-input'}`;
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <Link to={isEdit && id ? `/printers/${id}` : '/printers'} className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-4 no-underline">
+        <ArrowLeft className="w-4 h-4" /> Back
+      </Link>
+
+      <div className="rounded-lg border border-border bg-card p-6">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold">{title}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Track machine details, availability, and where this printer lives.</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="grid gap-5 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium mb-1.5">Name *</label>
+              <input value={form.name} onChange={(e) => update('name', e.target.value)} className={inputClass('name')} placeholder="Bambu X1C #1" />
+              {errors.name && <p className="mt-1 text-xs text-destructive">{errors.name}</p>}
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1.5">Slug *</label>
+              <input
+                value={form.slug}
+                onChange={(e) => {
+                  setSlugTouched(true);
+                  update('slug', slugify(e.target.value));
+                }}
+                className={inputClass('slug')}
+                placeholder="bambu-x1c-1"
+              />
+              {errors.slug && <p className="mt-1 text-xs text-destructive">{errors.slug}</p>}
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1.5">Manufacturer</label>
+              <input value={form.manufacturer} onChange={(e) => update('manufacturer', e.target.value)} className={inputClass('manufacturer')} placeholder="Bambu Lab" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1.5">Model</label>
+              <input value={form.model} onChange={(e) => update('model', e.target.value)} className={inputClass('model')} placeholder="X1 Carbon" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1.5">Serial Number</label>
+              <input value={form.serial_number} onChange={(e) => update('serial_number', e.target.value)} className={inputClass('serial_number')} placeholder="Optional" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1.5">Location</label>
+              <input value={form.location} onChange={(e) => update('location', e.target.value)} className={inputClass('location')} placeholder="Print room shelf A" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1.5">Status</label>
+              <select value={form.status} onChange={(e) => update('status', e.target.value)} className={inputClass('status')}>
+                {STATUS_OPTIONS.map((option) => (
+                  <option key={option} value={option}>{option.replace('_', ' ')}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-end">
+              <label className="inline-flex items-center gap-3 rounded-md border border-border px-4 py-3 w-full cursor-pointer hover:bg-accent/50">
+                <input type="checkbox" checked={form.is_active} onChange={(e) => update('is_active', e.target.checked)} className="h-4 w-4" />
+                <div>
+                  <p className="text-sm font-medium">Active printer</p>
+                  <p className="text-xs text-muted-foreground">Inactive printers stay in history but are hidden from active use.</p>
+                </div>
+              </label>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1.5">Notes</label>
+            <textarea
+              value={form.notes}
+              onChange={(e) => update('notes', e.target.value)}
+              rows={5}
+              className={inputClass('notes')}
+              placeholder="Nozzle size, preferred materials, maintenance notes, quirks, etc."
+            />
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <button type="submit" disabled={saving} className="cursor-pointer rounded-md bg-primary px-4 py-2 font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50">
+              {saving ? 'Saving...' : isEdit ? 'Save Changes' : 'Create Printer'}
+            </button>
+            <button type="button" onClick={() => navigate(isEdit && id ? `/printers/${id}` : '/printers')} className="cursor-pointer rounded-md border border-border px-4 py-2 hover:bg-accent">
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -1,0 +1,274 @@
+import { useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { Plus, Search, Eye, Edit, Archive, ArchiveRestore } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import EmptyState from '@/components/ui/EmptyState';
+import { SkeletonTable } from '@/components/ui/Skeleton';
+import { cn } from '@/lib/utils';
+import type { PaginatedPrinters, Printer } from '@/types';
+
+const STATUS_OPTIONS = ['idle', 'printing', 'paused', 'maintenance', 'offline', 'error'] as const;
+
+const statusClasses: Record<string, string> = {
+  idle: 'bg-slate-100 text-slate-800 dark:bg-slate-800/60 dark:text-slate-200',
+  printing: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  paused: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+  maintenance: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
+  offline: 'bg-zinc-100 text-zinc-800 dark:bg-zinc-900/50 dark:text-zinc-300',
+  error: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+};
+
+const activeClasses: Record<string, string> = {
+  active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  inactive: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+};
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize', statusClasses[status] || 'bg-primary/10 text-primary')}>
+      {status.replace('_', ' ')}
+    </span>
+  );
+}
+
+function ActiveBadge({ isActive }: { isActive: boolean }) {
+  return (
+    <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', isActive ? activeClasses.active : activeClasses.inactive)}>
+      {isActive ? 'Active' : 'Inactive'}
+    </span>
+  );
+}
+
+export default function PrintersPage() {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState('');
+  const [active, setActive] = useState('');
+  const [page, setPage] = useState(0);
+  const limit = 24;
+
+  const { data, isLoading } = useQuery<PaginatedPrinters>({
+    queryKey: ['printers', { search, status, active, page }],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (search) params.set('search', search);
+      if (status) params.set('status', status);
+      if (active) params.set('is_active', active);
+      params.set('skip', String(page * limit));
+      params.set('limit', String(limit));
+      const { data } = await api.get(`/printers?${params.toString()}`);
+      return data;
+    },
+  });
+
+  const printers = data?.items || [];
+  const total = data?.total || 0;
+  const totalPages = Math.ceil(total / limit);
+
+  const summary = useMemo(() => ({
+    total: printers.length,
+    printing: printers.filter((printer) => printer.status === 'printing').length,
+    maintenance: printers.filter((printer) => printer.status === 'maintenance').length,
+    inactive: printers.filter((printer) => !printer.is_active).length,
+  }), [printers]);
+
+  const toggleActive = async (printer: Printer) => {
+    const confirmed = window.confirm(
+      printer.is_active
+        ? `Deactivate ${printer.name}?\n\nThis keeps the printer in historical records but removes it from active assignment.`
+        : `Restore ${printer.name} to active printers?`
+    );
+
+    if (!confirmed) return;
+
+    try {
+      if (printer.is_active) {
+        await api.delete(`/printers/${printer.id}`);
+        toast.success(`${printer.name} deactivated`);
+      } else {
+        await api.put(`/printers/${printer.id}`, { is_active: true });
+        toast.success(`${printer.name} restored`);
+      }
+      queryClient.invalidateQueries({ queryKey: ['printers'] });
+      queryClient.invalidateQueries({ queryKey: ['printer', printer.id] });
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Failed to update printer');
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6 gap-3">
+        <div>
+          <h1 className="text-3xl font-bold">Printers</h1>
+          <p className="text-sm text-muted-foreground mt-1">Manage your print farm, machine status, and printer assignments.</p>
+        </div>
+        <Link to="/printers/new" className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground no-underline hover:opacity-90">
+          <Plus className="w-4 h-4" /> Add Printer
+        </Link>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4 mb-6">
+        <div className="rounded-lg border border-border bg-card p-4"><p className="text-xs text-muted-foreground">Visible printers</p><p className="text-2xl font-bold mt-1">{summary.total}</p></div>
+        <div className="rounded-lg border border-border bg-card p-4"><p className="text-xs text-muted-foreground">Currently printing</p><p className="text-2xl font-bold mt-1">{summary.printing}</p></div>
+        <div className="rounded-lg border border-border bg-card p-4"><p className="text-xs text-muted-foreground">In maintenance</p><p className="text-2xl font-bold mt-1">{summary.maintenance}</p></div>
+        <div className="rounded-lg border border-border bg-card p-4"><p className="text-xs text-muted-foreground">Inactive</p><p className="text-2xl font-bold mt-1">{summary.inactive}</p></div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px_180px] mb-6">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <input
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(0);
+            }}
+            placeholder="Search printers by name, model, slug, or location..."
+            className="w-full rounded-md border border-input bg-background py-2 pr-3 pl-10 focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+        <select
+          value={status}
+          onChange={(e) => {
+            setStatus(e.target.value);
+            setPage(0);
+          }}
+          className="rounded-md border border-input bg-background px-3 py-2 focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="">All statuses</option>
+          {STATUS_OPTIONS.map((option) => (
+            <option key={option} value={option}>{option.replace('_', ' ')}</option>
+          ))}
+        </select>
+        <select
+          value={active}
+          onChange={(e) => {
+            setActive(e.target.value);
+            setPage(0);
+          }}
+          className="rounded-md border border-input bg-background px-3 py-2 focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="">Active + inactive</option>
+          <option value="true">Active only</option>
+          <option value="false">Inactive only</option>
+        </select>
+      </div>
+
+      {isLoading ? (
+        <SkeletonTable rows={6} cols={7} />
+      ) : !printers.length ? (
+        <EmptyState
+          title="No printers found"
+          description="Add your first printer to start tracking status, locations, and job assignments."
+          action={<Link to="/printers/new" className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground no-underline hover:opacity-90"><Plus className="w-4 h-4" /> Add Printer</Link>}
+        />
+      ) : (
+        <>
+          <div className="hidden lg:block overflow-x-auto rounded-lg border border-border bg-card">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-left text-muted-foreground">
+                  <th className="px-4 py-3 font-medium">Name</th>
+                  <th className="px-4 py-3 font-medium">Manufacturer / Model</th>
+                  <th className="px-4 py-3 font-medium">Location</th>
+                  <th className="px-4 py-3 font-medium">Status</th>
+                  <th className="px-4 py-3 font-medium">State</th>
+                  <th className="px-4 py-3 font-medium">Notes</th>
+                  <th className="px-4 py-3 font-medium text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {printers.map((printer) => (
+                  <tr key={printer.id} className="border-b border-border last:border-0 hover:bg-accent/50">
+                    <td className="px-4 py-3">
+                      <div className="font-medium">{printer.name}</div>
+                      <div className="text-xs text-muted-foreground font-mono">{printer.slug}</div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div>{printer.manufacturer || '—'}</div>
+                      <div className="text-xs text-muted-foreground">{printer.model || '—'}</div>
+                    </td>
+                    <td className="px-4 py-3">{printer.location || '—'}</td>
+                    <td className="px-4 py-3"><StatusBadge status={printer.status} /></td>
+                    <td className="px-4 py-3"><ActiveBadge isActive={printer.is_active} /></td>
+                    <td className="px-4 py-3 max-w-xs truncate text-muted-foreground">{printer.notes || '—'}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex justify-end gap-1">
+                        <Link to={`/printers/${printer.id}`} className="rounded-md p-1.5 text-muted-foreground hover:bg-accent" title="View"><Eye className="w-4 h-4" /></Link>
+                        <Link to={`/printers/${printer.id}/edit`} className="rounded-md p-1.5 text-muted-foreground hover:bg-accent" title="Edit"><Edit className="w-4 h-4" /></Link>
+                        <button onClick={() => toggleActive(printer)} className="cursor-pointer rounded-md p-1.5 text-muted-foreground hover:bg-accent" title={printer.is_active ? 'Deactivate printer' : 'Restore printer'}>
+                          {printer.is_active ? <Archive className="w-4 h-4" /> : <ArchiveRestore className="w-4 h-4" />}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="grid gap-3 lg:hidden">
+            {printers.map((printer) => (
+              <div key={printer.id} className="rounded-lg border border-border bg-card p-4">
+                <div className="flex items-start justify-between gap-3 mb-3">
+                  <div>
+                    <Link to={`/printers/${printer.id}`} className="font-semibold text-foreground no-underline hover:text-primary">{printer.name}</Link>
+                    <p className="text-xs text-muted-foreground font-mono mt-0.5">{printer.slug}</p>
+                  </div>
+                  <div className="flex flex-col items-end gap-2">
+                    <StatusBadge status={printer.status} />
+                    <ActiveBadge isActive={printer.is_active} />
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <p className="text-xs text-muted-foreground">Manufacturer</p>
+                    <p>{printer.manufacturer || '—'}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground">Model</p>
+                    <p>{printer.model || '—'}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground">Location</p>
+                    <p>{printer.location || '—'}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground">Notes</p>
+                    <p className="line-clamp-2">{printer.notes || '—'}</p>
+                  </div>
+                </div>
+                <div className="mt-4 flex gap-2">
+                  <Link to={`/printers/${printer.id}`} className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm no-underline hover:bg-accent">
+                    <Eye className="w-4 h-4" /> View
+                  </Link>
+                  <Link to={`/printers/${printer.id}/edit`} className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm no-underline hover:bg-accent">
+                    <Edit className="w-4 h-4" /> Edit
+                  </Link>
+                  <button onClick={() => toggleActive(printer)} className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm hover:bg-accent">
+                    {printer.is_active ? <Archive className="w-4 h-4" /> : <ArchiveRestore className="w-4 h-4" />}
+                    {printer.is_active ? 'Deactivate' : 'Restore'}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="mt-4 flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">Showing {page * limit + 1}–{Math.min((page + 1) * limit, total)} of {total}</p>
+              <div className="flex gap-2">
+                <button disabled={page === 0} onClick={() => setPage((current) => current - 1)} className="cursor-pointer rounded-md border border-border px-3 py-1 text-sm hover:bg-accent disabled:opacity-50">Prev</button>
+                <span className="px-3 py-1 text-sm">{page + 1} / {totalPages}</span>
+                <button disabled={page >= totalPages - 1} onClick={() => setPage((current) => current + 1)} className="cursor-pointer rounded-md border border-border px-3 py-1 text-sm hover:bg-accent disabled:opacity-50">Next</button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add dedicated printers list, detail, and create/edit pages
- register /printers routes and add printers to the main navigation
- support browse, search, filter, create, edit, and activate/deactivate flows
- show related jobs on printer detail using existing jobs filtering

## Testing
- npm --prefix frontend run build

Closes #85