### PR TITLE
fix: harden secret handling for issue 130

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # Database
-DATABASE_URL=postgresql+asyncpg://printuser:replace-with-local-db-password@db:5432/printsales
+DATABASE_URL=postgresql+asyncpg://printuser:change-me-local-db-password@db:5432/printsales
 DB_USER=printuser
-DB_PASSWORD=replace-with-local-db-password
+DB_PASSWORD=change-me-local-db-password
 DB_NAME=printsales
 
 # Auth
-SECRET_KEY=replace-with-local-dev-secret-key
+SECRET_KEY=generate-a-random-local-secret-key
 ACCESS_TOKEN_EXPIRE_MINUTES=1440
 
 # App
@@ -16,7 +16,9 @@ BACKEND_CORS_ORIGINS=["http://localhost:5173","http://localhost:3000"]
 
 # Admin seed account
 ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=replace-with-local-admin-password
+ADMIN_PASSWORD=change-me-local-admin-password
+
+# The backend refuses to start while these placeholder secrets remain unchanged.
 
 # Rate limiting
 RATE_LIMIT_PER_MINUTE=120

--- a/.env.production.example
+++ b/.env.production.example
@@ -5,11 +5,11 @@
 
 # Database
 DB_USER=printuser
-DB_PASSWORD=replace-with-strong-db-password
+DB_PASSWORD=change-me-production-db-password
 DB_NAME=printsales
 
 # Backend auth/app secrets
-SECRET_KEY=replace-with-long-random-secret
+SECRET_KEY=generate-a-long-random-production-secret-key
 ACCESS_TOKEN_EXPIRE_MINUTES=1440
 
 # App environment
@@ -23,7 +23,9 @@ BACKEND_CORS_ORIGINS=["http://web01.bengtson.local"]
 
 # Admin seed account
 ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=replace-with-strong-admin-password
+ADMIN_PASSWORD=change-me-production-admin-password
+
+# The backend refuses to start while these placeholder secrets remain unchanged.
 
 # Rate limiting
 RATE_LIMIT_PER_MINUTE=60

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker compose -f docker-compose.prod.yml up -d --build
 
 ### Admin Seed Login
 
-The backend seeds an admin user from `ADMIN_EMAIL` and `ADMIN_PASSWORD`. Set those values in your local `.env` before first run instead of relying on a committed default password.
+The backend seeds an admin user from `ADMIN_EMAIL` and `ADMIN_PASSWORD`. Set those values in your local `.env` before first run. The backend now refuses to start while tracked placeholder secrets remain in place.
 
 ## Project Structure
 
@@ -239,14 +239,24 @@ See `.env.example` for all configuration options. Key variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DATABASE_URL` | `postgresql+asyncpg://...` | PostgreSQL connection string |
-| `SECRET_KEY` | `replace-with-...` | JWT signing key |
+| `SECRET_KEY` | `generate-a-random-...` | JWT signing key |
 | `ENVIRONMENT` | `development` | `development` / `staging` / `production` |
 | `ADMIN_EMAIL` | `admin@example.com` | Seed admin email |
-| `ADMIN_PASSWORD` | `replace-with-...` | Seed admin password |
+| `ADMIN_PASSWORD` | `change-me-...` | Seed admin password |
 | `RATE_LIMIT_PER_MINUTE` | `120` | API rate limit per IP |
 | `RATE_LIMIT_BURST` | `30` | Rate limit burst capacity |
 
-Generate distinct local development secrets for database and auth settings before using the app. Placeholder values in tracked files are intentionally non-production and should be replaced in your local environment.
+Generate distinct local development secrets for database and auth settings before using the app. Placeholder values in tracked files are intentionally unusable, and the backend will exit until `DATABASE_URL` or `DB_PASSWORD`, `SECRET_KEY`, and `ADMIN_PASSWORD` are replaced with real values.
+
+## Secret Scanning
+
+The repository includes a GitHub Actions secret scan in [`.github/workflows/secret-scan.yml`](./.github/workflows/secret-scan.yml) using `gitleaks`.
+
+Run the same check locally before publishing or opening large refactors:
+
+```bash
+gitleaks git --redact --verbose --no-banner
+```
 
 ## Finance Metric Naming
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,6 +3,21 @@ from urllib.parse import quote
 from pydantic_settings import BaseSettings
 
 
+PLACEHOLDER_MARKERS = (
+    "replace-with",
+    "change-me",
+    "generate-a-random",
+    "generate-a-long-random",
+)
+
+
+def _contains_placeholder(value: str | None) -> bool:
+    if not value:
+        return False
+    normalized = value.strip().lower()
+    return any(marker in normalized for marker in PLACEHOLDER_MARKERS)
+
+
 class Settings(BaseSettings):
     PROJECT_NAME: str = "3D Print Sales API"
     VERSION: str = "1.0.0"
@@ -10,16 +25,16 @@ class Settings(BaseSettings):
     ENVIRONMENT: str = "development"  # development | staging | production
     TESTING: bool = False
 
-    DATABASE_URL: str = "postgresql+asyncpg://printuser:replace-with-local-db-password@db:5432/printsales"
+    DATABASE_URL: str = "postgresql+asyncpg://printuser:change-me-local-db-password@db:5432/printsales"
     DB_USER: str = "printuser"
-    DB_PASSWORD: str = "replace-with-local-db-password"
+    DB_PASSWORD: str = "change-me-local-db-password"
     DB_NAME: str = "printsales"
     DB_HOST: str = "db"
     DB_PORT: int = 5432
 
     AUTO_CREATE_SCHEMA: bool = True
 
-    SECRET_KEY: str = "replace-with-local-dev-secret-key"
+    SECRET_KEY: str = "generate-a-random-local-secret-key"
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 1440
 
@@ -29,7 +44,7 @@ class Settings(BaseSettings):
     ]
 
     ADMIN_EMAIL: str = "admin@example.com"
-    ADMIN_PASSWORD: str = "replace-with-local-admin-password"
+    ADMIN_PASSWORD: str = "change-me-local-admin-password"
 
     # Rate limiting
     RATE_LIMIT_PER_MINUTE: int = 120
@@ -37,14 +52,17 @@ class Settings(BaseSettings):
 
     model_config = {"env_file": ".env", "case_sensitive": True}
 
+    def _require_real_value(self, field_name: str, value: str) -> None:
+        if _contains_placeholder(value):
+            raise ValueError(
+                f"{field_name} still contains a tracked placeholder value. "
+                "Replace it with a real secret before starting the app."
+            )
+
     def model_post_init(self, __context) -> None:
-        placeholder_markers = (
-            "replace-with-local-db-password",
-            "replace-with-strong-db-password",
-        )
         if (
             not self.DATABASE_URL
-            or any(marker in self.DATABASE_URL for marker in placeholder_markers)
+            or _contains_placeholder(self.DATABASE_URL)
         ):
             encoded_password = quote(self.DB_PASSWORD, safe="")
             self.DATABASE_URL = (
@@ -53,6 +71,11 @@ class Settings(BaseSettings):
 
         if self.ENVIRONMENT == "production" and not self.TESTING:
             self.AUTO_CREATE_SCHEMA = False
+
+        if not self.TESTING:
+            self._require_real_value("DATABASE_URL", self.DATABASE_URL)
+            self._require_real_value("SECRET_KEY", self.SECRET_KEY)
+            self._require_real_value("ADMIN_PASSWORD", self.ADMIN_PASSWORD)
 
 
 settings = Settings()

--- a/backend/tests/test_api_printers.py
+++ b/backend/tests/test_api_printers.py
@@ -193,6 +193,12 @@ async def test_printer_responses_do_not_expose_monitor_api_key(client: AsyncClie
     assert "monitor_api_key" not in detail_data
     assert detail_data["monitor_api_key_configured"] is True
 
+    listing = await client.get("/api/v1/printers")
+    assert listing.status_code == 200
+    list_item = next(item for item in listing.json()["items"] if item["id"] == printer_id)
+    assert "monitor_api_key" not in list_item
+    assert list_item["monitor_api_key_configured"] is True
+
 
 @pytest.mark.asyncio
 async def test_update_printer_can_clear_saved_monitor_api_key(client: AsyncClient, auth_headers: dict, db_session):

--- a/backend/tests/test_config_database_url.py
+++ b/backend/tests/test_config_database_url.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from app.core.config import Settings
 
 
@@ -7,12 +9,14 @@ def test_settings_builds_database_url_from_db_parts_when_placeholder_present():
     settings = Settings(
         ENVIRONMENT="production",
         TESTING=False,
-        DATABASE_URL="postgresql+asyncpg://printuser:replace-with-strong-db-password@db:5432/printsales",
+        DATABASE_URL="postgresql+asyncpg://printuser:change-me-production-db-password@db:5432/printsales",
         DB_USER="printuser",
         DB_PASSWORD="p@ss/with+symbols=ok",
         DB_NAME="printsales",
         DB_HOST="db",
         DB_PORT=5432,
+        SECRET_KEY="a-real-production-secret-key",
+        ADMIN_PASSWORD="a-real-production-admin-password",
     )
     assert settings.DATABASE_URL == "postgresql+asyncpg://printuser:p%40ss%2Fwith%2Bsymbols%3Dok@db:5432/printsales"
     assert settings.AUTO_CREATE_SCHEMA is False
@@ -28,6 +32,30 @@ def test_settings_preserves_explicit_database_url_outside_placeholder_case():
         DB_NAME="printsales",
         DB_HOST="db",
         DB_PORT=5432,
+        SECRET_KEY="a-real-development-secret-key",
+        ADMIN_PASSWORD="a-real-development-admin-password",
     )
     assert settings.DATABASE_URL == "postgresql+asyncpg://custom:secret@db:5432/customdb"
     assert settings.AUTO_CREATE_SCHEMA is True
+
+
+def test_settings_reject_placeholder_secret_key_when_not_testing():
+    with pytest.raises(ValueError, match="SECRET_KEY"):
+        Settings(
+            ENVIRONMENT="development",
+            TESTING=False,
+            DATABASE_URL="postgresql+asyncpg://custom:secret@db:5432/customdb",
+            SECRET_KEY="generate-a-random-local-secret-key",
+            ADMIN_PASSWORD="actually-secure-admin-password",
+        )
+
+
+def test_settings_reject_placeholder_admin_password_when_not_testing():
+    with pytest.raises(ValueError, match="ADMIN_PASSWORD"):
+        Settings(
+            ENVIRONMENT="development",
+            TESTING=False,
+            DATABASE_URL="postgresql+asyncpg://custom:secret@db:5432/customdb",
+            SECRET_KEY="a-real-secret-key",
+            ADMIN_PASSWORD="change-me-local-admin-password",
+        )

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,7 +6,7 @@ services:
     container_name: 3d-print-sales-db
     environment:
       POSTGRES_USER: ${DB_USER:-printuser}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-replace-with-strong-db-password}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-change-me-production-db-password}
       POSTGRES_DB: ${DB_NAME:-printsales}
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: postgres:16-alpine
     environment:
       POSTGRES_USER: ${DB_USER:-printuser}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-replace-with-local-db-password}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-change-me-local-db-password}
       POSTGRES_DB: ${DB_NAME:-printsales}
     ports:
       - "5432:5432"
@@ -22,12 +22,12 @@ services:
     ports:
       - "8000:8000"
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql+asyncpg://printuser:replace-with-local-db-password@db:5432/printsales}
-      SECRET_KEY: ${SECRET_KEY:-replace-with-local-dev-secret-key}
+      DATABASE_URL: ${DATABASE_URL:-postgresql+asyncpg://printuser:change-me-local-db-password@db:5432/printsales}
+      SECRET_KEY: ${SECRET_KEY:-generate-a-random-local-secret-key}
       ENVIRONMENT: development
       BACKEND_CORS_ORIGINS: '["http://localhost:5173","http://localhost:3000"]'
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
-      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-replace-with-local-admin-password}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-change-me-local-admin-password}
       RATE_LIMIT_PER_MINUTE: "120"
       RATE_LIMIT_BURST: "30"
     depends_on:

--- a/docs/deployment_web01_env_and_storage.md
+++ b/docs/deployment_web01_env_and_storage.md
@@ -61,6 +61,7 @@ If a dedicated deployment user is introduced later, ownership should be adjusted
 ## Required Secret / Config Values
 
 These values must be set with real production-safe values before deployment.
+The backend refuses to start if tracked placeholder secrets are still present.
 
 ### Database
 - `DB_USER`

--- a/frontend/src/pages/PrinterFormPage.tsx
+++ b/frontend/src/pages/PrinterFormPage.tsx
@@ -304,8 +304,8 @@ export default function PrinterFormPage() {
                   />
                   <p className="mt-1 text-xs text-muted-foreground">
                     {printer?.monitor_api_key_configured && isEdit
-                      ? 'A monitor key is already stored. Leave this blank to keep it, enter a new key to replace it, or clear the saved key below.'
-                      : selectedProvider.authHint}
+                      ? 'A monitor key is already stored as a write-only secret. Leave this blank to keep it, enter a new key to replace it, or clear the saved key below.'
+                      : `${selectedProvider.authHint} Stored keys are write-only and are never returned to the browser.`}
                   </p>
                   {isEdit && printer?.monitor_api_key_configured ? (
                     <label className="mt-3 inline-flex items-center gap-2 text-sm text-muted-foreground">


### PR DESCRIPTION
Closes #130

## Summary
- enforce real secrets for database/auth/admin settings outside test mode
- keep printer monitor keys explicitly write-only and document that behavior in the UI
- update env, compose, and deployment docs to match the hardened startup behavior

## Validation
- source .venv/bin/activate && python -m pytest backend/tests/test_config_database_url.py backend/tests/test_api_printers.py -q
- cd frontend && npm run build
- source .venv/bin/activate && python -m pytest backend/tests -q *(repo has unrelated pre-existing failures in accounting/approvals/invoices tests)*