### PR TITLE
feat(pos): add backend checkout foundation (#65)

### DIFF
--- a/backend/app/api/v1/endpoints/pos.py
+++ b/backend/app/api/v1/endpoints/pos.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app.api.deps import DB, CurrentUser
+from app.api.v1.endpoints.sales import _to_sale_response
+from app.models.sale import Sale
+from app.schemas.sale import POSCheckoutCreate, SaleResponse
+from app.services.audit_service import create_audit_log
+from app.services.sales_service import create_sale_with_items, get_or_create_sales_channel
+
+POS_CHANNEL_NAME = "POS"
+
+router = APIRouter(prefix="/pos", tags=["Sales"])
+
+
+@router.post(
+    "/checkout",
+    response_model=SaleResponse,
+    status_code=201,
+    summary="Create a POS checkout sale",
+    description=(
+        "Creates a point-of-sale checkout using the standard sales tables and inventory path. "
+        "POS sales are identified by the dedicated POS sales channel and stored as normal sales."
+    ),
+)
+async def pos_checkout(body: POSCheckoutCreate, user: CurrentUser, db: DB):
+    channel = await get_or_create_sales_channel(db, name=POS_CHANNEL_NAME)
+
+    try:
+        sale = await create_sale_with_items(
+            db,
+            user_id=user.id,
+            date=body.date,
+            customer_id=body.customer_id,
+            customer_name=body.customer_name,
+            channel_id=channel.id,
+            tax_profile_id=body.tax_profile_id,
+            tax_treatment=body.tax_treatment,
+            shipping_charged=0,
+            shipping_cost=0,
+            tax_collected=body.tax_collected,
+            payment_method=body.payment_method,
+            tracking_number=None,
+            notes=body.notes,
+            status="paid",
+            items=body.items,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    await create_audit_log(
+        db,
+        actor_user_id=user.id,
+        entity_type="sale",
+        entity_id=str(sale.id),
+        action="pos_checkout",
+        after_snapshot={
+            "sale_number": sale.sale_number,
+            "status": sale.status,
+            "total": sale.total,
+            "customer_name": sale.customer_name,
+            "payment_method": sale.payment_method,
+            "channel": POS_CHANNEL_NAME,
+        },
+        reason=body.notes,
+    )
+    await db.commit()
+
+    result = await db.execute(
+        select(Sale).options(selectinload(Sale.items)).where(Sale.id == sale.id)
+    )
+    return _to_sale_response(result.scalar_one())

--- a/backend/app/api/v1/endpoints/sales.py
+++ b/backend/app/api/v1/endpoints/sales.py
@@ -17,6 +17,7 @@ from app.models.sales_channel import SalesChannel
 from app.models.tax_profile import TaxProfile
 from app.schemas.approval import RefundRequestBody
 from app.schemas.sale import (
+    POSCheckoutCreate,
     PaginatedSales,
     SaleCreate,
     SaleListResponse,
@@ -29,6 +30,7 @@ from app.services.accounting_service import AccountingValidationError, assert_fi
 from app.services.audit_service import create_audit_log, snapshot_model
 from app.services.sales_service import (
     compute_sale_totals,
+    create_sale_with_items,
     deduct_inventory_for_sale,
     generate_sale_number,
     restore_inventory_for_refund,
@@ -251,57 +253,27 @@ async def get_sale(sale_id: uuid.UUID, db: DB):
     description="Create a sale with line items. Platform fees are auto-computed from channel. Inventory is deducted for product items.",
 )
 async def create_sale(body: SaleCreate, user: CurrentUser, db: DB):
-    sale_number = await generate_sale_number(db)
-
-    items_data = [i.model_dump() for i in body.items]
-    totals = await compute_sale_totals(
-        db=db,
-        items=items_data,
-        channel_id=body.channel_id,
-        shipping_charged=body.shipping_charged,
-        shipping_cost=body.shipping_cost,
-        tax_collected=body.tax_collected,
-    )
-
-    sale = Sale(
-        sale_number=sale_number,
-        date=body.date,
-        customer_id=body.customer_id,
-        customer_name=body.customer_name,
-        channel_id=body.channel_id,
-        tax_profile_id=body.tax_profile_id,
-        tax_treatment=body.tax_treatment,
-        status=body.status.value,
-        shipping_charged=body.shipping_charged,
-        shipping_cost=body.shipping_cost,
-        tax_collected=body.tax_collected,
-        payment_method=body.payment_method,
-        tracking_number=body.tracking_number,
-        notes=body.notes,
-        created_by=user.id,
-        **totals,
-    )
-    db.add(sale)
-    await db.flush()
-
-    # Create line items
-    sale_items = []
-    for item_data in body.items:
-        sale_item = SaleItem(
-            sale_id=sale.id,
-            product_id=item_data.product_id,
-            job_id=item_data.job_id,
-            description=item_data.description,
-            quantity=item_data.quantity,
-            unit_price=item_data.unit_price,
-            line_total=item_data.unit_price * item_data.quantity,
-            unit_cost=item_data.unit_cost,
+    try:
+        sale = await create_sale_with_items(
+            db,
+            user_id=user.id,
+            date=body.date,
+            customer_id=body.customer_id,
+            customer_name=body.customer_name,
+            channel_id=body.channel_id,
+            tax_profile_id=body.tax_profile_id,
+            tax_treatment=body.tax_treatment,
+            shipping_charged=body.shipping_charged,
+            shipping_cost=body.shipping_cost,
+            tax_collected=body.tax_collected,
+            payment_method=body.payment_method,
+            tracking_number=body.tracking_number,
+            notes=body.notes,
+            status=body.status.value,
+            items=body.items,
         )
-        db.add(sale_item)
-        sale_items.append(sale_item)
-
-    # Deduct inventory
-    await deduct_inventory_for_sale(db, sale.id, sale_items, user.id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
     await create_audit_log(
         db,

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, audit, auth, customers, dashboard, inventory, invoices, jobs, materials, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, tax
+from app.api.v1.endpoints import accounting, approvals, audit, auth, customers, dashboard, inventory, invoices, jobs, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -19,6 +19,7 @@ api_router.include_router(invoices.router)
 api_router.include_router(inventory.router)
 api_router.include_router(sales_channels.router)
 api_router.include_router(sales.router)
+api_router.include_router(pos.router)
 api_router.include_router(settlements.router)
 api_router.include_router(reports.router)
 api_router.include_router(dashboard.router)

--- a/backend/app/schemas/sale.py
+++ b/backend/app/schemas/sale.py
@@ -100,6 +100,23 @@ class SaleResponse(BaseModel):
     created_at: datetime.datetime | None = None
     updated_at: datetime.datetime | None = None
 
+    model_config = {"from_attributes": True}
+
+
+class POSCheckoutCreate(BaseModel):
+    date: datetime.date = Field(..., examples=["2026-03-20"])
+    customer_id: uuid.UUID | None = None
+    customer_name: str | None = Field(None, max_length=200, examples=["Walk-up Customer"])
+    tax_profile_id: uuid.UUID | None = None
+    tax_treatment: str = Field(
+        "seller_collected",
+        pattern="^(seller_collected|marketplace_facilitated|non_taxable)$",
+    )
+    tax_collected: Decimal = Field(Decimal(0), ge=0, examples=[0])
+    payment_method: str = Field(..., min_length=1, max_length=50, examples=["cash"])
+    notes: str | None = Field(None, max_length=1000)
+    items: list[SaleItemCreate] = Field(..., min_length=1)
+
 
 class SaleListResponse(BaseModel):
     """Lightweight sale for list views (no items)."""

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -80,6 +80,7 @@ async def run_seed():
                 SalesChannel(name="Amazon Handmade", platform_fee_pct=Decimal("15"), fixed_fee=Decimal("0")),
                 SalesChannel(name="Direct Sale", platform_fee_pct=Decimal("0"), fixed_fee=Decimal("0")),
                 SalesChannel(name="Craft Fair", platform_fee_pct=Decimal("0"), fixed_fee=Decimal("0")),
+                SalesChannel(name="POS", platform_fee_pct=Decimal("0"), fixed_fee=Decimal("0")),
             ]
             for ch in channels:
                 db.add(ch)

--- a/backend/app/services/sales_service.py
+++ b/backend/app/services/sales_service.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.customer import Customer
 from app.models.sale import Sale
 from app.models.sale_item import SaleItem
 from app.models.sales_channel import SalesChannel
@@ -24,6 +25,122 @@ async def generate_sale_number(db: AsyncSession) -> str:
     )
     count = result.scalar() or 0
     return f"{prefix}{count + 1:04d}"
+
+
+async def get_or_create_sales_channel(
+    db: AsyncSession,
+    *,
+    name: str,
+    platform_fee_pct: Decimal = Decimal(0),
+    fixed_fee: Decimal = Decimal(0),
+) -> SalesChannel:
+    result = await db.execute(select(SalesChannel).where(SalesChannel.name == name))
+    channel = result.scalar_one_or_none()
+    if channel:
+        return channel
+
+    channel = SalesChannel(
+        name=name,
+        platform_fee_pct=platform_fee_pct,
+        fixed_fee=fixed_fee,
+    )
+    db.add(channel)
+    await db.flush()
+    return channel
+
+
+async def resolve_sale_customer(
+    db: AsyncSession,
+    *,
+    customer_id: uuid.UUID | None,
+    customer_name: str | None,
+) -> tuple[uuid.UUID | None, str | None]:
+    if not customer_id:
+        return None, customer_name
+
+    result = await db.execute(select(Customer).where(Customer.id == customer_id))
+    customer = result.scalar_one_or_none()
+    if not customer:
+        raise ValueError("Customer not found")
+
+    return customer.id, customer_name or customer.name
+
+
+async def create_sale_with_items(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID | None,
+    date,
+    customer_id: uuid.UUID | None,
+    customer_name: str | None,
+    channel_id: uuid.UUID | None,
+    tax_profile_id: uuid.UUID | None,
+    tax_treatment: str,
+    shipping_charged: Decimal,
+    shipping_cost: Decimal,
+    tax_collected: Decimal,
+    payment_method: str | None,
+    tracking_number: str | None,
+    notes: str | None,
+    status: str,
+    items: list,
+) -> Sale:
+    resolved_customer_id, resolved_customer_name = await resolve_sale_customer(
+        db,
+        customer_id=customer_id,
+        customer_name=customer_name,
+    )
+
+    sale_number = await generate_sale_number(db)
+    items_data = [i.model_dump() if hasattr(i, "model_dump") else i for i in items]
+    totals = await compute_sale_totals(
+        db=db,
+        items=items_data,
+        channel_id=channel_id,
+        shipping_charged=shipping_charged,
+        shipping_cost=shipping_cost,
+        tax_collected=tax_collected,
+    )
+
+    sale = Sale(
+        sale_number=sale_number,
+        date=date,
+        customer_id=resolved_customer_id,
+        customer_name=resolved_customer_name,
+        channel_id=channel_id,
+        tax_profile_id=tax_profile_id,
+        tax_treatment=tax_treatment,
+        status=status,
+        shipping_charged=shipping_charged,
+        shipping_cost=shipping_cost,
+        tax_collected=tax_collected,
+        payment_method=payment_method,
+        tracking_number=tracking_number,
+        notes=notes,
+        created_by=user_id,
+        **totals,
+    )
+    db.add(sale)
+    await db.flush()
+
+    sale_items = []
+    for item_data in items:
+        sale_item = SaleItem(
+            sale_id=sale.id,
+            product_id=item_data.product_id,
+            job_id=item_data.job_id,
+            description=item_data.description,
+            quantity=item_data.quantity,
+            unit_price=item_data.unit_price,
+            line_total=item_data.unit_price * item_data.quantity,
+            unit_cost=item_data.unit_cost,
+        )
+        db.add(sale_item)
+        sale_items.append(sale_item)
+
+    await deduct_inventory_for_sale(db, sale.id, sale_items, user_id)
+    await db.flush()
+    return sale
 
 
 async def compute_sale_totals(

--- a/backend/tests/test_api_pos.py
+++ b/backend/tests/test_api_pos.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.customer import Customer
+from app.models.product import Product
+from app.models.sale import Sale
+from app.models.sales_channel import SalesChannel
+
+
+@pytest_asyncio.fixture
+async def seed_pos_product(db_session: AsyncSession, seed_material) -> Product:
+    product = Product(
+        name="Desk Dragon",
+        sku="POS-DRAGON-001",
+        material_id=seed_material.id,
+        unit_price=Decimal("15.00"),
+        unit_cost=Decimal("6.00"),
+        stock_qty=5,
+    )
+    db_session.add(product)
+    await db_session.commit()
+    await db_session.refresh(product)
+    return product
+
+
+@pytest_asyncio.fixture
+async def seed_customer(db_session: AsyncSession) -> Customer:
+    customer = Customer(name="Morgan Buyer", email="morgan@example.com")
+    db_session.add(customer)
+    await db_session.commit()
+    await db_session.refresh(customer)
+    return customer
+
+
+def _payload(product_id, **overrides):
+    payload = {
+        "date": "2026-04-03",
+        "payment_method": "cash",
+        "items": [
+            {
+                "product_id": str(product_id),
+                "description": "Desk Dragon",
+                "quantity": 2,
+                "unit_price": 15,
+                "unit_cost": 6,
+            }
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_pos_checkout_guest_sale_uses_pos_channel_and_deducts_inventory(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    seed_pos_product: Product,
+):
+    resp = await client.post(
+        "/api/v1/pos/checkout",
+        headers=auth_headers,
+        json=_payload(seed_pos_product.id, customer_name="Walk-up Customer", notes="Booth checkout"),
+    )
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["status"] == "paid"
+    assert data["customer_id"] is None
+    assert data["customer_name"] == "Walk-up Customer"
+    assert data["payment_method"] == "cash"
+    assert float(data["total"]) == 30.0
+
+    sale = (
+        await db_session.execute(select(Sale).where(Sale.id == uuid.UUID(data["id"])))
+    ).scalar_one()
+    channel = (
+        await db_session.execute(select(SalesChannel).where(SalesChannel.id == sale.channel_id))
+    ).scalar_one()
+    assert channel.name == "POS"
+
+    product_resp = await client.get(f"/api/v1/products/{seed_pos_product.id}")
+    assert product_resp.status_code == 200
+    assert product_resp.json()["stock_qty"] == 3
+
+
+@pytest.mark.asyncio
+async def test_pos_checkout_customer_linked_sale_defaults_customer_name(
+    client: AsyncClient,
+    auth_headers: dict,
+    seed_pos_product: Product,
+    seed_customer: Customer,
+):
+    resp = await client.post(
+        "/api/v1/pos/checkout",
+        headers=auth_headers,
+        json=_payload(seed_pos_product.id, customer_id=str(seed_customer.id), payment_method="card"),
+    )
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["customer_id"] == str(seed_customer.id)
+    assert data["customer_name"] == seed_customer.name
+    assert data["payment_method"] == "card"
+    assert float(data["platform_fees"]) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_pos_checkout_rejects_unknown_customer(
+    client: AsyncClient,
+    auth_headers: dict,
+    seed_pos_product: Product,
+):
+    resp = await client.post(
+        "/api/v1/pos/checkout",
+        headers=auth_headers,
+        json=_payload(
+            seed_pos_product.id,
+            customer_id="00000000-0000-0000-0000-000000000000",
+        ),
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Customer not found"

--- a/backend/tests/test_api_sales.py
+++ b/backend/tests/test_api_sales.py
@@ -195,7 +195,11 @@ async def test_delete_sale(client: AsyncClient, auth_headers: dict):
 async def test_refund_sale(client: AsyncClient, auth_headers: dict):
     create_resp = await client.post("/api/v1/sales", headers=auth_headers, json=_sale_payload())
     sale_id = create_resp.json()["id"]
-    resp = await client.post(f"/api/v1/sales/{sale_id}/refund", headers=auth_headers)
+    resp = await client.post(
+        f"/api/v1/sales/{sale_id}/refund",
+        headers=auth_headers,
+        json={"reason": "Customer returned item"},
+    )
     assert resp.status_code == 200
     assert resp.json()["status"] == "refunded"
 
@@ -204,8 +208,16 @@ async def test_refund_sale(client: AsyncClient, auth_headers: dict):
 async def test_refund_already_refunded(client: AsyncClient, auth_headers: dict):
     create_resp = await client.post("/api/v1/sales", headers=auth_headers, json=_sale_payload())
     sale_id = create_resp.json()["id"]
-    await client.post(f"/api/v1/sales/{sale_id}/refund", headers=auth_headers)
-    resp = await client.post(f"/api/v1/sales/{sale_id}/refund", headers=auth_headers)
+    await client.post(
+        f"/api/v1/sales/{sale_id}/refund",
+        headers=auth_headers,
+        json={"reason": "Customer returned item"},
+    )
+    resp = await client.post(
+        f"/api/v1/sales/{sale_id}/refund",
+        headers=auth_headers,
+        json={"reason": "Duplicate refund attempt"},
+    )
     assert resp.status_code == 400
 
 


### PR DESCRIPTION
## Summary
- add a thin POS checkout endpoint at POST /api/v1/pos/checkout
- represent POS sales as normal sales + sale items using a dedicated POS sales channel
- extract shared sale creation logic into sales_service for reuse
- support guest and customer-linked checkout flows
- keep inventory deduction on the trusted existing sale path
- seed a POS sales channel for reporting/identification

## Testing
- .venv/bin/pytest backend/tests/test_api_pos.py backend/tests/test_api_sales.py -q

Closes #65