### PR TITLE
feat(printers): add live monitoring integration (#102)

### DIFF
--- a/backend/alembic/versions/20260329_01_add_printer_monitoring_fields.py
+++ b/backend/alembic/versions/20260329_01_add_printer_monitoring_fields.py
@@ -1,0 +1,50 @@
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260329_01"
+down_revision: Union[str, None] = "20260324_02"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("printers", sa.Column("monitor_enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")))
+    op.add_column("printers", sa.Column("monitor_provider", sa.String(length=50), nullable=True))
+    op.add_column("printers", sa.Column("monitor_base_url", sa.String(length=500), nullable=True))
+    op.add_column("printers", sa.Column("monitor_api_key", sa.String(length=255), nullable=True))
+    op.add_column("printers", sa.Column("monitor_poll_interval_seconds", sa.Integer(), nullable=False, server_default="30"))
+    op.add_column("printers", sa.Column("monitor_online", sa.Boolean(), nullable=True))
+    op.add_column("printers", sa.Column("monitor_status", sa.String(length=30), nullable=True))
+    op.add_column("printers", sa.Column("monitor_progress_percent", sa.Float(), nullable=True))
+    op.add_column("printers", sa.Column("current_print_name", sa.String(length=255), nullable=True))
+    op.add_column("printers", sa.Column("monitor_last_message", sa.Text(), nullable=True))
+    op.add_column("printers", sa.Column("monitor_last_error", sa.Text(), nullable=True))
+    op.add_column("printers", sa.Column("monitor_bed_temp_c", sa.Float(), nullable=True))
+    op.add_column("printers", sa.Column("monitor_tool_temp_c", sa.Float(), nullable=True))
+    op.add_column("printers", sa.Column("monitor_last_seen_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("printers", sa.Column("monitor_last_updated_at", sa.DateTime(timezone=True), nullable=True))
+    op.create_index(op.f("ix_printers_monitor_enabled"), "printers", ["monitor_enabled"], unique=False)
+    op.create_index(op.f("ix_printers_monitor_provider"), "printers", ["monitor_provider"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_printers_monitor_provider"), table_name="printers")
+    op.drop_index(op.f("ix_printers_monitor_enabled"), table_name="printers")
+    op.drop_column("printers", "monitor_last_updated_at")
+    op.drop_column("printers", "monitor_last_seen_at")
+    op.drop_column("printers", "monitor_tool_temp_c")
+    op.drop_column("printers", "monitor_bed_temp_c")
+    op.drop_column("printers", "monitor_last_error")
+    op.drop_column("printers", "monitor_last_message")
+    op.drop_column("printers", "current_print_name")
+    op.drop_column("printers", "monitor_progress_percent")
+    op.drop_column("printers", "monitor_status")
+    op.drop_column("printers", "monitor_online")
+    op.drop_column("printers", "monitor_poll_interval_seconds")
+    op.drop_column("printers", "monitor_api_key")
+    op.drop_column("printers", "monitor_base_url")
+    op.drop_column("printers", "monitor_provider")
+    op.drop_column("printers", "monitor_enabled")

--- a/backend/app/api/v1/endpoints/printers.py
+++ b/backend/app/api/v1/endpoints/printers.py
@@ -7,9 +7,29 @@ from sqlalchemy import func, select
 
 from app.api.deps import DB, CurrentUser
 from app.models.printer import Printer
-from app.schemas.printer import PaginatedPrinters, PrinterCreate, PrinterResponse, PrinterUpdate
+from app.schemas.printer import (
+    PaginatedPrinters,
+    PrinterConnectionTestResponse,
+    PrinterCreate,
+    PrinterResponse,
+    PrinterUpdate,
+)
+from app.services.printer_monitoring import (
+    PrinterMonitoringError,
+    mark_printer_stale_if_needed,
+    refresh_printer_monitoring,
+    test_printer_connection,
+)
 
 router = APIRouter(prefix="/printers", tags=["Printers"])
+
+
+async def _get_printer_or_404(db: DB, printer_id: uuid.UUID) -> Printer:
+    result = await db.execute(select(Printer).where(Printer.id == printer_id))
+    printer = result.scalar_one_or_none()
+    if not printer:
+        raise HTTPException(status_code=404, detail="Printer not found")
+    return printer
 
 
 @router.get(
@@ -45,6 +65,9 @@ async def list_printers(
 
     result = await db.execute(base.order_by(Printer.name).offset(skip).limit(limit))
     items = result.scalars().all()
+    for printer in items:
+        mark_printer_stale_if_needed(printer)
+        await refresh_printer_monitoring(db, printer)
     return PaginatedPrinters(items=items, total=total, skip=skip, limit=limit)
 
 
@@ -55,10 +78,9 @@ async def list_printers(
     description="Retrieve a single printer record.",
 )
 async def get_printer(printer_id: uuid.UUID, db: DB):
-    result = await db.execute(select(Printer).where(Printer.id == printer_id))
-    printer = result.scalar_one_or_none()
-    if not printer:
-        raise HTTPException(status_code=404, detail="Printer not found")
+    printer = await _get_printer_or_404(db, printer_id)
+    mark_printer_stale_if_needed(printer)
+    await refresh_printer_monitoring(db, printer)
     return printer
 
 
@@ -78,6 +100,8 @@ async def create_printer(body: PrinterCreate, user: CurrentUser, db: DB):
     db.add(printer)
     await db.commit()
     await db.refresh(printer)
+    if printer.monitor_enabled:
+        await refresh_printer_monitoring(db, printer, force=True)
     return printer
 
 
@@ -88,10 +112,7 @@ async def create_printer(body: PrinterCreate, user: CurrentUser, db: DB):
     description="Update one or more fields of a printer.",
 )
 async def update_printer(printer_id: uuid.UUID, body: PrinterUpdate, user: CurrentUser, db: DB):
-    result = await db.execute(select(Printer).where(Printer.id == printer_id))
-    printer = result.scalar_one_or_none()
-    if not printer:
-        raise HTTPException(status_code=404, detail="Printer not found")
+    printer = await _get_printer_or_404(db, printer_id)
 
     update_data = body.model_dump(exclude_unset=True)
     if "name" in update_data or "slug" in update_data:
@@ -107,9 +128,58 @@ async def update_printer(printer_id: uuid.UUID, body: PrinterUpdate, user: Curre
     for field, value in update_data.items():
         setattr(printer, field, value)
 
+    if not printer.monitor_enabled:
+        printer.monitor_online = None
+        printer.monitor_status = None
+        printer.monitor_progress_percent = None
+        printer.current_print_name = None
+        printer.monitor_last_message = None
+        printer.monitor_last_error = None
+        printer.monitor_bed_temp_c = None
+        printer.monitor_tool_temp_c = None
+        printer.monitor_last_seen_at = None
+        printer.monitor_last_updated_at = None
+
     await db.commit()
     await db.refresh(printer)
+    if printer.monitor_enabled:
+        await refresh_printer_monitoring(db, printer, force=True)
     return printer
+
+
+@router.post(
+    "/{printer_id}/refresh",
+    response_model=PrinterResponse,
+    summary="Refresh live printer status",
+    description="Force a live provider refresh for a configured printer.",
+)
+async def refresh_printer(printer_id: uuid.UUID, user: CurrentUser, db: DB):
+    printer = await _get_printer_or_404(db, printer_id)
+    await refresh_printer_monitoring(db, printer, force=True)
+    return printer
+
+
+@router.post(
+    "/{printer_id}/test-connection",
+    response_model=PrinterConnectionTestResponse,
+    summary="Test printer monitoring connection",
+    description="Tests connectivity to the configured monitoring provider without changing saved live state.",
+)
+async def test_connection(printer_id: uuid.UUID, user: CurrentUser, db: DB):
+    printer = await _get_printer_or_404(db, printer_id)
+    try:
+        result = await test_printer_connection(printer)
+        return PrinterConnectionTestResponse(
+            ok=result.ok,
+            provider=result.provider,
+            normalized_status=result.normalized_status,
+            online=result.online,
+            message=result.message,
+        )
+    except PrinterMonitoringError as exc:
+        return PrinterConnectionTestResponse(ok=False, provider=printer.monitor_provider or "unconfigured", message=str(exc))
+    except Exception as exc:  # noqa: BLE001
+        return PrinterConnectionTestResponse(ok=False, provider=printer.monitor_provider or "unconfigured", message=str(exc))
 
 
 @router.delete(
@@ -119,9 +189,6 @@ async def update_printer(printer_id: uuid.UUID, body: PrinterUpdate, user: Curre
     description="Soft-deletes a printer by setting is_active=false.",
 )
 async def delete_printer(printer_id: uuid.UUID, user: CurrentUser, db: DB):
-    result = await db.execute(select(Printer).where(Printer.id == printer_id))
-    printer = result.scalar_one_or_none()
-    if not printer:
-        raise HTTPException(status_code=404, detail="Printer not found")
+    printer = await _get_printer_or_404(db, printer_id)
     printer.is_active = False
     await db.commit()

--- a/backend/app/models/printer.py
+++ b/backend/app/models/printer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Boolean, DateTime, String, Text
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -22,6 +22,21 @@ class Printer(Base):
     status: Mapped[str] = mapped_column(String(20), default="idle", index=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    monitor_enabled: Mapped[bool] = mapped_column(Boolean, default=False, index=True)
+    monitor_provider: Mapped[str | None] = mapped_column(String(50), nullable=True, index=True)
+    monitor_base_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    monitor_api_key: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    monitor_poll_interval_seconds: Mapped[int] = mapped_column(Integer, default=30)
+    monitor_online: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    monitor_status: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    monitor_progress_percent: Mapped[float | None] = mapped_column(Float, nullable=True)
+    current_print_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    monitor_last_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    monitor_last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    monitor_bed_temp_c: Mapped[float | None] = mapped_column(Float, nullable=True)
+    monitor_tool_temp_c: Mapped[float | None] = mapped_column(Float, nullable=True)
+    monitor_last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    monitor_last_updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/backend/app/schemas/printer.py
+++ b/backend/app/schemas/printer.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class PrinterStatus(str, Enum):
@@ -14,6 +14,10 @@ class PrinterStatus(str, Enum):
     maintenance = "maintenance"
     offline = "offline"
     error = "error"
+
+
+class PrinterMonitorProvider(str, Enum):
+    octoprint = "octoprint"
 
 
 class PrinterCreate(BaseModel):
@@ -26,6 +30,19 @@ class PrinterCreate(BaseModel):
     status: PrinterStatus = PrinterStatus.idle
     is_active: bool = True
     notes: str | None = Field(None, max_length=1000)
+    monitor_enabled: bool = False
+    monitor_provider: PrinterMonitorProvider | None = None
+    monitor_base_url: str | None = Field(None, max_length=500)
+    monitor_api_key: str | None = Field(None, max_length=255)
+    monitor_poll_interval_seconds: int = Field(30, ge=5, le=3600)
+
+    @field_validator("monitor_base_url")
+    @classmethod
+    def normalize_monitor_base_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = value.strip()
+        return value.rstrip("/") or None
 
 
 class PrinterUpdate(BaseModel):
@@ -38,6 +55,19 @@ class PrinterUpdate(BaseModel):
     status: PrinterStatus | None = None
     is_active: bool | None = None
     notes: str | None = Field(None, max_length=1000)
+    monitor_enabled: bool | None = None
+    monitor_provider: PrinterMonitorProvider | None = None
+    monitor_base_url: str | None = Field(None, max_length=500)
+    monitor_api_key: str | None = Field(None, max_length=255)
+    monitor_poll_interval_seconds: int | None = Field(None, ge=5, le=3600)
+
+    @field_validator("monitor_base_url")
+    @classmethod
+    def normalize_monitor_base_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = value.strip()
+        return value.rstrip("/") or None
 
 
 class PrinterResponse(BaseModel):
@@ -51,10 +81,33 @@ class PrinterResponse(BaseModel):
     status: str
     is_active: bool
     notes: str | None = None
+    monitor_enabled: bool
+    monitor_provider: str | None = None
+    monitor_base_url: str | None = None
+    monitor_api_key: str | None = None
+    monitor_poll_interval_seconds: int
+    monitor_online: bool | None = None
+    monitor_status: str | None = None
+    monitor_progress_percent: float | None = None
+    current_print_name: str | None = None
+    monitor_last_message: str | None = None
+    monitor_last_error: str | None = None
+    monitor_bed_temp_c: float | None = None
+    monitor_tool_temp_c: float | None = None
+    monitor_last_seen_at: datetime | None = None
+    monitor_last_updated_at: datetime | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
     model_config = {"from_attributes": True}
+
+
+class PrinterConnectionTestResponse(BaseModel):
+    ok: bool
+    provider: str
+    normalized_status: str | None = None
+    online: bool | None = None
+    message: str | None = None
 
 
 class PaginatedPrinters(BaseModel):

--- a/backend/app/services/printer_monitoring.py
+++ b/backend/app/services/printer_monitoring.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.printer import Printer
+
+DEFAULT_TIMEOUT_SECONDS = 8.0
+DEFAULT_STALE_AFTER_MINUTES = 10
+SUPPORTED_PROVIDERS = {"octoprint"}
+
+
+@dataclass
+class ProviderTestResult:
+    ok: bool
+    provider: str
+    normalized_status: str | None = None
+    online: bool | None = None
+    message: str | None = None
+    raw: dict[str, Any] | None = None
+
+
+class PrinterMonitoringError(Exception):
+    pass
+
+
+class UnsupportedPrinterProviderError(PrinterMonitoringError):
+    pass
+
+
+class PrinterMonitorProvider:
+    provider_name: str
+
+    async def test_connection(self, printer: Printer) -> ProviderTestResult:
+        raise NotImplementedError
+
+    async def fetch_live_state(self, printer: Printer) -> dict[str, Any]:
+        raise NotImplementedError
+
+
+class OctoPrintMonitorProvider(PrinterMonitorProvider):
+    provider_name = "octoprint"
+
+    async def _request(self, printer: Printer, path: str) -> dict[str, Any]:
+        if not printer.monitor_base_url:
+            raise PrinterMonitoringError("Monitoring base URL is required for OctoPrint")
+
+        headers: dict[str, str] = {}
+        if printer.monitor_api_key:
+            headers["X-Api-Key"] = printer.monitor_api_key
+
+        timeout = httpx.Timeout(DEFAULT_TIMEOUT_SECONDS)
+        url = f"{printer.monitor_base_url.rstrip('/')}{path}"
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+            return response.json()
+
+    def _normalize_status(self, state_text: str | None, flags: dict[str, Any] | None) -> tuple[str, bool]:
+        text = (state_text or "").strip().lower()
+        flags = flags or {}
+
+        if flags.get("error"):
+            return "error", True
+        if flags.get("paused") or "pause" in text:
+            return "paused", True
+        if flags.get("printing") or "print" in text:
+            return "printing", True
+        if flags.get("ready") or flags.get("operational") or text in {"operational", "ready"}:
+            return "idle", True
+        if flags.get("closedOrError"):
+            return "offline", False
+        if text in {"offline", "disconnected"}:
+            return "offline", False
+        return "idle", True
+
+    async def test_connection(self, printer: Printer) -> ProviderTestResult:
+        payload = await self._request(printer, "/api/printer")
+        state = payload.get("state", {})
+        normalized_status, online = self._normalize_status(state.get("text"), state.get("flags"))
+        return ProviderTestResult(
+            ok=True,
+            provider=self.provider_name,
+            normalized_status=normalized_status,
+            online=online,
+            message=state.get("text") or "Connection successful",
+            raw=payload,
+        )
+
+    async def fetch_live_state(self, printer: Printer) -> dict[str, Any]:
+        printer_payload, job_payload = await _gather_octoprint_payloads(self, printer)
+        state = printer_payload.get("state", {})
+        temp = printer_payload.get("temperature", {})
+        progress = (job_payload.get("progress") or {})
+        job = job_payload.get("job") or {}
+
+        normalized_status, online = self._normalize_status(state.get("text"), state.get("flags"))
+        bed_actual = _to_float((temp.get("bed") or {}).get("actual"))
+        tool_actual = _extract_tool_actual(temp)
+        completion = _to_float(progress.get("completion"))
+        file_name = ((job.get("file") or {}).get("name")) or job.get("filename")
+
+        now = datetime.now(timezone.utc)
+        return {
+            "monitor_online": online,
+            "status": normalized_status,
+            "monitor_status": normalized_status,
+            "monitor_progress_percent": completion,
+            "current_print_name": file_name,
+            "monitor_last_message": state.get("text"),
+            "monitor_bed_temp_c": bed_actual,
+            "monitor_tool_temp_c": tool_actual,
+            "monitor_last_seen_at": now,
+            "monitor_last_updated_at": now,
+            "monitor_last_error": None,
+        }
+
+
+async def _gather_octoprint_payloads(provider: OctoPrintMonitorProvider, printer: Printer) -> tuple[dict[str, Any], dict[str, Any]]:
+    printer_payload = await provider._request(printer, "/api/printer")
+    job_payload = await provider._request(printer, "/api/job")
+    return printer_payload, job_payload
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_tool_actual(temp_payload: dict[str, Any]) -> float | None:
+    for key in ("tool0", "tool1"):
+        value = (temp_payload.get(key) or {}).get("actual")
+        if value is not None:
+            return _to_float(value)
+    return None
+
+
+def get_provider(printer: Printer) -> PrinterMonitorProvider:
+    provider = (printer.monitor_provider or "").strip().lower()
+    if provider == "octoprint":
+        return OctoPrintMonitorProvider()
+    raise UnsupportedPrinterProviderError(f"Unsupported monitor provider '{printer.monitor_provider}'")
+
+
+async def test_printer_connection(printer: Printer) -> ProviderTestResult:
+    if not printer.monitor_provider:
+        return ProviderTestResult(ok=False, provider="unconfigured", message="Monitoring provider is not configured")
+    provider = get_provider(printer)
+    return await provider.test_connection(printer)
+
+
+async def refresh_printer_monitoring(db: AsyncSession, printer: Printer, *, force: bool = False) -> Printer:
+    if not printer.monitor_enabled or not printer.monitor_provider or not printer.monitor_base_url:
+        return printer
+
+    if not force and not _should_refresh(printer):
+        return printer
+
+    try:
+        provider = get_provider(printer)
+        updates = await provider.fetch_live_state(printer)
+        for field, value in updates.items():
+            setattr(printer, field, value)
+    except Exception as exc:  # noqa: BLE001
+        now = datetime.now(timezone.utc)
+        printer.monitor_online = False
+        printer.monitor_status = "offline"
+        printer.status = "offline"
+        printer.monitor_last_error = str(exc)
+        printer.monitor_last_message = str(exc)
+        printer.monitor_last_updated_at = now
+    await db.commit()
+    await db.refresh(printer)
+    return printer
+
+
+def _should_refresh(printer: Printer) -> bool:
+    interval = max(5, printer.monitor_poll_interval_seconds or 30)
+    if printer.monitor_last_updated_at is None:
+        return True
+    return datetime.now(timezone.utc) - printer.monitor_last_updated_at >= timedelta(seconds=interval)
+
+
+def mark_printer_stale_if_needed(printer: Printer) -> Printer:
+    if not printer.monitor_enabled:
+        return printer
+    if printer.monitor_last_seen_at is None:
+        return printer
+    stale_after = timedelta(minutes=DEFAULT_STALE_AFTER_MINUTES)
+    if datetime.now(timezone.utc) - printer.monitor_last_seen_at > stale_after:
+        printer.monitor_online = False
+        printer.monitor_status = "offline"
+        printer.status = "offline"
+    return printer

--- a/backend/tests/test_api_printers.py
+++ b/backend/tests/test_api_printers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 from httpx import AsyncClient
 
@@ -24,6 +26,7 @@ async def test_create_printer(client: AsyncClient, auth_headers: dict):
     assert data["slug"] == "bambu-x1c-01"
     assert data["status"] == "idle"
     assert data["is_active"] is True
+    assert data["monitor_enabled"] is False
 
 
 @pytest.mark.asyncio
@@ -111,3 +114,110 @@ async def test_delete_printer_soft_deactivates(client: AsyncClient, auth_headers
     get_resp = await client.get(f"/api/v1/printers/{printer_id}")
     assert get_resp.status_code == 200
     assert get_resp.json()["is_active"] is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_printer_monitoring_endpoint_updates_live_fields(client: AsyncClient, auth_headers: dict, monkeypatch):
+    async def fake_refresh(db, printer, force=False):
+        printer.status = "printing"
+        printer.monitor_online = True
+        printer.monitor_status = "printing"
+        printer.monitor_progress_percent = 42.5
+        printer.current_print_name = "demo.gcode"
+        printer.monitor_last_seen_at = datetime.now(timezone.utc)
+        printer.monitor_last_updated_at = datetime.now(timezone.utc)
+        return printer
+
+    monkeypatch.setattr("app.api.v1.endpoints.printers.refresh_printer_monitoring", fake_refresh)
+
+    create = await client.post(
+        "/api/v1/printers",
+        headers=auth_headers,
+        json={
+            "name": "Octo Farm 1",
+            "slug": "octo-farm-1",
+            "status": "idle",
+            "monitor_enabled": True,
+            "monitor_provider": "octoprint",
+            "monitor_base_url": "http://octoprint.local",
+            "monitor_api_key": "secret",
+        },
+    )
+    printer_id = create.json()["id"]
+
+    resp = await client.post(f"/api/v1/printers/{printer_id}/refresh", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "printing"
+    assert data["monitor_online"] is True
+    assert data["monitor_progress_percent"] == 42.5
+    assert data["current_print_name"] == "demo.gcode"
+
+
+@pytest.mark.asyncio
+async def test_test_connection_endpoint_returns_provider_result(client: AsyncClient, auth_headers: dict, monkeypatch):
+    class FakeResult:
+        ok = True
+        provider = "octoprint"
+        normalized_status = "idle"
+        online = True
+        message = "Connection successful"
+
+    async def fake_test(printer):
+        return FakeResult()
+
+    monkeypatch.setattr("app.api.v1.endpoints.printers.test_printer_connection", fake_test)
+
+    create = await client.post(
+        "/api/v1/printers",
+        headers=auth_headers,
+        json={
+            "name": "Octo Farm 2",
+            "slug": "octo-farm-2",
+            "status": "idle",
+            "monitor_enabled": True,
+            "monitor_provider": "octoprint",
+            "monitor_base_url": "http://octoprint.local",
+        },
+    )
+    printer_id = create.json()["id"]
+
+    resp = await client.post(f"/api/v1/printers/{printer_id}/test-connection", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "ok": True,
+        "provider": "octoprint",
+        "normalized_status": "idle",
+        "online": True,
+        "message": "Connection successful",
+    }
+
+
+@pytest.mark.asyncio
+async def test_disabling_monitoring_clears_live_fields(client: AsyncClient, auth_headers: dict):
+    create = await client.post(
+        "/api/v1/printers",
+        headers=auth_headers,
+        json={
+            "name": "Octo Farm 3",
+            "slug": "octo-farm-3",
+            "status": "printing",
+            "monitor_enabled": True,
+            "monitor_provider": "octoprint",
+            "monitor_base_url": "http://octoprint.local",
+            "monitor_online": True,
+        },
+    )
+    printer_id = create.json()["id"]
+
+    resp = await client.put(
+        f"/api/v1/printers/{printer_id}",
+        headers=auth_headers,
+        json={"monitor_enabled": False},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["monitor_enabled"] is False
+    assert data["monitor_online"] is None
+    assert data["monitor_status"] is None
+    assert data["monitor_progress_percent"] is None

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -1,11 +1,11 @@
 import { Link, useParams } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Edit, Archive, ArchiveRestore } from 'lucide-react';
+import { ArrowLeft, Edit, Archive, ArchiveRestore, RefreshCw, PlugZap } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { cn, formatCurrency } from '@/lib/utils';
 import { SkeletonTable } from '@/components/ui/Skeleton';
-import type { Job, PaginatedJobs, Printer } from '@/types';
+import type { Job, PaginatedJobs, Printer, PrinterConnectionTestResult } from '@/types';
 
 const statusClasses: Record<string, string> = {
   idle: 'bg-slate-100 text-slate-800 dark:bg-slate-800/60 dark:text-slate-200',
@@ -27,6 +27,11 @@ function StatusBadge({ status }: { status: string }) {
   return <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize', statusClasses[status] || 'bg-primary/10 text-primary')}>{status.replace('_', ' ')}</span>;
 }
 
+function formatDateTime(value: string | null) {
+  if (!value) return '—';
+  return new Date(value).toLocaleString();
+}
+
 export default function PrinterDetailPage() {
   const { id } = useParams<{ id: string }>();
   const queryClient = useQueryClient();
@@ -35,6 +40,7 @@ export default function PrinterDetailPage() {
     queryKey: ['printer', id],
     queryFn: () => api.get(`/printers/${id}`).then((response) => response.data),
     enabled: Boolean(id),
+    refetchInterval: (query) => (query.state.data?.monitor_enabled ? Math.max((query.state.data.monitor_poll_interval_seconds || 30) * 1000, 5000) : false),
   });
 
   const { data: jobs, isLoading: jobsLoading } = useQuery<PaginatedJobs>({
@@ -68,6 +74,28 @@ export default function PrinterDetailPage() {
     }
   };
 
+  const refreshNow = async () => {
+    if (!printer) return;
+    try {
+      await api.post(`/printers/${printer.id}/refresh`);
+      toast.success('Live status refreshed');
+      queryClient.invalidateQueries({ queryKey: ['printer', printer.id] });
+      queryClient.invalidateQueries({ queryKey: ['printers'] });
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Refresh failed');
+    }
+  };
+
+  const testConnection = async () => {
+    if (!printer) return;
+    try {
+      const { data } = await api.post<PrinterConnectionTestResult>(`/printers/${printer.id}/test-connection`);
+      data.ok ? toast.success(data.message || 'Connection successful') : toast.error(data.message || 'Connection failed');
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Connection test failed');
+    }
+  };
+
   if (printerLoading) return <SkeletonTable rows={4} cols={4} />;
   if (!printer) return <p className="py-16 text-center text-muted-foreground">Printer not found</p>;
 
@@ -89,12 +117,27 @@ export default function PrinterDetailPage() {
               <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', printer.is_active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400')}>
                 {printer.is_active ? 'Active' : 'Inactive'}
               </span>
+              {printer.monitor_enabled ? (
+                <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', printer.monitor_online ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-zinc-100 text-zinc-800 dark:bg-zinc-900/50 dark:text-zinc-300')}>
+                  {printer.monitor_online ? 'Monitor online' : 'Monitor offline'}
+                </span>
+              ) : null}
             </div>
             <p className="text-sm text-muted-foreground font-mono">{printer.slug}</p>
             {!printer.is_active && <p className="mt-2 text-sm text-muted-foreground">This printer is inactive. Historical job assignments are still preserved.</p>}
           </div>
 
           <div className="flex flex-wrap gap-2">
+            {printer.monitor_enabled ? (
+              <>
+                <button onClick={testConnection} className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border px-4 py-2 hover:bg-accent">
+                  <PlugZap className="w-4 h-4" /> Test connection
+                </button>
+                <button onClick={refreshNow} className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border px-4 py-2 hover:bg-accent">
+                  <RefreshCw className="w-4 h-4" /> Refresh now
+                </button>
+              </>
+            ) : null}
             <Link to={`/printers/${printer.id}/edit`} className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 no-underline hover:bg-accent">
               <Edit className="w-4 h-4" /> Edit
             </Link>
@@ -148,6 +191,46 @@ export default function PrinterDetailPage() {
             )}
           </div>
         </div>
+      </div>
+
+      <div className="mb-6 rounded-lg border border-border bg-card p-6">
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-bold">Live monitoring</h2>
+            <p className="text-sm text-muted-foreground">Normalized status pulled from the configured monitoring provider.</p>
+          </div>
+          {printer.monitor_enabled ? <StatusBadge status={printer.monitor_status || printer.status} /> : null}
+        </div>
+
+        {!printer.monitor_enabled ? (
+          <p className="text-sm text-muted-foreground">Monitoring is not configured for this printer yet. The printer still works as a static record.</p>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <div><p className="text-xs text-muted-foreground">Provider</p><p className="font-semibold">{printer.monitor_provider || '—'}</p></div>
+            <div><p className="text-xs text-muted-foreground">Progress</p><p className="font-semibold">{printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(1)}%` : '—'}</p></div>
+            <div><p className="text-xs text-muted-foreground">Current print</p><p className="font-semibold">{printer.current_print_name || '—'}</p></div>
+            <div><p className="text-xs text-muted-foreground">Poll interval</p><p className="font-semibold">{printer.monitor_poll_interval_seconds}s</p></div>
+            <div><p className="text-xs text-muted-foreground">Tool temp</p><p className="font-semibold">{printer.monitor_tool_temp_c != null ? `${printer.monitor_tool_temp_c.toFixed(1)} °C` : '—'}</p></div>
+            <div><p className="text-xs text-muted-foreground">Bed temp</p><p className="font-semibold">{printer.monitor_bed_temp_c != null ? `${printer.monitor_bed_temp_c.toFixed(1)} °C` : '—'}</p></div>
+            <div><p className="text-xs text-muted-foreground">Last seen</p><p className="font-semibold">{formatDateTime(printer.monitor_last_seen_at)}</p></div>
+            <div><p className="text-xs text-muted-foreground">Last updated</p><p className="font-semibold">{formatDateTime(printer.monitor_last_updated_at)}</p></div>
+          </div>
+        )}
+
+        {printer.monitor_enabled ? (
+          <div className="mt-4 space-y-3">
+            <div className="rounded-lg border border-border bg-background/40 p-4">
+              <p className="text-xs text-muted-foreground mb-1">Provider message</p>
+              <p className="text-sm">{printer.monitor_last_message || '—'}</p>
+            </div>
+            {printer.monitor_last_error ? (
+              <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-800 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-300">
+                <p className="text-xs uppercase tracking-wide">Last monitor error</p>
+                <p className="mt-1 text-sm">{printer.monitor_last_error}</p>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
       </div>
 
       <div>

--- a/frontend/src/pages/PrinterFormPage.tsx
+++ b/frontend/src/pages/PrinterFormPage.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, PlugZap } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
-import type { Printer } from '@/types';
+import type { Printer, PrinterConnectionTestResult } from '@/types';
 
 const STATUS_OPTIONS = ['idle', 'printing', 'paused', 'maintenance', 'offline', 'error'] as const;
+const MONITOR_PROVIDER_OPTIONS = ['octoprint'] as const;
 
 const emptyForm = {
   name: '',
@@ -18,6 +19,11 @@ const emptyForm = {
   status: 'idle',
   is_active: true,
   notes: '',
+  monitor_enabled: false,
+  monitor_provider: 'octoprint',
+  monitor_base_url: '',
+  monitor_api_key: '',
+  monitor_poll_interval_seconds: 30,
 };
 
 function slugify(value: string) {
@@ -44,6 +50,7 @@ export default function PrinterFormPage() {
   const [form, setForm] = useState(emptyForm);
   const [slugTouched, setSlugTouched] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [testingConnection, setTestingConnection] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
@@ -58,6 +65,11 @@ export default function PrinterFormPage() {
       status: printer.status,
       is_active: printer.is_active,
       notes: printer.notes || '',
+      monitor_enabled: printer.monitor_enabled,
+      monitor_provider: printer.monitor_provider || 'octoprint',
+      monitor_base_url: printer.monitor_base_url || '',
+      monitor_api_key: printer.monitor_api_key || '',
+      monitor_poll_interval_seconds: printer.monitor_poll_interval_seconds || 30,
     });
     setSlugTouched(true);
   }, [printer]);
@@ -69,7 +81,7 @@ export default function PrinterFormPage() {
 
   const title = useMemo(() => (isEdit ? 'Edit Printer' : 'Add Printer'), [isEdit]);
 
-  const update = (field: string, value: string | boolean) => {
+  const update = (field: string, value: string | boolean | number) => {
     setForm((current) => ({ ...current, [field]: value }));
     setErrors((current) => ({ ...current, [field]: '' }));
   };
@@ -79,9 +91,25 @@ export default function PrinterFormPage() {
     if (!form.name.trim()) nextErrors.name = 'Name is required';
     if (!form.slug.trim()) nextErrors.slug = 'Slug is required';
     if (form.slug && !/^[a-z0-9-]+$/.test(form.slug)) nextErrors.slug = 'Use lowercase letters, numbers, and hyphens only';
+    if (form.monitor_enabled && !form.monitor_base_url.trim()) nextErrors.monitor_base_url = 'Base URL is required when monitoring is enabled';
+    if (form.monitor_poll_interval_seconds < 5) nextErrors.monitor_poll_interval_seconds = 'Poll interval must be at least 5 seconds';
     setErrors(nextErrors);
     return Object.keys(nextErrors).length === 0;
   };
+
+  const buildPayload = () => ({
+    ...form,
+    name: form.name.trim(),
+    slug: form.slug.trim(),
+    manufacturer: form.manufacturer.trim() || null,
+    model: form.model.trim() || null,
+    serial_number: form.serial_number.trim() || null,
+    location: form.location.trim() || null,
+    notes: form.notes.trim() || null,
+    monitor_provider: form.monitor_enabled ? form.monitor_provider : null,
+    monitor_base_url: form.monitor_enabled ? (form.monitor_base_url.trim() || null) : null,
+    monitor_api_key: form.monitor_enabled ? (form.monitor_api_key.trim() || null) : null,
+  });
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -89,16 +117,7 @@ export default function PrinterFormPage() {
 
     setSaving(true);
     try {
-      const payload = {
-        ...form,
-        name: form.name.trim(),
-        slug: form.slug.trim(),
-        manufacturer: form.manufacturer.trim() || null,
-        model: form.model.trim() || null,
-        serial_number: form.serial_number.trim() || null,
-        location: form.location.trim() || null,
-        notes: form.notes.trim() || null,
-      };
+      const payload = buildPayload();
 
       if (isEdit) {
         await api.put(`/printers/${id}`, payload);
@@ -118,6 +137,30 @@ export default function PrinterFormPage() {
       toast.error(err.response?.data?.detail || 'Failed to save printer');
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleTestConnection = async () => {
+    if (!validate()) return;
+
+    try {
+      setTestingConnection(true);
+
+      if (isEdit && id) {
+        const response = await api.post<PrinterConnectionTestResult>(`/printers/${id}/test-connection`);
+        response.data.ok ? toast.success(response.data.message || 'Connection successful') : toast.error(response.data.message || 'Connection failed');
+        return;
+      }
+
+      const draftResponse = await api.post<Printer>('/printers', buildPayload());
+      const createdPrinter = draftResponse.data;
+      const testResponse = await api.post<PrinterConnectionTestResult>(`/printers/${createdPrinter.id}/test-connection`);
+      await api.delete(`/printers/${createdPrinter.id}`);
+      testResponse.data.ok ? toast.success(testResponse.data.message || 'Connection successful') : toast.error(testResponse.data.message || 'Connection failed');
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Connection test failed');
+    } finally {
+      setTestingConnection(false);
     }
   };
 
@@ -143,7 +186,7 @@ export default function PrinterFormPage() {
           <p className="mt-1 text-sm text-muted-foreground">Track machine details, availability, and where this printer lives.</p>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-5">
+        <form onSubmit={handleSubmit} className="space-y-6">
           <div className="grid gap-5 sm:grid-cols-2">
             <div>
               <label className="block text-sm font-medium mb-1.5">Name *</label>
@@ -196,6 +239,57 @@ export default function PrinterFormPage() {
                 </div>
               </label>
             </div>
+          </div>
+
+          <div className="rounded-lg border border-border p-4 space-y-4">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="font-semibold">Live monitoring</h2>
+                <p className="text-sm text-muted-foreground">Optional first-pass live status via provider polling. Static printers still work fine if you leave this off.</p>
+              </div>
+              <label className="inline-flex items-center gap-2 text-sm font-medium">
+                <input type="checkbox" checked={form.monitor_enabled} onChange={(e) => update('monitor_enabled', e.target.checked)} className="h-4 w-4" />
+                Enable
+              </label>
+            </div>
+
+            {form.monitor_enabled ? (
+              <>
+                <div className="grid gap-5 sm:grid-cols-2">
+                  <div>
+                    <label className="block text-sm font-medium mb-1.5">Provider</label>
+                    <select value={form.monitor_provider} onChange={(e) => update('monitor_provider', e.target.value)} className={inputClass('monitor_provider')}>
+                      {MONITOR_PROVIDER_OPTIONS.map((option) => (
+                        <option key={option} value={option}>{option}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1.5">Poll interval (seconds)</label>
+                    <input type="number" min={5} max={3600} value={form.monitor_poll_interval_seconds} onChange={(e) => update('monitor_poll_interval_seconds', Number(e.target.value) || 30)} className={inputClass('monitor_poll_interval_seconds')} />
+                    {errors.monitor_poll_interval_seconds && <p className="mt-1 text-xs text-destructive">{errors.monitor_poll_interval_seconds}</p>}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium mb-1.5">Base URL *</label>
+                  <input value={form.monitor_base_url} onChange={(e) => update('monitor_base_url', e.target.value)} className={inputClass('monitor_base_url')} placeholder="http://octoprint.local" />
+                  {errors.monitor_base_url && <p className="mt-1 text-xs text-destructive">{errors.monitor_base_url}</p>}
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium mb-1.5">API key / token</label>
+                  <input value={form.monitor_api_key} onChange={(e) => update('monitor_api_key', e.target.value)} className={inputClass('monitor_api_key')} placeholder="Optional if your provider requires auth" />
+                </div>
+
+                <div className="flex justify-end">
+                  <button type="button" onClick={handleTestConnection} disabled={testingConnection} className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border px-4 py-2 hover:bg-accent disabled:opacity-50">
+                    <PlugZap className="h-4 w-4" />
+                    {testingConnection ? 'Testing...' : 'Test connection'}
+                  </button>
+                </div>
+              </>
+            ) : null}
           </div>
 
           <div>

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -84,6 +84,15 @@ function PrinterAssignmentCard({ printer, currentJob }: { printer: Printer; curr
             {[printer.manufacturer, printer.model].filter(Boolean).join(' · ') || 'Printer details pending'}
             {printer.location ? ` · ${printer.location}` : ''}
           </p>
+          {printer.monitor_enabled ? (
+            <p className="mt-1 text-xs text-muted-foreground">
+              Live: {printer.monitor_status || printer.status}
+              {printer.monitor_progress_percent != null ? ` · ${printer.monitor_progress_percent.toFixed(0)}%` : ''}
+              {printer.current_print_name ? ` · ${printer.current_print_name}` : ''}
+            </p>
+          ) : (
+            <p className="mt-1 text-xs text-muted-foreground">Static record only</p>
+          )}
         </div>
         <Link to={`/printers/${printer.id}`} className="rounded-md border border-border p-2 text-muted-foreground hover:bg-accent" title="View printer">
           <Eye className="h-4 w-4" />
@@ -147,6 +156,7 @@ export default function PrintersPage() {
       const { data } = await api.get(`/printers?${params.toString()}`);
       return data;
     },
+    refetchInterval: 15000,
   });
 
   const { data: activeJobsData, isLoading: jobsLoading } = useQuery<PaginatedJobs>({
@@ -396,6 +406,7 @@ export default function PrintersPage() {
                   <th className="px-4 py-3 font-medium">Manufacturer / Model</th>
                   <th className="px-4 py-3 font-medium">Location</th>
                   <th className="px-4 py-3 font-medium">Status</th>
+                  <th className="px-4 py-3 font-medium">Live monitor</th>
                   <th className="px-4 py-3 font-medium">Assignment</th>
                   <th className="px-4 py-3 font-medium">State</th>
                   <th className="px-4 py-3 font-medium">Notes</th>
@@ -418,6 +429,16 @@ export default function PrintersPage() {
                       </td>
                       <td className="px-4 py-3">{printer.location || '—'}</td>
                       <td className="px-4 py-3"><StatusBadge status={printer.status} /></td>
+                      <td className="px-4 py-3 text-xs text-muted-foreground">
+                        {printer.monitor_enabled ? (
+                          <div>
+                            <div>{printer.monitor_status || printer.status}{printer.monitor_online === false ? ' · offline' : ''}</div>
+                            <div>{printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}{printer.current_print_name ? ` · ${printer.current_print_name}` : ''}</div>
+                          </div>
+                        ) : (
+                          'Not configured'
+                        )}
+                      </td>
                       <td className="px-4 py-3">
                         {currentJob ? (
                           <div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -47,8 +47,31 @@ export interface Printer {
   status: string;
   is_active: boolean;
   notes: string | null;
+  monitor_enabled: boolean;
+  monitor_provider: string | null;
+  monitor_base_url: string | null;
+  monitor_api_key: string | null;
+  monitor_poll_interval_seconds: number;
+  monitor_online: boolean | null;
+  monitor_status: string | null;
+  monitor_progress_percent: number | null;
+  current_print_name: string | null;
+  monitor_last_message: string | null;
+  monitor_last_error: string | null;
+  monitor_bed_temp_c: number | null;
+  monitor_tool_temp_c: number | null;
+  monitor_last_seen_at: string | null;
+  monitor_last_updated_at: string | null;
   created_at: string | null;
   updated_at: string | null;
+}
+
+export interface PrinterConnectionTestResult {
+  ok: boolean;
+  provider: string;
+  normalized_status: string | null;
+  online: boolean | null;
+  message: string | null;
 }
 
 export interface PaginatedPrinters {


### PR DESCRIPTION
## Summary
- add first-pass live printer monitoring with a provider abstraction and OctoPrint adapter
- extend printer records with monitoring configuration and persisted live status fields
- add refresh and connection-test printer API actions
- surface live monitoring config and status in printer form, list, and detail pages
- persist normalized online/offline/progress/current print data for UI consumption

## Testing
- .venv/bin/pytest backend/tests/test_api_printers.py -q
- npm --prefix frontend run build

Closes #102