### PR TITLE
feat(layout): move primary nav to left sidebar (#100)

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,81 +1,52 @@
-import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { Moon, Sun, Printer, LogOut, Menu, X, Settings, User } from 'lucide-react';
-import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Moon, Sun, Printer, LogOut, Menu, Settings, User } from 'lucide-react';
 import { useAuthStore } from '@/store/auth';
 import { useTheme } from '@/hooks/useTheme';
-import { cn } from '@/lib/utils';
 
-const navLinks = [
-  { to: '/', label: 'Dashboard' },
-  { to: '/jobs', label: 'Jobs' },
-  { to: '/materials', label: 'Materials' },
-  { to: '/rates', label: 'Rates' },
-  { to: '/products', label: 'Products' },
-  { to: '/printers', label: 'Printers' },
-  { to: '/sales', label: 'Sales' },
-  { to: '/customers', label: 'Customers' },
-  { to: '/reports', label: 'Reports' },
-  { to: '/calculator', label: 'Calculator' },
-];
+interface HeaderProps {
+  onOpenMobileNav?: () => void;
+}
 
-export default function Header() {
+export default function Header({ onOpenMobileNav }: HeaderProps) {
   const { dark, toggle } = useTheme();
-  const [menuOpen, setMenuOpen] = useState(false);
   const { user, logout } = useAuthStore();
   const navigate = useNavigate();
-  const location = useLocation();
 
   const handleLogout = () => {
     logout();
     navigate('/login');
   };
 
-  const isActive = (path: string) => {
-    if (path === '/') return location.pathname === '/';
-    return location.pathname.startsWith(path);
-  };
-
   return (
-    <header className="border-b border-border bg-card sticky top-0 z-50">
+    <header className="border-b border-border bg-card/95 backdrop-blur sticky top-0 z-40">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between h-16">
-          <Link to="/" className="flex items-center gap-2 text-primary font-bold text-xl no-underline">
-            <Printer className="w-6 h-6" />
-            <span className="hidden sm:inline">3D Print Sales</span>
-          </Link>
+        <div className="flex items-center justify-between h-16 gap-4">
+          <div className="flex items-center gap-3 min-w-0">
+            <button
+              onClick={onOpenMobileNav}
+              className="md:hidden p-2 rounded-md hover:bg-accent transition-colors text-muted-foreground"
+              aria-label="Open navigation menu"
+            >
+              <Menu className="w-5 h-5" />
+            </button>
 
-          <nav className="hidden md:flex items-center gap-1">
-            {navLinks.map((link) => (
-              <Link
-                key={link.to}
-                to={link.to}
-                className={cn(
-                  'px-3 py-2 rounded-md text-sm font-medium transition-colors no-underline',
-                  isActive(link.to)
-                    ? 'bg-primary/10 text-primary'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-                )}
-              >
-                {link.label}
-              </Link>
-            ))}
+            <Link to="/" className="flex items-center gap-2 text-primary font-bold text-xl no-underline min-w-0">
+              <Printer className="w-6 h-6 shrink-0" />
+              <span className="truncate">3D Print Sales</span>
+            </Link>
+          </div>
+
+          <div className="flex items-center gap-2 shrink-0">
             {user?.role === 'admin' && (
               <Link
                 to="/admin/settings"
-                className={cn(
-                  'px-3 py-2 rounded-md text-sm font-medium transition-colors no-underline',
-                  isActive('/admin')
-                    ? 'bg-primary/10 text-primary'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-                )}
+                className="hidden sm:inline-flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium no-underline text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
               >
-                <Settings className="w-4 h-4 inline-block mr-1 -mt-0.5" />
+                <Settings className="w-4 h-4" />
                 Admin
               </Link>
             )}
-          </nav>
 
-          <div className="flex items-center gap-2">
             <button
               onClick={toggle}
               className="p-2 rounded-md hover:bg-accent transition-colors text-muted-foreground"
@@ -83,10 +54,11 @@ export default function Header() {
             >
               {dark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
             </button>
+
             {user && (
-              <div className="hidden sm:flex items-center gap-2 text-sm text-muted-foreground border-l border-border pl-3 ml-1">
-                <User className="w-4 h-4" />
-                <span className="max-w-[120px] truncate">{user.full_name}</span>
+              <div className="hidden sm:flex items-center gap-2 text-sm text-muted-foreground border-l border-border pl-3 ml-1 min-w-0 max-w-[220px]">
+                <User className="w-4 h-4 shrink-0" />
+                <span className="truncate">{user.full_name}</span>
                 <button
                   onClick={handleLogout}
                   className="p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-destructive"
@@ -97,58 +69,20 @@ export default function Header() {
                 </button>
               </div>
             )}
+
             {user && (
               <button
                 onClick={handleLogout}
                 className="sm:hidden p-2 rounded-md hover:bg-accent transition-colors text-muted-foreground"
                 aria-label="Logout"
+                title="Sign out"
               >
                 <LogOut className="w-5 h-5" />
               </button>
             )}
-            <button
-              onClick={() => setMenuOpen(!menuOpen)}
-              className="md:hidden p-2 rounded-md hover:bg-accent transition-colors text-muted-foreground"
-            >
-              {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
-            </button>
           </div>
         </div>
       </div>
-
-      {menuOpen && (
-        <nav className="md:hidden border-t border-border px-4 py-2 bg-card">
-          {navLinks.map((link) => (
-            <Link
-              key={link.to}
-              to={link.to}
-              onClick={() => setMenuOpen(false)}
-              className={cn(
-                'block px-3 py-2 rounded-md text-sm font-medium no-underline',
-                isActive(link.to)
-                  ? 'bg-primary/10 text-primary'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-              )}
-            >
-              {link.label}
-            </Link>
-          ))}
-          {user?.role === 'admin' && (
-            <Link
-              to="/admin/settings"
-              onClick={() => setMenuOpen(false)}
-              className={cn(
-                'block px-3 py-2 rounded-md text-sm font-medium no-underline',
-                isActive('/admin')
-                  ? 'bg-primary/10 text-primary'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-              )}
-            >
-              Admin
-            </Link>
-          )}
-        </nav>
-      )}
     </header>
   );
 }

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,14 +1,130 @@
-import { Outlet } from 'react-router-dom';
+import { useState } from 'react';
+import { NavLink, Outlet } from 'react-router-dom';
+import { ChevronLeft, Settings, X } from 'lucide-react';
 import Header from './Header';
 import Footer from './Footer';
+import { useAuthStore } from '@/store/auth';
+import { cn } from '@/lib/utils';
+import { appNavLinks } from './appNav';
+
+function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
+  const { user } = useAuthStore();
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="px-3 pb-3">
+        <p className="px-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          Main Navigation
+        </p>
+      </div>
+
+      <nav className="space-y-1 px-3">
+        {appNavLinks.map(({ to, label, icon: Icon, end }) => (
+          <NavLink
+            key={to}
+            to={to}
+            end={end}
+            onClick={onNavigate}
+            className={({ isActive }) =>
+              cn(
+                'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors no-underline',
+                isActive
+                  ? 'bg-primary/10 text-primary shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+              )
+            }
+          >
+            <Icon className="w-4 h-4 shrink-0" />
+            <span>{label}</span>
+          </NavLink>
+        ))}
+      </nav>
+
+      {user?.role === 'admin' && (
+        <div className="mt-6 border-t border-border px-3 pt-6">
+          <NavLink
+            to="/admin/settings"
+            onClick={onNavigate}
+            className={({ isActive }) =>
+              cn(
+                'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors no-underline',
+                isActive
+                  ? 'bg-primary/10 text-primary shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+              )
+            }
+          >
+            <Settings className="w-4 h-4 shrink-0" />
+            <span>Admin</span>
+          </NavLink>
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function Layout() {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
   return (
     <div className="min-h-screen flex flex-col bg-background">
-      <Header />
-      <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <Outlet />
-      </main>
+      <Header onOpenMobileNav={() => setMobileNavOpen(true)} />
+
+      <div className="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 lg:py-8">
+        <div className="flex gap-6 lg:gap-8 min-h-full">
+          <aside className="hidden md:block w-64 shrink-0">
+            <div className="sticky top-24 rounded-2xl border border-border bg-card p-3 shadow-sm">
+              <SidebarContent />
+            </div>
+          </aside>
+
+          <main className="flex-1 min-w-0">
+            <Outlet />
+          </main>
+        </div>
+      </div>
+
+      {mobileNavOpen && (
+        <div className="md:hidden fixed inset-0 z-50 flex">
+          <button
+            type="button"
+            className="absolute inset-0 bg-black/50"
+            aria-label="Close navigation menu"
+            onClick={() => setMobileNavOpen(false)}
+          />
+
+          <aside className="relative flex h-full w-full max-w-xs flex-col border-r border-border bg-card shadow-xl">
+            <div className="flex items-center justify-between border-b border-border px-4 py-4">
+              <div>
+                <p className="text-sm font-semibold">Navigation</p>
+                <p className="text-xs text-muted-foreground">Jump to any section</p>
+              </div>
+              <button
+                onClick={() => setMobileNavOpen(false)}
+                className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-accent"
+                aria-label="Close navigation menu"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto py-4">
+              <SidebarContent onNavigate={() => setMobileNavOpen(false)} />
+            </div>
+
+            <div className="border-t border-border p-3">
+              <button
+                onClick={() => setMobileNavOpen(false)}
+                className="flex w-full items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent"
+              >
+                <ChevronLeft className="h-4 w-4" />
+                Close menu
+              </button>
+            </div>
+          </aside>
+        </div>
+      )}
+
       <Footer />
     </div>
   );

--- a/frontend/src/components/layout/appNav.ts
+++ b/frontend/src/components/layout/appNav.ts
@@ -1,0 +1,34 @@
+import {
+  BarChart3,
+  Boxes,
+  Calculator,
+  DollarSign,
+  Gauge,
+  Package,
+  Printer,
+  ShoppingCart,
+  Users,
+  ClipboardList,
+  type LucideIcon,
+} from 'lucide-react';
+
+export interface AppNavLink {
+  to: string;
+  label: string;
+  icon: LucideIcon;
+  end?: boolean;
+}
+
+export const appNavLinks: AppNavLink[] = [
+  { to: '/', label: 'Dashboard', icon: Gauge, end: true },
+  { to: '/jobs', label: 'Jobs', icon: ClipboardList },
+  { to: '/printers', label: 'Printers', icon: Printer },
+  { to: '/materials', label: 'Materials', icon: Boxes },
+  { to: '/rates', label: 'Rates', icon: DollarSign },
+  { to: '/products', label: 'Products', icon: Package },
+  { to: '/inventory', label: 'Inventory', icon: Package },
+  { to: '/sales', label: 'Sales', icon: ShoppingCart },
+  { to: '/customers', label: 'Customers', icon: Users },
+  { to: '/reports', label: 'Reports', icon: BarChart3 },
+  { to: '/calculator', label: 'Calculator', icon: Calculator },
+];


### PR DESCRIPTION
## Summary
- move the main app primary navigation from the top header into a left sidebar
- add a persistent desktop sidebar and a mobile drawer toggle
- simplify the top bar to branding, controls, and account actions
- centralize main nav links in a shared appNav config
- preserve admin access and route highlighting

## Testing
- npm --prefix frontend run build

Closes #100