### PR TITLE
feat(printers): add Moonraker monitoring provider (#104)

### DIFF
--- a/backend/app/schemas/printer.py
+++ b/backend/app/schemas/printer.py
@@ -18,6 +18,7 @@ class PrinterStatus(str, Enum):
 
 class PrinterMonitorProvider(str, Enum):
     octoprint = "octoprint"
+    moonraker = "moonraker"
 
 
 class PrinterCreate(BaseModel):

--- a/backend/app/services/printer_monitoring.py
+++ b/backend/app/services/printer_monitoring.py
@@ -11,7 +11,7 @@ from app.models.printer import Printer
 
 DEFAULT_TIMEOUT_SECONDS = 8.0
 DEFAULT_STALE_AFTER_MINUTES = 10
-SUPPORTED_PROVIDERS = {"octoprint"}
+SUPPORTED_PROVIDERS = {"octoprint", "moonraker"}
 
 
 @dataclass
@@ -42,23 +42,32 @@ class PrinterMonitorProvider:
         raise NotImplementedError
 
 
-class OctoPrintMonitorProvider(PrinterMonitorProvider):
-    provider_name = "octoprint"
+class HttpPrinterMonitorProvider(PrinterMonitorProvider):
+    auth_header_name: str | None = None
+
+    def _build_headers(self, printer: Printer) -> dict[str, str]:
+        if self.auth_header_name and printer.monitor_api_key:
+            return {self.auth_header_name: printer.monitor_api_key}
+        return {}
+
+    def _build_url(self, printer: Printer, path: str) -> str:
+        if not printer.monitor_base_url:
+            raise PrinterMonitoringError(f"Monitoring base URL is required for {self.provider_name}")
+        return f"{printer.monitor_base_url.rstrip('/')}{path}"
 
     async def _request(self, printer: Printer, path: str) -> dict[str, Any]:
-        if not printer.monitor_base_url:
-            raise PrinterMonitoringError("Monitoring base URL is required for OctoPrint")
-
-        headers: dict[str, str] = {}
-        if printer.monitor_api_key:
-            headers["X-Api-Key"] = printer.monitor_api_key
-
         timeout = httpx.Timeout(DEFAULT_TIMEOUT_SECONDS)
-        url = f"{printer.monitor_base_url.rstrip('/')}{path}"
+        url = self._build_url(printer, path)
+        headers = self._build_headers(printer)
         async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.get(url, headers=headers)
             response.raise_for_status()
             return response.json()
+
+
+class OctoPrintMonitorProvider(HttpPrinterMonitorProvider):
+    provider_name = "octoprint"
+    auth_header_name = "X-Api-Key"
 
     def _normalize_status(self, state_text: str | None, flags: dict[str, Any] | None) -> tuple[str, bool]:
         text = (state_text or "").strip().lower()
@@ -120,10 +129,126 @@ class OctoPrintMonitorProvider(PrinterMonitorProvider):
         }
 
 
+class MoonrakerMonitorProvider(HttpPrinterMonitorProvider):
+    provider_name = "moonraker"
+    auth_header_name = "X-Api-Key"
+
+    def _normalize_status(
+        self,
+        *,
+        server_state: str | None,
+        printer_state: str | None,
+        print_state: str | None,
+        sdcard_active: bool | None,
+    ) -> tuple[str, bool]:
+        server = (server_state or "").strip().lower()
+        printer = (printer_state or "").strip().lower()
+        job = (print_state or "").strip().lower()
+
+        if server and server not in {"ready"}:
+            if server in {"error", "shutdown"}:
+                return "error", True
+            if server in {"startup", "loading", "initializing"}:
+                return "maintenance", True
+            if server in {"disconnected", "offline"}:
+                return "offline", False
+
+        if printer in {"error", "shutdown"}:
+            return "error", True
+        if printer in {"startup", "initializing"}:
+            return "maintenance", True
+        if printer in {"disconnected", "offline"}:
+            return "offline", False
+
+        if job in {"paused"}:
+            return "paused", True
+        if job in {"printing"} or bool(sdcard_active):
+            return "printing", True
+        if job in {"error", "cancelled", "canceled", "complete", "standby"}:
+            return "idle", True
+        if printer in {"paused"}:
+            return "paused", True
+        if printer in {"printing"}:
+            return "printing", True
+        if printer in {"ready", "standby"}:
+            return "idle", True
+        return "idle", True
+
+    async def test_connection(self, printer: Printer) -> ProviderTestResult:
+        server_payload = await self._request(printer, "/server/info")
+        printer_payload = await self._request(printer, "/printer/info")
+        server_info = server_payload.get("result") or {}
+        printer_info = printer_payload.get("result") or {}
+        normalized_status, online = self._normalize_status(
+            server_state=server_info.get("klippy_state"),
+            printer_state=printer_info.get("state"),
+            print_state=None,
+            sdcard_active=None,
+        )
+        message = printer_info.get("state_message") or f"Moonraker {server_info.get('moonraker_version', 'connected')}"
+        return ProviderTestResult(
+            ok=True,
+            provider=self.provider_name,
+            normalized_status=normalized_status,
+            online=online,
+            message=message,
+            raw={"server": server_payload, "printer": printer_payload},
+        )
+
+    async def fetch_live_state(self, printer: Printer) -> dict[str, Any]:
+        server_payload, printer_payload, objects_payload = await _gather_moonraker_payloads(self, printer)
+        server_info = server_payload.get("result") or {}
+        printer_info = printer_payload.get("result") or {}
+        status = (objects_payload.get("result") or {}).get("status") or {}
+        print_stats = status.get("print_stats") or {}
+        virtual_sdcard = status.get("virtual_sdcard") or {}
+        extruder = status.get("extruder") or {}
+        heater_bed = status.get("heater_bed") or {}
+
+        normalized_status, online = self._normalize_status(
+            server_state=server_info.get("klippy_state"),
+            printer_state=printer_info.get("state"),
+            print_state=print_stats.get("state"),
+            sdcard_active=virtual_sdcard.get("is_active"),
+        )
+
+        progress = _to_float(virtual_sdcard.get("progress"))
+        completion = None if progress is None else round(progress * 100, 2)
+        file_name = print_stats.get("filename") or _extract_filename_from_path(virtual_sdcard.get("file_path"))
+        message = print_stats.get("message") or printer_info.get("state_message") or server_info.get("klippy_state")
+
+        now = datetime.now(timezone.utc)
+        return {
+            "monitor_online": online,
+            "status": normalized_status,
+            "monitor_status": normalized_status,
+            "monitor_progress_percent": completion,
+            "current_print_name": file_name,
+            "monitor_last_message": message,
+            "monitor_bed_temp_c": _to_float(heater_bed.get("temperature")),
+            "monitor_tool_temp_c": _to_float(extruder.get("temperature")),
+            "monitor_last_seen_at": now,
+            "monitor_last_updated_at": now,
+            "monitor_last_error": None,
+        }
+
+
 async def _gather_octoprint_payloads(provider: OctoPrintMonitorProvider, printer: Printer) -> tuple[dict[str, Any], dict[str, Any]]:
     printer_payload = await provider._request(printer, "/api/printer")
     job_payload = await provider._request(printer, "/api/job")
     return printer_payload, job_payload
+
+
+async def _gather_moonraker_payloads(
+    provider: MoonrakerMonitorProvider, printer: Printer
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    server_payload = await provider._request(printer, "/server/info")
+    printer_payload = await provider._request(printer, "/printer/info")
+    objects_payload = await provider._request(
+        printer,
+        "/printer/objects/query?print_stats&virtual_sdcard&extruder&heater_bed",
+    )
+    return server_payload, printer_payload, objects_payload
 
 
 def _to_float(value: Any) -> float | None:
@@ -143,10 +268,21 @@ def _extract_tool_actual(temp_payload: dict[str, Any]) -> float | None:
     return None
 
 
+def _extract_filename_from_path(value: Any) -> str | None:
+    if not value or not isinstance(value, str):
+        return None
+    normalized = value.rstrip("/")
+    if not normalized:
+        return None
+    return normalized.rsplit("/", 1)[-1] or None
+
+
 def get_provider(printer: Printer) -> PrinterMonitorProvider:
     provider = (printer.monitor_provider or "").strip().lower()
     if provider == "octoprint":
         return OctoPrintMonitorProvider()
+    if provider == "moonraker":
+        return MoonrakerMonitorProvider()
     raise UnsupportedPrinterProviderError(f"Unsupported monitor provider '{printer.monitor_provider}'")
 
 

--- a/backend/tests/test_printer_monitoring.py
+++ b/backend/tests/test_printer_monitoring.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from app.models.printer import Printer
+from app.services.printer_monitoring import MoonrakerMonitorProvider, OctoPrintMonitorProvider, get_provider
+
+
+def test_get_provider_supports_moonraker_and_octoprint():
+    moonraker_printer = Printer(name="Moonraker", slug="moonraker", monitor_provider="moonraker")
+    octoprint_printer = Printer(name="OctoPrint", slug="octoprint", monitor_provider="octoprint")
+
+    assert isinstance(get_provider(moonraker_printer), MoonrakerMonitorProvider)
+    assert isinstance(get_provider(octoprint_printer), OctoPrintMonitorProvider)
+
+
+@pytest.mark.asyncio
+async def test_moonraker_fetch_live_state_normalizes_printing(monkeypatch):
+    provider = MoonrakerMonitorProvider()
+    printer = Printer(
+        name="Lava",
+        slug="lava",
+        monitor_provider="moonraker",
+        monitor_base_url="http://printer.local:7125",
+    )
+
+    async def fake_request(_printer, path):
+        if path == "/server/info":
+            return {"result": {"klippy_state": "ready", "moonraker_version": "1.2.0"}}
+        if path == "/printer/info":
+            return {"result": {"state": "ready", "state_message": "Printer is ready"}}
+        if path == "/printer/objects/query?print_stats&virtual_sdcard&extruder&heater_bed":
+            return {
+                "result": {
+                    "status": {
+                        "print_stats": {
+                            "filename": "demo.gcode",
+                            "state": "printing",
+                            "message": "",
+                        },
+                        "virtual_sdcard": {
+                            "progress": 0.5,
+                            "is_active": True,
+                            "file_path": "/home/pi/printer_data/gcodes/demo.gcode",
+                        },
+                        "extruder": {"temperature": 215.2},
+                        "heater_bed": {"temperature": 60.4},
+                    }
+                }
+            }
+        raise AssertionError(f"Unexpected path {path}")
+
+    monkeypatch.setattr(provider, "_request", fake_request)
+
+    result = await provider.fetch_live_state(printer)
+
+    assert result["status"] == "printing"
+    assert result["monitor_status"] == "printing"
+    assert result["monitor_online"] is True
+    assert result["monitor_progress_percent"] == 50.0
+    assert result["current_print_name"] == "demo.gcode"
+    assert result["monitor_tool_temp_c"] == 215.2
+    assert result["monitor_bed_temp_c"] == 60.4
+    assert result["monitor_last_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_moonraker_test_connection_returns_idle(monkeypatch):
+    provider = MoonrakerMonitorProvider()
+    printer = Printer(
+        name="Lava",
+        slug="lava",
+        monitor_provider="moonraker",
+        monitor_base_url="http://printer.local:7125",
+    )
+
+    async def fake_request(_printer, path):
+        if path == "/server/info":
+            return {"result": {"klippy_state": "ready", "moonraker_version": "1.2.0"}}
+        if path == "/printer/info":
+            return {"result": {"state": "ready", "state_message": "Printer is ready"}}
+        raise AssertionError(f"Unexpected path {path}")
+
+    monkeypatch.setattr(provider, "_request", fake_request)
+
+    result = await provider.test_connection(printer)
+
+    assert result.ok is True
+    assert result.provider == "moonraker"
+    assert result.normalized_status == "idle"
+    assert result.online is True
+    assert result.message == "Printer is ready"

--- a/frontend/src/pages/PrinterFormPage.tsx
+++ b/frontend/src/pages/PrinterFormPage.tsx
@@ -7,7 +7,10 @@ import api from '@/api/client';
 import type { Printer, PrinterConnectionTestResult } from '@/types';
 
 const STATUS_OPTIONS = ['idle', 'printing', 'paused', 'maintenance', 'offline', 'error'] as const;
-const MONITOR_PROVIDER_OPTIONS = ['octoprint'] as const;
+const MONITOR_PROVIDER_OPTIONS = [
+  { value: 'octoprint', label: 'OctoPrint', placeholder: 'http://octoprint.local', authHint: 'Optional API key if your OctoPrint instance requires one.' },
+  { value: 'moonraker', label: 'Moonraker / Fluidd / Mainsail', placeholder: 'http://printer.local:7125', authHint: 'Usually no API key on LAN, but you can supply one if your Moonraker setup requires it.' },
+] as const;
 
 const emptyForm = {
   name: '',
@@ -80,6 +83,10 @@ export default function PrinterFormPage() {
   }, [form.name, slugTouched]);
 
   const title = useMemo(() => (isEdit ? 'Edit Printer' : 'Add Printer'), [isEdit]);
+  const selectedProvider = useMemo(
+    () => MONITOR_PROVIDER_OPTIONS.find((option) => option.value === form.monitor_provider) ?? MONITOR_PROVIDER_OPTIONS[0],
+    [form.monitor_provider],
+  );
 
   const update = (field: string, value: string | boolean | number) => {
     setForm((current) => ({ ...current, [field]: value }));
@@ -260,7 +267,7 @@ export default function PrinterFormPage() {
                     <label className="block text-sm font-medium mb-1.5">Provider</label>
                     <select value={form.monitor_provider} onChange={(e) => update('monitor_provider', e.target.value)} className={inputClass('monitor_provider')}>
                       {MONITOR_PROVIDER_OPTIONS.map((option) => (
-                        <option key={option} value={option}>{option}</option>
+                        <option key={option.value} value={option.value}>{option.label}</option>
                       ))}
                     </select>
                   </div>
@@ -273,13 +280,17 @@ export default function PrinterFormPage() {
 
                 <div>
                   <label className="block text-sm font-medium mb-1.5">Base URL *</label>
-                  <input value={form.monitor_base_url} onChange={(e) => update('monitor_base_url', e.target.value)} className={inputClass('monitor_base_url')} placeholder="http://octoprint.local" />
+                  <input value={form.monitor_base_url} onChange={(e) => update('monitor_base_url', e.target.value)} className={inputClass('monitor_base_url')} placeholder={selectedProvider.placeholder} />
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {form.monitor_provider === 'moonraker' ? 'Use the Moonraker API URL, typically port 7125.' : 'Use the OctoPrint base URL hosting the API.'}
+                  </p>
                   {errors.monitor_base_url && <p className="mt-1 text-xs text-destructive">{errors.monitor_base_url}</p>}
                 </div>
 
                 <div>
                   <label className="block text-sm font-medium mb-1.5">API key / token</label>
                   <input value={form.monitor_api_key} onChange={(e) => update('monitor_api_key', e.target.value)} className={inputClass('monitor_api_key')} placeholder="Optional if your provider requires auth" />
+                  <p className="mt-1 text-xs text-muted-foreground">{selectedProvider.authHint}</p>
                 </div>
 
                 <div className="flex justify-end">


### PR DESCRIPTION
## Summary
- add Moonraker/Fluidd provider support to the live printer monitoring system
- normalize Moonraker states into app printer statuses
- support Moonraker connection testing and refresh through the existing monitoring flow
- add frontend provider option and Moonraker-specific setup guidance
- add focused backend tests for Moonraker monitoring behavior

## Testing
- .venv/bin/pytest backend/tests/test_printer_monitoring.py backend/tests/test_api_printers.py -q
- npm --prefix frontend run build

Closes #104