### PR TITLE
feat(printers): add printer status and assignment history (#87)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -19,6 +19,7 @@ from app.models.customer import Customer  # noqa
 from app.models.job import Job  # noqa
 from app.models.user import User  # noqa
 from app.models.printer import Printer  # noqa
+from app.models.printer_history_event import PrinterHistoryEvent  # noqa
 from app.models.product import Product  # noqa
 from app.models.inventory_transaction import InventoryTransaction  # noqa
 from app.models.sales_channel import SalesChannel  # noqa

--- a/backend/alembic/versions/20260329_03_add_printer_history_events.py
+++ b/backend/alembic/versions/20260329_03_add_printer_history_events.py
@@ -1,0 +1,48 @@
+"""add printer history events
+
+Revision ID: 20260329_03
+Revises: 20260329_02
+Create Date: 2026-03-29 19:05:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260329_03"
+down_revision = "20260329_02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "printer_history_events",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("printer_id", sa.UUID(), nullable=False),
+        sa.Column("job_id", sa.UUID(), nullable=True),
+        sa.Column("actor_user_id", sa.UUID(), nullable=True),
+        sa.Column("event_type", sa.String(length=50), nullable=False),
+        sa.Column("title", sa.String(length=160), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("metadata", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["actor_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["job_id"], ["jobs.id"]),
+        sa.ForeignKeyConstraint(["printer_id"], ["printers.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_printer_history_events_actor_user_id"), "printer_history_events", ["actor_user_id"], unique=False)
+    op.create_index(op.f("ix_printer_history_events_created_at"), "printer_history_events", ["created_at"], unique=False)
+    op.create_index(op.f("ix_printer_history_events_event_type"), "printer_history_events", ["event_type"], unique=False)
+    op.create_index(op.f("ix_printer_history_events_job_id"), "printer_history_events", ["job_id"], unique=False)
+    op.create_index(op.f("ix_printer_history_events_printer_id"), "printer_history_events", ["printer_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_printer_history_events_printer_id"), table_name="printer_history_events")
+    op.drop_index(op.f("ix_printer_history_events_job_id"), table_name="printer_history_events")
+    op.drop_index(op.f("ix_printer_history_events_event_type"), table_name="printer_history_events")
+    op.drop_index(op.f("ix_printer_history_events_created_at"), table_name="printer_history_events")
+    op.drop_index(op.f("ix_printer_history_events_actor_user_id"), table_name="printer_history_events")
+    op.drop_table("printer_history_events")

--- a/backend/app/api/v1/endpoints/jobs.py
+++ b/backend/app/api/v1/endpoints/jobs.py
@@ -119,9 +119,11 @@ async def get_job(job_id: uuid.UUID, db: DB):
 async def create_job(body: JobCreate, user: CurrentUser, db: DB):
     job_number = body.job_number or await generate_job_number(db, body.date)
 
+    assigned_printer = None
     if body.printer_id:
-        printer_exists = await db.execute(select(Printer.id).where(Printer.id == body.printer_id))
-        if not printer_exists.scalar_one_or_none():
+        printer_exists = await db.execute(select(Printer).where(Printer.id == body.printer_id))
+        assigned_printer = printer_exists.scalar_one_or_none()
+        if not assigned_printer:
             raise HTTPException(status_code=404, detail="Printer not found")
 
     # Check for duplicate job number

--- a/backend/app/api/v1/endpoints/printers.py
+++ b/backend/app/api/v1/endpoints/printers.py
@@ -14,6 +14,7 @@ from app.schemas.printer import (
     PrinterResponse,
     PrinterUpdate,
 )
+from app.services.printer_history_service import list_printer_history_events, record_printer_status_change
 from app.services.printer_monitoring import (
     MoonrakerMonitorProvider,
     PrinterMonitoringError,
@@ -91,6 +92,10 @@ async def get_printer(printer_id: uuid.UUID, db: DB):
     printer = await _get_printer_or_404(db, printer_id)
     mark_printer_stale_if_needed(printer)
     await refresh_printer_monitoring(db, printer)
+    history_events = await list_printer_history_events(db, printer.id, limit=25)
+    for event in history_events:
+        setattr(event, "actor_name", event.actor.full_name if getattr(event, "actor", None) else None)
+    setattr(printer, "history_events", history_events)
     return _apply_thumbnail_urls(printer)
 
 
@@ -124,6 +129,7 @@ async def create_printer(body: PrinterCreate, user: CurrentUser, db: DB):
 async def update_printer(printer_id: uuid.UUID, body: PrinterUpdate, user: CurrentUser, db: DB):
     printer = await _get_printer_or_404(db, printer_id)
 
+    old_status = printer.status
     update_data = body.model_dump(exclude_unset=True)
     if "name" in update_data or "slug" in update_data:
         existing = await db.execute(
@@ -164,6 +170,7 @@ async def update_printer(printer_id: uuid.UUID, body: PrinterUpdate, user: Curre
         printer.monitor_last_seen_at = None
         printer.monitor_last_updated_at = None
 
+    await record_printer_status_change(db, printer=printer, old_status=old_status, new_status=printer.status, actor_user_id=user.id)
     await db.commit()
     await db.refresh(printer)
     if printer.monitor_enabled:

--- a/backend/app/models/printer_history_event.py
+++ b/backend/app/models/printer_history_event.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.sqlite import JSON as SQLiteJSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class PrinterHistoryEvent(Base):
+    __tablename__ = "printer_history_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    printer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("printers.id"), index=True)
+    job_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("jobs.id"), nullable=True, index=True)
+    actor_user_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("users.id"), nullable=True, index=True)
+    event_type: Mapped[str] = mapped_column(String(50), index=True)
+    title: Mapped[str] = mapped_column(String(160))
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    event_metadata: Mapped[dict | None] = mapped_column("metadata", SQLiteJSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True)
+
+    printer = relationship("Printer")
+    job = relationship("Job")
+    actor = relationship("User")

--- a/backend/app/schemas/printer.py
+++ b/backend/app/schemas/printer.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class PrinterStatus(str, Enum):
@@ -78,6 +78,21 @@ class PrinterThumbnailResponse(BaseModel):
     size: int | None = None
 
 
+class PrinterHistoryEventResponse(BaseModel):
+    id: uuid.UUID
+    printer_id: uuid.UUID
+    job_id: uuid.UUID | None = None
+    actor_user_id: uuid.UUID | None = None
+    actor_name: str | None = None
+    event_type: str
+    title: str
+    description: str | None = None
+    metadata: dict | None = Field(None, validation_alias="event_metadata")
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class PrinterResponse(BaseModel):
     id: uuid.UUID
     name: str
@@ -103,6 +118,7 @@ class PrinterResponse(BaseModel):
     current_print_thumbnail_path: str | None = None
     current_print_thumbnail_url: str | None = None
     current_print_thumbnails: list[PrinterThumbnailResponse] = Field(default_factory=list)
+    history_events: list[PrinterHistoryEventResponse] = Field(default_factory=list)
     monitor_bed_temp_c: float | None = None
     monitor_tool_temp_c: float | None = None
     monitor_bed_target_c: float | None = None

--- a/backend/app/services/printer_history_service.py
+++ b/backend/app/services/printer_history_service.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.printer import Printer
+from app.models.printer_history_event import PrinterHistoryEvent
+from app.models.user import User
+from app.services.audit_service import _json_safe
+
+
+async def create_printer_history_event(
+    db: AsyncSession,
+    *,
+    printer_id: uuid.UUID,
+    event_type: str,
+    title: str,
+    description: str | None = None,
+    job_id: uuid.UUID | None = None,
+    actor_user_id: uuid.UUID | None = None,
+    metadata: dict | None = None,
+) -> PrinterHistoryEvent:
+    event = PrinterHistoryEvent(
+        printer_id=printer_id,
+        job_id=job_id,
+        actor_user_id=actor_user_id,
+        event_type=event_type,
+        title=title,
+        description=description,
+        event_metadata=_json_safe(metadata),
+    )
+    db.add(event)
+    await db.flush()
+    return event
+
+
+async def list_printer_history_events(db: AsyncSession, printer_id: uuid.UUID, *, limit: int = 25) -> list[PrinterHistoryEvent]:
+    result = await db.execute(
+        select(PrinterHistoryEvent)
+        .options(selectinload(PrinterHistoryEvent.actor), selectinload(PrinterHistoryEvent.job))
+        .where(PrinterHistoryEvent.printer_id == printer_id)
+        .order_by(PrinterHistoryEvent.created_at.desc())
+        .limit(limit)
+    )
+    return result.scalars().all()
+
+
+async def record_printer_status_change(
+    db: AsyncSession,
+    *,
+    printer: Printer,
+    old_status: str | None,
+    new_status: str | None,
+    actor_user_id: uuid.UUID | None = None,
+    source: str = "manual",
+) -> PrinterHistoryEvent | None:
+    if old_status == new_status:
+        return None
+    return await create_printer_history_event(
+        db,
+        printer_id=printer.id,
+        actor_user_id=actor_user_id,
+        event_type="status_changed",
+        title=f"Status changed to {new_status or 'unknown'}",
+        description=f"Printer status changed from {old_status or 'unknown'} to {new_status or 'unknown'}.",
+        metadata={"from_status": old_status, "to_status": new_status, "source": source},
+    )
+
+
+async def record_job_assignment_change(
+    db: AsyncSession,
+    *,
+    job_id: uuid.UUID,
+    job_number: str,
+    product_name: str,
+    old_printer: Printer | None,
+    new_printer: Printer | None,
+    actor_user_id: uuid.UUID | None = None,
+) -> None:
+    if (old_printer.id if old_printer else None) == (new_printer.id if new_printer else None):
+        return
+
+    base_metadata = {
+        "job_id": job_id,
+        "job_number": job_number,
+        "product_name": product_name,
+        "from_printer_id": str(old_printer.id) if old_printer else None,
+        "from_printer_name": old_printer.name if old_printer else None,
+        "to_printer_id": str(new_printer.id) if new_printer else None,
+        "to_printer_name": new_printer.name if new_printer else None,
+    }
+
+    if old_printer and new_printer:
+        await create_printer_history_event(
+            db,
+            printer_id=old_printer.id,
+            job_id=job_id,
+            actor_user_id=actor_user_id,
+            event_type="job_reassigned_from",
+            title=f"Job {job_number} reassigned away",
+            description=f"{product_name} was moved from {old_printer.name} to {new_printer.name}.",
+            metadata=base_metadata,
+        )
+        await create_printer_history_event(
+            db,
+            printer_id=new_printer.id,
+            job_id=job_id,
+            actor_user_id=actor_user_id,
+            event_type="job_reassigned_to",
+            title=f"Job {job_number} reassigned here",
+            description=f"{product_name} was moved from {old_printer.name} to {new_printer.name}.",
+            metadata=base_metadata,
+        )
+        return
+
+    if new_printer:
+        await create_printer_history_event(
+            db,
+            printer_id=new_printer.id,
+            job_id=job_id,
+            actor_user_id=actor_user_id,
+            event_type="job_assigned",
+            title=f"Job {job_number} assigned",
+            description=f"{product_name} was assigned to {new_printer.name}.",
+            metadata=base_metadata,
+        )
+        return
+
+    if old_printer:
+        await create_printer_history_event(
+            db,
+            printer_id=old_printer.id,
+            job_id=job_id,
+            actor_user_id=actor_user_id,
+            event_type="job_unassigned",
+            title=f"Job {job_number} unassigned",
+            description=f"{product_name} was unassigned from {old_printer.name}.",
+            metadata=base_metadata,
+        )
+
+
+async def get_user_label(db: AsyncSession, user_id: uuid.UUID | None) -> str | None:
+    if not user_id:
+        return None
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if not user:
+        return None
+    return user.full_name or user.email

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -24,6 +24,7 @@ from app.models.material_receipt import MaterialReceipt
 from app.models.rate import Rate
 from app.models.setting import Setting
 from app.models.user import User
+from app.models.printer_history_event import PrinterHistoryEvent  # noqa: F401
 from app.services.accounting_service import seed_chart_of_accounts
 
 TEST_DB_URL = "sqlite+aiosqlite:///./test.db"

--- a/backend/tests/test_api_jobs.py
+++ b/backend/tests/test_api_jobs.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy import select
 
 from app.models.inventory_transaction import InventoryTransaction
+from app.models.printer_history_event import PrinterHistoryEvent
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_api_printers.py
+++ b/backend/tests/test_api_printers.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import uuid
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models.printer_history_event import PrinterHistoryEvent
 
 
 @pytest.mark.asyncio
@@ -225,3 +229,34 @@ async def test_disabling_monitoring_clears_live_fields(client: AsyncClient, auth
     assert data["monitor_total_layers"] is None
     assert data["monitor_remaining_seconds"] is None
     assert data["monitor_ws_connected"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_printer_status_records_history_event(client: AsyncClient, auth_headers: dict, db_session):
+    create = await client.post(
+        "/api/v1/printers",
+        headers=auth_headers,
+        json={"name": "History Printer", "slug": "history-printer", "status": "idle"},
+    )
+    printer_id = create.json()["id"]
+
+    update = await client.put(
+        f"/api/v1/printers/{printer_id}",
+        headers=auth_headers,
+        json={"status": "printing"},
+    )
+    assert update.status_code == 200
+    assert update.json()["history_events"] == []
+
+    events = (await db_session.execute(select(PrinterHistoryEvent).where(PrinterHistoryEvent.printer_id == uuid.UUID(printer_id)))).scalars().all()
+    assert len(events) == 1
+    assert events[0].event_type == "status_changed"
+    assert events[0].event_metadata["from_status"] == "idle"
+    assert events[0].event_metadata["to_status"] == "printing"
+
+    detail = await client.get(f"/api/v1/printers/{printer_id}")
+    assert detail.status_code == 200
+    history = detail.json()["history_events"]
+    assert len(history) == 1
+    assert history[0]["event_type"] == "status_changed"
+    assert history[0]["actor_name"]

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -55,6 +55,11 @@ function formatLayer(current: number | null | undefined, total: number | null | 
   return String(current ?? total ?? '—');
 }
 
+function formatEventMetaValue(value: unknown) {
+  if (value == null || value === '') return null;
+  return String(value);
+}
+
 export default function PrinterDetailPage() {
   const { id } = useParams<{ id: string }>();
   const queryClient = useQueryClient();
@@ -288,6 +293,49 @@ export default function PrinterDetailPage() {
             ) : null}
           </div>
         ) : null}
+      </div>
+
+      <div className="mb-6 rounded-lg border border-border bg-card p-6">
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-bold">Recent Activity</h2>
+            <p className="text-sm text-muted-foreground">Status changes and printer assignment events for this machine.</p>
+          </div>
+          <span className="rounded-full bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground">{printer.history_events.length} events</span>
+        </div>
+
+        {!printer.history_events.length ? (
+          <div className="rounded-lg border border-border bg-background/40 p-6 text-sm text-muted-foreground">No printer activity has been recorded yet.</div>
+        ) : (
+          <div className="space-y-3">
+            {printer.history_events.map((event) => {
+              const jobNumber = formatEventMetaValue(event.metadata?.job_number);
+              const fromStatus = formatEventMetaValue(event.metadata?.from_status);
+              const toStatus = formatEventMetaValue(event.metadata?.to_status);
+              const fromPrinter = formatEventMetaValue(event.metadata?.from_printer_name);
+              const toPrinter = formatEventMetaValue(event.metadata?.to_printer_name);
+              return (
+                <div key={event.id} className="rounded-lg border border-border bg-background/40 p-4">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <p className="font-medium text-foreground">{event.title}</p>
+                      <p className="mt-1 text-sm text-muted-foreground">{event.description || '—'}</p>
+                    </div>
+                    <div className="text-xs text-muted-foreground sm:text-right">
+                      <p>{formatDateTime(event.created_at)}</p>
+                      <p>{event.actor_name || 'System'}</p>
+                    </div>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                    {jobNumber ? <span className="rounded-full bg-card px-2.5 py-1">Job {jobNumber}</span> : null}
+                    {fromStatus || toStatus ? <span className="rounded-full bg-card px-2.5 py-1">{fromStatus || '—'} → {toStatus || '—'}</span> : null}
+                    {fromPrinter || toPrinter ? <span className="rounded-full bg-card px-2.5 py-1">{fromPrinter || 'Unassigned'} → {toPrinter || 'Unassigned'}</span> : null}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
 
       <div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -43,6 +43,19 @@ export interface PrinterThumbnailInfo {
   size: number | null;
 }
 
+export interface PrinterHistoryEvent {
+  id: string;
+  printer_id: string;
+  job_id: string | null;
+  actor_user_id: string | null;
+  actor_name: string | null;
+  event_type: string;
+  title: string;
+  description: string | null;
+  metadata: Record<string, any> | null;
+  created_at: string | null;
+}
+
 export interface Printer {
   id: string;
   name: string;
@@ -68,6 +81,7 @@ export interface Printer {
   current_print_thumbnail_path: string | null;
   current_print_thumbnail_url: string | null;
   current_print_thumbnails: PrinterThumbnailInfo[];
+  history_events: PrinterHistoryEvent[];
   monitor_bed_temp_c: number | null;
   monitor_tool_temp_c: number | null;
   monitor_bed_target_c: number | null;


### PR DESCRIPTION
## Summary
- add persisted printer history events for status changes and job assignment changes
- capture actor/user when available for manual API-driven changes
- expose recent printer history on printer detail responses
- render recent printer activity on the printer detail page
- add focused backend coverage for history creation

## Testing
- .venv/bin/pytest backend/tests/test_api_printers.py backend/tests/test_api_jobs.py -q
- npm --prefix frontend run build

Closes #87