### PR TITLE
ci: add application validation workflow for issue 132

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r backend/requirements.txt
+
+      - name: Run backend tests
+        run: python -m pytest backend/tests -q
+
+  frontend:
+    name: Frontend Validation
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Run frontend tests
+        run: npm test
+
+      - name: Build frontend
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Net Profit          = not yet exposed for sales reporting until overhead allocat
 - Use **Python 3.13** for local backend development and test execution.
 - A repo-level `.python-version` file is included to make the expected interpreter explicit.
 - Backend tests run with `TESTING=true`, which disables request rate limiting middleware so the suite does not fail with unrelated `429 Too Many Requests` responses.
+- GitHub Actions CI mirrors the repo baseline with `python -m pytest backend/tests -q`, `cd frontend && npm test`, and `cd frontend && npm run build`.
 
 ```bash
 # Run all backend tests
@@ -231,6 +232,17 @@ docker compose down
 docker compose down -v
 docker compose up -d
 ```
+
+## CI
+
+Baseline repository CI now lives in [`.github/workflows/ci.yml`](./.github/workflows/ci.yml).
+
+It runs on pull requests and pushes to `main` with separate jobs for:
+- backend tests via `python -m pytest backend/tests -q`
+- frontend tests via `cd frontend && npm test`
+- frontend build validation via `cd frontend && npm run build`
+
+Keep local validation aligned with those commands before opening or updating a PR.
 
 ## Environment Variables
 

--- a/backend/app/api/v1/endpoints/approvals.py
+++ b/backend/app/api/v1/endpoints/approvals.py
@@ -65,7 +65,12 @@ async def approve_request(approval_id: uuid.UUID, body: ApprovalDecisionBody, ad
             reason=request.reason,
         )
     elif request.action_type == "sale_refund":
-        sale = (await db.execute(select(Sale).options(selectinload(Sale.items)).where(Sale.id == request.request_payload["sale_id"]))).scalar_one_or_none()
+        sale_id = request.request_payload.get("sale_id")
+        try:
+            sale_uuid = uuid.UUID(str(sale_id))
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail="Approval request contains an invalid sale reference") from exc
+        sale = (await db.execute(select(Sale).options(selectinload(Sale.items)).where(Sale.id == sale_uuid))).scalar_one_or_none()
         if not sale:
             raise HTTPException(status_code=404, detail="Sale not found for approval execution")
         if sale.status != "refunded":

--- a/backend/tests/test_api_invoices.py
+++ b/backend/tests/test_api_invoices.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import date, timedelta
+
 import pytest
 
 
@@ -13,10 +15,12 @@ async def _seed_customer(client, auth_headers):
 
 
 def _invoice_payload(customer_id: str | None = None):
+    issue_date = date.today() + timedelta(days=1)
+    due_date = issue_date + timedelta(days=7)
     payload = {
         "invoice_number": "INV-2026-0001",
-        "issue_date": "2026-03-23",
-        "due_date": "2026-03-30",
+        "issue_date": issue_date.isoformat(),
+        "due_date": due_date.isoformat(),
         "customer_name": "Wholesale Buyer",
         "tax_amount": "5.00",
         "shipping_amount": "10.00",
@@ -34,8 +38,8 @@ def _invoice_payload(customer_id: str | None = None):
 def _quote_payload(material_id: str, customer_id: str | None = None):
     payload = {
         "quote_number": "Q-INV-0001",
-        "date": "2026-03-23",
-        "valid_until": "2026-04-06",
+        "date": date.today().isoformat(),
+        "valid_until": (date.today() + timedelta(days=14)).isoformat(),
         "customer_name": "Wholesale Buyer",
         "product_name": "Custom Bracket",
         "qty_per_plate": 2,
@@ -68,7 +72,7 @@ async def test_create_invoice_and_apply_partial_then_full_payment(client, auth_h
     partial = await client.post(
         f"/api/v1/invoices/{invoice['id']}/apply-payment",
         headers=auth_headers,
-        json={"amount": "40.00", "paid_at": "2026-03-24"},
+        json={"amount": "40.00", "paid_at": (date.today() + timedelta(days=2)).isoformat()},
     )
     assert partial.status_code == 200
     assert partial.json()["status"] == "partially_paid"
@@ -77,7 +81,7 @@ async def test_create_invoice_and_apply_partial_then_full_payment(client, auth_h
     full = await client.post(
         f"/api/v1/invoices/{invoice['id']}/apply-payment",
         headers=auth_headers,
-        json={"amount": "100.00", "paid_at": "2026-03-25"},
+        json={"amount": "100.00", "paid_at": (date.today() + timedelta(days=3)).isoformat()},
     )
     assert full.status_code == 200
     assert full.json()["status"] == "paid"
@@ -96,7 +100,7 @@ async def test_apply_credit_and_mark_invoice_paid(client, auth_headers):
         json={
             "customer_id": customer["id"],
             "invoice_id": invoice["id"],
-            "credit_date": "2026-03-24",
+            "credit_date": (date.today() + timedelta(days=2)).isoformat(),
             "amount": "15.00",
             "reason": "Adjustment",
         },
@@ -137,8 +141,8 @@ async def test_create_invoice_from_accepted_quote(client, auth_headers, seed_set
         headers=auth_headers,
         json={
             "invoice_number": "INV-QUOTE-0001",
-            "issue_date": "2026-03-23",
-            "due_date": "2026-03-31",
+            "issue_date": (date.today() + timedelta(days=1)).isoformat(),
+            "due_date": (date.today() + timedelta(days=8)).isoformat(),
             "tax_amount": "4.00",
             "status": "sent",
         },

--- a/backend/tests/test_inventory_scrap.py
+++ b/backend/tests/test_inventory_scrap.py
@@ -16,6 +16,7 @@ from app.services.inventory_service import record_scrap_inventory
 async def scrap_material(db_session: AsyncSession) -> Material:
     material = Material(
         name="PLA Gray",
+        brand="Generic",
         cost_per_g=Decimal("0.025"),
         spool_weight_g=1000,
         spool_price=Decimal("25.00"),


### PR DESCRIPTION
Closes #132

## Summary
- add a GitHub Actions CI workflow for backend tests and frontend validation
- document the CI baseline in the README
- fix the current backend test blockers so the CI workflow lands green

## Validation
- source .venv/bin/activate && python -m pytest backend/tests -q
- cd frontend && npm test
- cd frontend && npm run build