### PR TITLE
feat(printers): show Moonraker print thumbnails (#109)

### DIFF
--- a/backend/app/api/v1/endpoints/printers.py
+++ b/backend/app/api/v1/endpoints/printers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Response
 from sqlalchemy import func, select
 
 from app.api.deps import DB, CurrentUser
@@ -15,6 +15,7 @@ from app.schemas.printer import (
     PrinterUpdate,
 )
 from app.services.printer_monitoring import (
+    MoonrakerMonitorProvider,
     PrinterMonitoringError,
     mark_printer_stale_if_needed,
     refresh_printer_monitoring,
@@ -22,6 +23,14 @@ from app.services.printer_monitoring import (
 )
 
 router = APIRouter(prefix="/printers", tags=["Printers"])
+
+
+def _apply_thumbnail_urls(printer: Printer) -> Printer:
+    thumbnail_path = getattr(printer, "current_print_thumbnail_path", None)
+    setattr(printer, "current_print_thumbnail_url", f"/api/v1/printers/{printer.id}/thumbnail" if thumbnail_path else None)
+    if getattr(printer, "current_print_thumbnails", None) is None:
+        setattr(printer, "current_print_thumbnails", [])
+    return printer
 
 
 async def _get_printer_or_404(db: DB, printer_id: uuid.UUID) -> Printer:
@@ -68,6 +77,7 @@ async def list_printers(
     for printer in items:
         mark_printer_stale_if_needed(printer)
         await refresh_printer_monitoring(db, printer)
+        _apply_thumbnail_urls(printer)
     return PaginatedPrinters(items=items, total=total, skip=skip, limit=limit)
 
 
@@ -81,7 +91,7 @@ async def get_printer(printer_id: uuid.UUID, db: DB):
     printer = await _get_printer_or_404(db, printer_id)
     mark_printer_stale_if_needed(printer)
     await refresh_printer_monitoring(db, printer)
-    return printer
+    return _apply_thumbnail_urls(printer)
 
 
 @router.post(
@@ -102,7 +112,7 @@ async def create_printer(body: PrinterCreate, user: CurrentUser, db: DB):
     await db.refresh(printer)
     if printer.monitor_enabled:
         await refresh_printer_monitoring(db, printer, force=True)
-    return printer
+    return _apply_thumbnail_urls(printer)
 
 
 @router.put(
@@ -133,6 +143,9 @@ async def update_printer(printer_id: uuid.UUID, body: PrinterUpdate, user: Curre
         printer.monitor_status = None
         printer.monitor_progress_percent = None
         printer.current_print_name = None
+        setattr(printer, "current_print_thumbnail_path", None)
+        setattr(printer, "current_print_thumbnail_url", None)
+        setattr(printer, "current_print_thumbnails", [])
         printer.monitor_last_message = None
         printer.monitor_last_error = None
         printer.monitor_bed_temp_c = None
@@ -155,7 +168,7 @@ async def update_printer(printer_id: uuid.UUID, body: PrinterUpdate, user: Curre
     await db.refresh(printer)
     if printer.monitor_enabled:
         await refresh_printer_monitoring(db, printer, force=True)
-    return printer
+    return _apply_thumbnail_urls(printer)
 
 
 @router.post(
@@ -167,7 +180,7 @@ async def update_printer(printer_id: uuid.UUID, body: PrinterUpdate, user: Curre
 async def refresh_printer(printer_id: uuid.UUID, user: CurrentUser, db: DB):
     printer = await _get_printer_or_404(db, printer_id)
     await refresh_printer_monitoring(db, printer, force=True)
-    return printer
+    return _apply_thumbnail_urls(printer)
 
 
 @router.post(
@@ -203,3 +216,25 @@ async def delete_printer(printer_id: uuid.UUID, user: CurrentUser, db: DB):
     printer = await _get_printer_or_404(db, printer_id)
     printer.is_active = False
     await db.commit()
+
+
+@router.get(
+    "/{printer_id}/thumbnail",
+    summary="Get current print thumbnail",
+    description="Fetches the active Moonraker print thumbnail through the backend to avoid frontend CORS and path encoding issues.",
+)
+async def get_printer_thumbnail(printer_id: uuid.UUID, db: DB):
+    printer = await _get_printer_or_404(db, printer_id)
+    if not printer.monitor_enabled or printer.monitor_provider != "moonraker":
+        raise HTTPException(status_code=404, detail="Printer thumbnail unavailable")
+
+    provider = MoonrakerMonitorProvider()
+    try:
+        thumbnail = await provider.fetch_current_thumbnail(printer)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    if thumbnail is None:
+        raise HTTPException(status_code=404, detail="Printer thumbnail unavailable")
+
+    return Response(content=thumbnail.content, media_type=thumbnail.media_type)

--- a/backend/app/schemas/printer.py
+++ b/backend/app/schemas/printer.py
@@ -71,6 +71,13 @@ class PrinterUpdate(BaseModel):
         return value.rstrip("/") or None
 
 
+class PrinterThumbnailResponse(BaseModel):
+    relative_path: str
+    width: int | None = None
+    height: int | None = None
+    size: int | None = None
+
+
 class PrinterResponse(BaseModel):
     id: uuid.UUID
     name: str
@@ -93,6 +100,9 @@ class PrinterResponse(BaseModel):
     current_print_name: str | None = None
     monitor_last_message: str | None = None
     monitor_last_error: str | None = None
+    current_print_thumbnail_path: str | None = None
+    current_print_thumbnail_url: str | None = None
+    current_print_thumbnails: list[PrinterThumbnailResponse] = Field(default_factory=list)
     monitor_bed_temp_c: float | None = None
     monitor_tool_temp_c: float | None = None
     monitor_bed_target_c: float | None = None

--- a/backend/app/services/printer_monitoring.py
+++ b/backend/app/services/printer_monitoring.py
@@ -6,10 +6,12 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from itertools import count
+from pathlib import PurePosixPath
 from typing import Any
-from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 
 import httpx
+import mimetypes
 import websockets
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -52,6 +54,21 @@ class PrinterMonitorProvider:
         raise NotImplementedError
 
 
+@dataclass
+class PrinterThumbnail:
+    relative_path: str
+    width: int | None = None
+    height: int | None = None
+    size: int | None = None
+
+
+@dataclass
+class PrinterThumbnailPayload:
+    path: str
+    content: bytes
+    media_type: str
+
+
 class HttpPrinterMonitorProvider(PrinterMonitorProvider):
     auth_header_name: str | None = None
 
@@ -73,6 +90,16 @@ class HttpPrinterMonitorProvider(PrinterMonitorProvider):
             response = await client.get(url, headers=headers)
             response.raise_for_status()
             return response.json()
+
+    async def _request_bytes(self, printer: Printer, path: str) -> tuple[bytes, str | None]:
+        timeout = httpx.Timeout(DEFAULT_TIMEOUT_SECONDS)
+        url = self._build_url(printer, path)
+        headers = self._build_headers(printer)
+        headers.setdefault("Accept", "image/*,application/octet-stream;q=0.9,*/*;q=0.1")
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+            return response.content, response.headers.get("content-type")
 
 
 class OctoPrintMonitorProvider(HttpPrinterMonitorProvider):
@@ -222,10 +249,19 @@ class MoonrakerMonitorProvider(HttpPrinterMonitorProvider):
         if snapshot and _snapshot_is_fresh(snapshot):
             return dict(snapshot)
 
-        server_payload, printer_payload, objects_payload = await _gather_moonraker_payloads(self, printer)
-        updates = _build_moonraker_state_from_poll(server_payload, printer_payload, objects_payload)
+        server_payload, printer_payload, objects_payload, metadata_payload = await _gather_moonraker_payloads(self, printer)
+        updates = _build_moonraker_state_from_poll(server_payload, printer_payload, objects_payload, metadata_payload)
         snapshot = moonraker_websocket_manager.merge_polled_state(printer.id, updates)
         return dict(snapshot)
+
+    async def fetch_current_thumbnail(self, printer: Printer) -> PrinterThumbnailPayload | None:
+        state = await self.fetch_live_state(printer)
+        thumbnail_path = state.get("current_print_thumbnail_path")
+        if not thumbnail_path:
+            return None
+        content, content_type = await self._request_bytes(printer, _build_moonraker_thumbnail_file_path(thumbnail_path))
+        media_type = _normalize_media_type(content_type, thumbnail_path)
+        return PrinterThumbnailPayload(path=thumbnail_path, content=content, media_type=media_type)
 
 
 class MoonrakerWebsocketManager:
@@ -365,14 +401,19 @@ async def _gather_octoprint_payloads(provider: OctoPrintMonitorProvider, printer
 
 async def _gather_moonraker_payloads(
     provider: MoonrakerMonitorProvider, printer: Printer
-) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any] | None]:
     server_payload = await provider._request(printer, "/server/info")
     printer_payload = await provider._request(printer, "/printer/info")
     objects_payload = await provider._request(
         printer,
         "/printer/objects/query?print_stats&virtual_sdcard&extruder&heater_bed&gcode_move",
     )
-    return server_payload, printer_payload, objects_payload
+    metadata_payload = None
+    filename = _extract_moonraker_print_filename((objects_payload.get("result") or {}).get("status") or {})
+    if filename:
+        encoded_filename = quote(filename, safe="")
+        metadata_payload = await provider._request(printer, f"/server/files/metadata?filename={encoded_filename}")
+    return server_payload, printer_payload, objects_payload, metadata_payload
 
 
 def _to_float(value: Any) -> float | None:
@@ -418,6 +459,75 @@ def _extract_filename_from_path(value: Any) -> str | None:
     return normalized.rsplit("/", 1)[-1] or None
 
 
+def _extract_moonraker_print_filename(status: dict[str, Any]) -> str | None:
+    print_stats = status.get("print_stats") or {}
+    virtual_sdcard = status.get("virtual_sdcard") or {}
+    return print_stats.get("filename") or virtual_sdcard.get("file_path") or None
+
+
+def _normalize_relative_thumbnail_path(filename: str, relative_path: str) -> str | None:
+    if not filename or not relative_path:
+        return None
+    file_path = PurePosixPath(str(filename).lstrip("/"))
+    relative = PurePosixPath(str(relative_path))
+    if relative.is_absolute():
+        combined = relative.relative_to("/")
+    else:
+        combined = file_path.parent / relative
+
+    parts: list[str] = []
+    for part in combined.parts:
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+            continue
+        parts.append(part)
+    return "/".join(parts) or None
+
+
+def _extract_moonraker_thumbnails(metadata: dict[str, Any]) -> list[PrinterThumbnail]:
+    filename = metadata.get("filename") or metadata.get("path") or metadata.get("file")
+    thumbnails: list[PrinterThumbnail] = []
+    for entry in metadata.get("thumbnails") or []:
+        if not isinstance(entry, dict):
+            continue
+        relative_path = _normalize_relative_thumbnail_path(filename, entry.get("relative_path") or entry.get("path") or "")
+        if not relative_path:
+            continue
+        thumbnails.append(
+            PrinterThumbnail(
+                relative_path=relative_path,
+                width=_to_int(entry.get("width")),
+                height=_to_int(entry.get("height")),
+                size=_to_int(entry.get("size")),
+            )
+        )
+    return thumbnails
+
+
+def _select_best_thumbnail(thumbnails: list[PrinterThumbnail]) -> PrinterThumbnail | None:
+    if not thumbnails:
+        return None
+    return max(
+        thumbnails,
+        key=lambda thumbnail: (thumbnail.width or 0) * (thumbnail.height or 0),
+    )
+
+
+def _build_moonraker_thumbnail_file_path(relative_path: str) -> str:
+    encoded = "/".join(quote(segment, safe="") for segment in relative_path.split("/") if segment)
+    return f"/server/files/gcodes/{encoded}"
+
+
+def _normalize_media_type(content_type: str | None, path: str) -> str:
+    if content_type:
+        return content_type.split(";", 1)[0].strip()
+    guessed, _ = mimetypes.guess_type(path)
+    return guessed or "application/octet-stream"
+
+
 def _coerce_datetime(value: Any) -> datetime | None:
     if isinstance(value, datetime):
         return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
@@ -430,6 +540,7 @@ def _build_moonraker_state_from_poll(
     server_payload: dict[str, Any],
     printer_payload: dict[str, Any],
     objects_payload: dict[str, Any],
+    metadata_payload: dict[str, Any] | None,
 ) -> dict[str, Any]:
     provider = MoonrakerMonitorProvider()
     server_info = server_payload.get("result") or {}
@@ -441,6 +552,7 @@ def _build_moonraker_state_from_poll(
         printer_state=printer_info.get("state"),
         printer_state_message=printer_info.get("state_message"),
         status=status,
+        metadata=(metadata_payload or {}).get("result") or {},
         event_type="poll",
         event_time=datetime.now(timezone.utc),
         ws_connected=None,
@@ -463,6 +575,7 @@ def _extract_moonraker_updates_from_ws(payload: dict[str, Any]) -> dict[str, Any
             printer_state=None,
             printer_state_message=None,
             status=status_patch,
+            metadata={},
             event_type=method,
             event_time=event_time,
             ws_connected=True,
@@ -484,6 +597,7 @@ def _extract_moonraker_updates_from_ws(payload: dict[str, Any]) -> dict[str, Any
         printer_state=None,
         printer_state_message=None,
         status=status_patch,
+        metadata={},
         event_type=method,
         event_time=event_time,
         ws_connected=True,
@@ -498,6 +612,7 @@ def _build_moonraker_updates(
     printer_state: str | None,
     printer_state_message: str | None,
     status: dict[str, Any],
+    metadata: dict[str, Any],
     event_type: str,
     event_time: datetime,
     ws_connected: bool | None,
@@ -509,6 +624,8 @@ def _build_moonraker_updates(
     heater_bed = status.get("heater_bed") or {}
     gcode_move = status.get("gcode_move") or {}
     info = status.get("info") or {}
+    thumbnails = _extract_moonraker_thumbnails(metadata)
+    selected_thumbnail = _select_best_thumbnail(thumbnails)
 
     normalized_status, online = provider._normalize_status(
         server_state=server_state,
@@ -571,6 +688,12 @@ def _build_moonraker_updates(
         "monitor_last_seen_at": event_time,
         "monitor_last_updated_at": event_time,
         "monitor_last_error": None,
+        "current_print_thumbnail_path": selected_thumbnail.relative_path if selected_thumbnail else None,
+        "current_print_thumbnail_url": None,
+        "current_print_thumbnails": [
+            {"relative_path": thumbnail.relative_path, "width": thumbnail.width, "height": thumbnail.height, "size": thumbnail.size}
+            for thumbnail in thumbnails
+        ],
         "monitor_last_event_type": event_type,
         "monitor_last_event_at": event_time,
     }

--- a/backend/tests/test_printer_monitoring.py
+++ b/backend/tests/test_printer_monitoring.py
@@ -8,7 +8,9 @@ from datetime import datetime, timezone
 from app.services.printer_monitoring import (
     MoonrakerMonitorProvider,
     OctoPrintMonitorProvider,
+    _build_moonraker_thumbnail_file_path,
     _extract_moonraker_updates_from_ws,
+    _normalize_relative_thumbnail_path,
     get_provider,
 )
 
@@ -59,6 +61,8 @@ async def test_moonraker_fetch_live_state_normalizes_printing(monkeypatch):
                     }
                 }
             }
+        if path == "/server/files/metadata?filename=demo.gcode":
+            return {"result": {"filename": "demo.gcode", "thumbnails": []}}
         raise AssertionError(f"Unexpected path {path}")
 
     monkeypatch.setattr(provider, "_request", fake_request)
@@ -142,3 +146,87 @@ def test_extract_moonraker_updates_from_websocket_event():
     assert updates["monitor_remaining_seconds"] == 900.0
     assert updates["monitor_tool_target_c"] == 215.0
     assert updates["monitor_last_event_type"] == "notify_status_update"
+
+
+@pytest.mark.asyncio
+async def test_moonraker_fetch_live_state_includes_thumbnail_metadata(monkeypatch):
+    provider = MoonrakerMonitorProvider()
+    printer = Printer(
+        name="Unicode",
+        slug="unicode",
+        monitor_provider="moonraker",
+        monitor_base_url="http://printer.local:7125",
+    )
+
+    async def fake_request(_printer, path):
+        if path == "/server/info":
+            return {"result": {"klippy_state": "ready", "moonraker_version": "1.2.0"}}
+        if path == "/printer/info":
+            return {"result": {"state": "ready", "state_message": "Printer is ready"}}
+        if path == "/printer/objects/query?print_stats&virtual_sdcard&extruder&heater_bed&gcode_move":
+            return {
+                "result": {
+                    "status": {
+                        "print_stats": {
+                            "filename": "prints/猫 テスト.gcode",
+                            "state": "printing",
+                        },
+                        "virtual_sdcard": {"progress": 0.5, "is_active": True},
+                    }
+                }
+            }
+        if path == "/server/files/metadata?filename=prints%2F%E7%8C%AB%20%E3%83%86%E3%82%B9%E3%83%88.gcode":
+            return {
+                "result": {
+                    "filename": "prints/猫 テスト.gcode",
+                    "thumbnails": [
+                        {"relative_path": ".thumbs/猫 テスト-32x32.png", "width": 32, "height": 32, "size": 100},
+                        {"relative_path": ".thumbs/猫 テスト-300x300.png", "width": 300, "height": 300, "size": 999},
+                    ],
+                }
+            }
+        raise AssertionError(f"Unexpected path {path}")
+
+    monkeypatch.setattr(provider, "_request", fake_request)
+
+    result = await provider.fetch_live_state(printer)
+
+    assert result["current_print_thumbnail_path"] == "prints/.thumbs/猫 テスト-300x300.png"
+    assert len(result["current_print_thumbnails"]) == 2
+    assert result["current_print_thumbnails"][0]["relative_path"] == "prints/.thumbs/猫 テスト-32x32.png"
+
+
+def test_thumbnail_path_helpers_handle_relative_and_unicode_paths():
+    relative = _normalize_relative_thumbnail_path("folder/猫 テスト.gcode", ".thumbs/猫 テスト-300x300.png")
+    parent_relative = _normalize_relative_thumbnail_path("folder/sub/猫 テスト.gcode", "../.thumbs/preview.png")
+    encoded = _build_moonraker_thumbnail_file_path("folder/.thumbs/猫 テスト-300x300.png")
+
+    assert relative == "folder/.thumbs/猫 テスト-300x300.png"
+    assert parent_relative == "folder/.thumbs/preview.png"
+    assert encoded == "/server/files/gcodes/folder/.thumbs/%E7%8C%AB%20%E3%83%86%E3%82%B9%E3%83%88-300x300.png"
+
+
+@pytest.mark.asyncio
+async def test_printer_thumbnail_endpoint_proxies_moonraker_file(client, auth_headers, db_session, monkeypatch):
+    printer = Printer(
+        name="Lava",
+        slug="lava",
+        monitor_enabled=True,
+        monitor_provider="moonraker",
+        monitor_base_url="http://printer.local:7125",
+    )
+    db_session.add(printer)
+    await db_session.commit()
+    await db_session.refresh(printer)
+
+    async def fake_fetch_current_thumbnail(self, printer_arg):
+        assert printer_arg.id == printer.id
+        return type("Thumb", (), {"content": b"png-bytes", "media_type": "image/png"})()
+
+    monkeypatch.setattr(MoonrakerMonitorProvider, "fetch_current_thumbnail", fake_fetch_current_thumbnail)
+
+    response = await client.get(f"/api/v1/printers/{printer.id}/thumbnail", headers=auth_headers)
+
+    assert response.status_code == 200
+    assert response.content == b"png-bytes"
+    assert response.headers["content-type"].startswith("image/png")

--- a/frontend/src/components/printers/PrinterThumbnail.tsx
+++ b/frontend/src/components/printers/PrinterThumbnail.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { ImageOff } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type PrinterThumbnailProps = {
+  src?: string | null;
+  alt: string;
+  className?: string;
+  imgClassName?: string;
+  fallbackLabel?: string;
+};
+
+export default function PrinterThumbnail({ src, alt, className, imgClassName, fallbackLabel = 'No thumbnail' }: PrinterThumbnailProps) {
+  const [failed, setFailed] = useState(false);
+  const showImage = Boolean(src) && !failed;
+
+  return (
+    <div className={cn('overflow-hidden rounded-lg border border-border bg-background/40', className)}>
+      {showImage ? (
+        <img
+          src={src || undefined}
+          alt={alt}
+          loading="lazy"
+          onError={() => setFailed(true)}
+          className={cn('h-full w-full object-cover', imgClassName)}
+        />
+      ) : (
+        <div className="flex h-full min-h-[120px] w-full flex-col items-center justify-center gap-2 px-4 py-6 text-center text-muted-foreground">
+          <ImageOff className="h-6 w-6" />
+          <p className="text-xs">{fallbackLabel}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { BarChart3, Package, DollarSign, TrendingUp, Layers, Award, AlertTriangle, ShoppingCart } from 'lucide-react';
 import { BarChart, Bar, LineChart, Line, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import api from '@/api/client';
+import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import { formatCurrency, formatPercent } from '@/lib/utils';
 import type { DashboardSummary, FinanceDashboardSummary, RevenueDataPoint, MaterialUsageDataPoint, ProfitMarginDataPoint, InventoryAlert, PaginatedPrinters, Printer, SalesMetrics } from '@/types';
 
@@ -154,17 +155,28 @@ export default function DashboardPage() {
           <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 xl:grid-cols-3">
             {printersData.items.map((printer) => (
               <Link key={printer.id} to={`/printers/${printer.id}`} className="rounded-lg border border-border bg-background/40 p-4 no-underline hover:bg-accent/50 transition-colors">
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="font-semibold text-foreground">{printer.name}</p>
-                    <p className="text-xs text-muted-foreground">{printer.monitor_provider || 'static'} · {printer.monitor_status || printer.status}</p>
+                <div className="flex gap-3">
+                  <PrinterThumbnail
+                    src={printer.current_print_thumbnail_url}
+                    alt={printer.current_print_name ? `${printer.current_print_name} thumbnail` : `${printer.name} current print thumbnail`}
+                    className="h-24 w-24 shrink-0"
+                    imgClassName="object-cover"
+                    fallbackLabel="No thumb"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate font-semibold text-foreground">{printer.name}</p>
+                        <p className="text-xs text-muted-foreground">{printer.monitor_provider || 'static'} · {printer.monitor_status || printer.status}</p>
+                      </div>
+                      <span className="text-sm font-semibold text-foreground">{printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}</span>
+                    </div>
+                    <div className="mt-3 space-y-1 text-sm text-muted-foreground">
+                      <p className="truncate">{printer.current_print_name || 'No active file'}</p>
+                      <p>Layer {formatLayer(printer)} · Remaining {formatDuration(printer.monitor_remaining_seconds)}</p>
+                      <p>{printer.monitor_provider === 'moonraker' ? (printer.monitor_ws_connected ? 'WebSocket live' : 'Polling fallback') : 'HTTP polling / static'}</p>
+                    </div>
                   </div>
-                  <span className="text-sm font-semibold text-foreground">{printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}</span>
-                </div>
-                <div className="mt-3 space-y-1 text-sm text-muted-foreground">
-                  <p>{printer.current_print_name || 'No active file'}</p>
-                  <p>Layer {formatLayer(printer)} · Remaining {formatDuration(printer.monitor_remaining_seconds)}</p>
-                  <p>{printer.monitor_provider === 'moonraker' ? (printer.monitor_ws_connected ? 'WebSocket live' : 'Polling fallback') : 'HTTP polling / static'}</p>
                 </div>
               </Link>
             ))}

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Edit, Archive, ArchiveRestore, RefreshCw, PlugZap } from 'lu
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { cn, formatCurrency } from '@/lib/utils';
+import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import type { Job, PaginatedJobs, Printer, PrinterConnectionTestResult } from '@/types';
 
@@ -232,7 +233,9 @@ export default function PrinterDetailPage() {
         {!printer.monitor_enabled ? (
           <p className="text-sm text-muted-foreground">Monitoring is not configured for this printer yet. The printer still works as a static record.</p>
         ) : (
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div className="space-y-4">
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1.3fr)_minmax(260px,0.7fr)]">
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
             <div><p className="text-xs text-muted-foreground">Provider</p><p className="font-semibold capitalize">{printer.monitor_provider || '—'}</p></div>
             <div><p className="text-xs text-muted-foreground">Progress</p><p className="font-semibold">{printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(1)}%` : '—'}</p></div>
             <div><p className="text-xs text-muted-foreground">Current print</p><p className="font-semibold">{printer.current_print_name || '—'}</p></div>
@@ -247,6 +250,20 @@ export default function PrinterDetailPage() {
             <div><p className="text-xs text-muted-foreground">Last seen</p><p className="font-semibold">{formatDateTime(printer.monitor_last_seen_at)}</p></div>
             <div><p className="text-xs text-muted-foreground">Last updated</p><p className="font-semibold">{formatDateTime(printer.monitor_last_updated_at)}</p></div>
             <div><p className="text-xs text-muted-foreground">Live transport</p><p className="font-semibold">{printer.monitor_provider === 'moonraker' ? (printer.monitor_ws_connected ? 'WebSocket streaming' : 'HTTP polling fallback') : 'HTTP polling'}</p></div>
+              </div>
+              <div className="space-y-2">
+                <div>
+                  <p className="text-xs text-muted-foreground">Current print thumbnail</p>
+                  <p className="text-sm text-muted-foreground">{printer.current_print_name || 'No active file'}</p>
+                </div>
+                <PrinterThumbnail
+                  src={printer.current_print_thumbnail_url}
+                  alt={printer.current_print_name ? `${printer.current_print_name} thumbnail` : `${printer.name} current print thumbnail`}
+                  className="aspect-square min-h-[220px]"
+                  fallbackLabel={printer.current_print_name ? 'No thumbnail in G-code metadata' : 'No active print'}
+                />
+              </div>
+            </div>
           </div>
         )}
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -36,6 +36,13 @@ export interface Customer {
   job_count: number;
 }
 
+export interface PrinterThumbnailInfo {
+  relative_path: string;
+  width: number | null;
+  height: number | null;
+  size: number | null;
+}
+
 export interface Printer {
   id: string;
   name: string;
@@ -58,6 +65,9 @@ export interface Printer {
   current_print_name: string | null;
   monitor_last_message: string | null;
   monitor_last_error: string | null;
+  current_print_thumbnail_path: string | null;
+  current_print_thumbnail_url: string | null;
+  current_print_thumbnails: PrinterThumbnailInfo[];
   monitor_bed_temp_c: number | null;
   monitor_tool_temp_c: number | null;
   monitor_bed_target_c: number | null;


### PR DESCRIPTION
## Summary
- fetch Moonraker G-code thumbnail metadata for the active print
- add a backend proxy endpoint for printer thumbnails
- expose thumbnail fields through printer APIs
- render current print thumbnails on printer detail and the dashboard live board
- handle Unicode thumbnail paths and missing-image fallbacks cleanly

## Testing
- .venv/bin/pytest backend/tests/test_printer_monitoring.py -q
- npm --prefix frontend run build

Closes #109