### PR TITLE
feat: add POS barcode scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ All endpoints are under `/api/v1`. Rate limited at 120 requests/minute per IP.
 | **Products** | Full CRUD at `/products` | `?is_active`, `?material_id`, `?low_stock`, `?search`, pagination |
 | **Inventory** | `GET/POST /inventory/transactions`, `GET /inventory/alerts` | `?product_id`, `?type`, pagination |
 | **Sales Channels** | Full CRUD at `/sales/channels` | `?is_active` |
-| **Sales** | Full CRUD at `/sales`, `GET /sales/metrics`, `POST /sales/{id}/refund`, `POST /pos/checkout` | `?status`, `?channel_id`, `?payment_method`, `?customer_id`, `?date_from`, `?date_to`, `?search`, pagination |
+| **Sales** | Full CRUD at `/sales`, `GET /sales/metrics`, `POST /sales/{id}/refund`, `POST /pos/checkout`, `POST /pos/scan/resolve` | `?status`, `?channel_id`, `?payment_method`, `?customer_id`, `?date_from`, `?date_to`, `?search`, pagination |
 | **Reports** | `GET /reports/inventory`, `/reports/sales`, `/reports/pl` + CSV variants | `?date_from`, `?date_to`, `?channel_id`, `?payment_method`, `?period` (daily/weekly/monthly/yearly) |
 | **Dashboard** | `GET /dashboard/summary`, `/charts/revenue`, `/charts/materials`, `/charts/profit-margins` | `?date_from`, `?date_to` |
 
@@ -155,7 +155,7 @@ Net Profit          = not yet exposed for sales reporting until overhead allocat
 - **Product Detail** — Product info with margin, inventory value, transaction history, stock adjustment
 - **Sales** — Sales list with search, status/channel filters, pagination; sale detail with line items, gross profit + contribution margin breakdown, status management, refund
 - **Sales** — Sales list with search, status/channel/payment-method filters, pagination; sale detail with line items, payment method, gross profit + contribution margin breakdown, status management, refund
-- **POS** — Dedicated `/pos` cashier page with searchable product catalog, touch-friendly cart controls, guest or attached customer checkout, tax entry, and success reset flow
+- **POS** — Dedicated `/pos` cashier page with searchable product catalog, keyboard-wedge barcode scanning by product UPC, touch-friendly cart controls, guest or attached customer checkout, tax entry, and success reset flow
 - **New Sale** — Sale creation form with customer autocomplete, channel select, product-linked line items, shipping/tax, live total
 - **Sales Channels** — CRUD for sales platforms (Etsy, Amazon, etc.) with platform fee and fixed fee configuration
 - **Reports** — Tab-based sub-navigation (Inventory, Sales, P&L) with shared date range/period controls and CSV export
@@ -216,6 +216,7 @@ Notes:
 - `npm test` runs the Vitest frontend suite, including POS cashier workflow coverage.
 - Frontend routes are lazy-loaded and chart-heavy dependencies are split into separate build chunks to keep the initial bundle healthier.
 - `frontend/package.json` may use `overrides` to pin patched transitive dependencies when upstream toolchain ranges lag behind published security fixes.
+- Barcode scanning for POS is documented in [docs/pos_barcode_scanning.md](docs/pos_barcode_scanning.md).
 
 ```bash
 # Rebuild after dependency changes

--- a/backend/app/api/v1/endpoints/pos.py
+++ b/backend/app/api/v1/endpoints/pos.py
@@ -7,8 +7,10 @@ from sqlalchemy.orm import selectinload
 from app.api.deps import DB, CurrentUser
 from app.api.v1.endpoints.sales import _to_sale_response
 from app.models.sale import Sale
+from app.schemas.product import POSProductScanRequest, ProductResponse
 from app.schemas.sale import POSCheckoutCreate, SaleResponse
 from app.services.audit_service import create_audit_log
+from app.services.pos_service import POSBarcodeResolutionError, resolve_pos_barcode_scan
 from app.services.sales_service import (
     InsufficientStockError,
     create_sale_with_items,
@@ -18,6 +20,25 @@ from app.services.sales_service import (
 POS_CHANNEL_NAME = "POS"
 
 router = APIRouter(prefix="/pos", tags=["Sales"])
+
+
+@router.post(
+    "/scan/resolve",
+    response_model=ProductResponse,
+    summary="Resolve a barcode scan for POS",
+    description=(
+        "Resolves an exact UPC/barcode match into a sellable active product for keyboard-wedge POS scanners. "
+        "Returns a conflict for duplicates, inactive products, or out-of-stock products."
+    ),
+)
+async def resolve_scan(body: POSProductScanRequest, user: CurrentUser, db: DB):
+    try:
+        result = await resolve_pos_barcode_scan(db, code=body.code)
+    except POSBarcodeResolutionError as exc:
+        detail = str(exc)
+        status_code = 404 if detail.startswith("No active product matches") else 409
+        raise HTTPException(status_code=status_code, detail=detail) from exc
+    return result.product
 
 
 @router.post(

--- a/backend/app/api/v1/endpoints/products.py
+++ b/backend/app/api/v1/endpoints/products.py
@@ -29,7 +29,7 @@ async def list_products(
     is_active: bool | None = Query(None, description="Filter by active status"),
     material_id: uuid.UUID | None = Query(None, description="Filter by material ID"),
     low_stock: bool | None = Query(None, description="Filter products below reorder point"),
-    search: str | None = Query(None, description="Search by name or SKU"),
+    search: str | None = Query(None, description="Search by name, SKU, or UPC"),
     skip: int = Query(0, ge=0, description="Number of records to skip"),
     limit: int = Query(50, ge=1, le=100, description="Max records to return"),
 ):
@@ -43,7 +43,7 @@ async def list_products(
     if search:
         pattern = f"%{search}%"
         base = base.where(
-            Product.name.ilike(pattern) | Product.sku.ilike(pattern)
+            Product.name.ilike(pattern) | Product.sku.ilike(pattern) | Product.upc.ilike(pattern)
         )
 
     count_stmt = select(func.count()).select_from(base.subquery())
@@ -77,6 +77,10 @@ async def get_product(product_id: uuid.UUID, db: DB):
     description="Create a new product in the catalog. SKU is auto-generated in format PRD-{MATERIAL}-{NNNN}.",
 )
 async def create_product(body: ProductCreate, user: CurrentUser, db: DB):
+    if body.upc:
+        existing_upc = await db.execute(select(Product.id).where(Product.upc == body.upc))
+        if existing_upc.scalar_one_or_none():
+            raise HTTPException(status_code=409, detail=f"UPC '{body.upc}' is already assigned to another product")
     sku = await generate_sku(db, body.material_id)
     product = Product(**body.model_dump(), sku=sku)
     db.add(product)
@@ -98,6 +102,13 @@ async def update_product(product_id: uuid.UUID, body: ProductUpdate, user: Curre
         raise HTTPException(status_code=404, detail="Product not found")
 
     update_data = body.model_dump(exclude_unset=True)
+
+    if "upc" in update_data and update_data["upc"]:
+        existing_upc = await db.execute(
+            select(Product.id).where(Product.id != product_id, Product.upc == update_data["upc"])
+        )
+        if existing_upc.scalar_one_or_none():
+            raise HTTPException(status_code=409, detail=f"UPC '{update_data['upc']}' is already assigned to another product")
 
     # If material changed, regenerate SKU
     if "material_id" in update_data and update_data["material_id"] != product.material_id:

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -50,6 +50,10 @@ class ProductResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class POSProductScanRequest(BaseModel):
+    code: str = Field(..., min_length=1, max_length=64, examples=["012345678901"])
+
+
 class PaginatedProducts(BaseModel):
     items: list[ProductResponse]
     total: int

--- a/backend/app/services/pos_service.py
+++ b/backend/app/services/pos_service.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.product import Product
+
+
+class POSBarcodeResolutionError(Exception):
+    """Raised when a barcode scan cannot be resolved into a sellable product."""
+
+
+@dataclass
+class POSBarcodeResolutionResult:
+    product: Product
+
+
+async def resolve_pos_barcode_scan(
+    db: AsyncSession,
+    *,
+    code: str,
+) -> POSBarcodeResolutionResult:
+    normalized_code = code.strip()
+    if not normalized_code:
+        raise POSBarcodeResolutionError("Scan code is required")
+
+    result = await db.execute(select(Product).where(Product.upc == normalized_code))
+    matches = result.scalars().all()
+
+    if not matches:
+        raise POSBarcodeResolutionError(f"No active product matches barcode '{normalized_code}'")
+
+    active_matches = [product for product in matches if product.is_active]
+    if len(active_matches) > 1:
+        raise POSBarcodeResolutionError(
+            f"Barcode '{normalized_code}' matches multiple active products. Resolve the duplicate UPC before scanning."
+        )
+
+    if not active_matches:
+        if len(matches) == 1:
+            raise POSBarcodeResolutionError(
+                f"Barcode '{normalized_code}' belongs to an inactive product. Reactivate it or assign a different barcode."
+            )
+        raise POSBarcodeResolutionError(
+            f"Barcode '{normalized_code}' does not map to a sellable active product."
+        )
+
+    product = active_matches[0]
+    if product.stock_qty <= 0:
+        raise POSBarcodeResolutionError(
+            f"{product.name} is out of stock and cannot be added from barcode scan."
+        )
+
+    return POSBarcodeResolutionResult(product=product)

--- a/backend/tests/test_api_pos.py
+++ b/backend/tests/test_api_pos.py
@@ -76,6 +76,33 @@ def _payload(product_id, **overrides):
     return payload
 
 
+async def _create_scannable_product(
+    db_session: AsyncSession,
+    *,
+    material_id,
+    sku: str,
+    name: str,
+    upc: str,
+    stock_qty: int = 5,
+    is_active: bool = True,
+) -> Product:
+    product = Product(
+        sku=sku,
+        name=name,
+        material_id=material_id,
+        unit_price=10,
+        unit_cost=4,
+        stock_qty=stock_qty,
+        reorder_point=1,
+        is_active=is_active,
+        upc=upc,
+    )
+    db_session.add(product)
+    await db_session.commit()
+    await db_session.refresh(product)
+    return product
+
+
 @pytest.mark.asyncio
 async def test_pos_checkout_guest_sale_uses_pos_channel_and_deducts_inventory(
     client: AsyncClient,
@@ -248,3 +275,57 @@ async def test_pos_refund_restores_inventory_for_pos_sale(
     product_resp = await client.get(f"/api/v1/products/{seed_pos_product.id}")
     assert product_resp.status_code == 200
     assert product_resp.json()["stock_qty"] == 5
+
+
+@pytest.mark.asyncio
+async def test_pos_scan_resolves_active_product(client: AsyncClient, auth_headers: dict, db_session: AsyncSession, seed_material):
+    product = await _create_scannable_product(
+        db_session,
+        material_id=seed_material.id,
+        sku="PRD-PLA-9001",
+        name="Desk Dragon",
+        upc="012345678901",
+    )
+
+    resp = await client.post("/api/v1/pos/scan/resolve", headers=auth_headers, json={"code": "012345678901"})
+    assert resp.status_code == 200
+    assert resp.json()["id"] == str(product.id)
+    assert resp.json()["name"] == "Desk Dragon"
+
+
+@pytest.mark.asyncio
+async def test_pos_scan_rejects_unknown_barcode(client: AsyncClient, auth_headers: dict):
+    resp = await client.post("/api/v1/pos/scan/resolve", headers=auth_headers, json={"code": "000000000000"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_pos_scan_rejects_inactive_product(client: AsyncClient, auth_headers: dict, db_session: AsyncSession, seed_material):
+    await _create_scannable_product(
+        db_session,
+        material_id=seed_material.id,
+        sku="PRD-PLA-9002",
+        name="Inactive Dragon",
+        upc="123450000000",
+        is_active=False,
+    )
+
+    resp = await client.post("/api/v1/pos/scan/resolve", headers=auth_headers, json={"code": "123450000000"})
+    assert resp.status_code == 409
+    assert "inactive product" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_pos_scan_rejects_out_of_stock_product(client: AsyncClient, auth_headers: dict, db_session: AsyncSession, seed_material):
+    await _create_scannable_product(
+        db_session,
+        material_id=seed_material.id,
+        sku="PRD-PLA-9003",
+        name="Sold Out Dragon",
+        upc="999990000000",
+        stock_qty=0,
+    )
+
+    resp = await client.post("/api/v1/pos/scan/resolve", headers=auth_headers, json={"code": "999990000000"})
+    assert resp.status_code == 409
+    assert "out of stock" in resp.json()["detail"].lower()

--- a/backend/tests/test_api_products.py
+++ b/backend/tests/test_api_products.py
@@ -72,6 +72,18 @@ async def test_list_products_search(client: AsyncClient, auth_headers: dict, see
 
 
 @pytest.mark.asyncio
+async def test_list_products_search_matches_upc(client: AsyncClient, auth_headers: dict, seed_material: Material):
+    await client.post(
+        "/api/v1/products",
+        headers=auth_headers,
+        json={"name": "Scannable Widget", "material_id": str(seed_material.id), "upc": "012345678901"},
+    )
+    resp = await client.get("/api/v1/products", params={"search": "012345678901"})
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1
+
+
+@pytest.mark.asyncio
 async def test_get_product(client: AsyncClient, auth_headers: dict, seed_material: Material):
     create_resp = await client.post(
         "/api/v1/products",
@@ -106,6 +118,42 @@ async def test_update_product(client: AsyncClient, auth_headers: dict, seed_mate
     assert resp.status_code == 200
     assert resp.json()["name"] == "Updated Name"
     assert float(resp.json()["unit_price"]) == 12.50
+
+
+@pytest.mark.asyncio
+async def test_create_product_rejects_duplicate_upc(client: AsyncClient, auth_headers: dict, seed_material: Material):
+    payload = {"name": "Barcode Product A", "material_id": str(seed_material.id), "upc": "012345678901"}
+    first = await client.post("/api/v1/products", headers=auth_headers, json=payload)
+    assert first.status_code == 201
+
+    dup = await client.post(
+        "/api/v1/products",
+        headers=auth_headers,
+        json={"name": "Barcode Product B", "material_id": str(seed_material.id), "upc": "012345678901"},
+    )
+    assert dup.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_update_product_rejects_duplicate_upc(client: AsyncClient, auth_headers: dict, seed_material: Material):
+    first = await client.post(
+        "/api/v1/products",
+        headers=auth_headers,
+        json={"name": "Barcode Product A", "material_id": str(seed_material.id), "upc": "012345678901"},
+    )
+    second = await client.post(
+        "/api/v1/products",
+        headers=auth_headers,
+        json={"name": "Barcode Product B", "material_id": str(seed_material.id), "upc": "999999999999"},
+    )
+    product_id = second.json()["id"]
+
+    resp = await client.put(
+        f"/api/v1/products/{product_id}",
+        headers=auth_headers,
+        json={"upc": "012345678901"},
+    )
+    assert resp.status_code == 409
 
 
 @pytest.mark.asyncio

--- a/docs/pos_barcode_scanning.md
+++ b/docs/pos_barcode_scanning.md
@@ -1,0 +1,71 @@
+# POS Barcode Scanning
+
+Issue: `#123`
+
+## Purpose
+
+The POS cashier flow supports remote-compatible barcode scanners that behave like a keyboard and end each scan with `Enter`.
+
+This implementation is intentionally narrow:
+
+- it uses the existing product `upc` field
+- it resolves exact UPC matches only
+- it supports keyboard-wedge scanners, including scanners connected through remote desktop or browser-based remote sessions
+- it adds the scanned product to the POS cart without routing through the general sales form
+
+## Operator Workflow
+
+1. Open the POS page at `/pos`.
+2. Scan into the `Barcode Scan` field, or scan while focus is outside other form controls.
+3. The app sends the scanned code to `POST /api/v1/pos/scan/resolve`.
+4. If one sellable product matches, that product is added to the cart.
+5. Complete checkout using the existing POS checkout flow.
+
+## Product Requirements
+
+Each scannable product must have:
+
+- a populated `upc`
+- `is_active = true`
+- `stock_qty > 0`
+
+The products API now also:
+
+- searches by UPC in the main product list search
+- rejects duplicate UPC assignment during create and update with `409 Conflict`
+
+## Error Behavior
+
+Barcode resolution fails when:
+
+- no product matches the scanned code
+- the code maps only to an inactive product
+- the resolved product is out of stock
+- duplicate active products share the same UPC
+
+The POS UI shows the failure inline in the scan panel and leaves the cart unchanged.
+
+## API Surface
+
+- `POST /api/v1/pos/scan/resolve`
+  - request: `{ "code": "012345678901" }`
+  - response: standard `ProductResponse`
+  - `404`: no active product matches the code
+  - `409`: duplicate, inactive, or out-of-stock conflict
+
+## Validation
+
+Backend:
+
+```bash
+source .venv/bin/activate
+python -m pytest backend/tests/test_api_products.py backend/tests/test_api_pos.py -q
+```
+
+Frontend:
+
+```bash
+cd frontend
+npm test
+npm run build
+```

--- a/frontend/src/pages/POSPage.test.tsx
+++ b/frontend/src/pages/POSPage.test.tsx
@@ -199,4 +199,44 @@ describe('POSPage', () => {
       'Insufficient stock for POS checkout: Desk Dragon only has 1 available'
     );
   });
+
+  it('adds a product from the barcode scan lane', async () => {
+    const user = userEvent.setup();
+    apiPost.mockImplementation((url: string, payload?: unknown) => {
+      if (url === '/pos/scan/resolve') {
+        expect(payload).toEqual({ code: '012345678901' });
+        return Promise.resolve({ data: productsResponse.items[0] });
+      }
+      return Promise.reject(new Error(`Unexpected POST ${url}`));
+    });
+
+    renderPOSPage();
+
+    await screen.findByText('Desk Dragon');
+    await user.type(screen.getByLabelText('Scan barcode'), '012345678901{enter}');
+
+    expect(await screen.findByText('Scanned Desk Dragon (POS-DRAGON-001)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Desk Dragon quantity')).toHaveTextContent('1');
+    expect(toastSuccess).toHaveBeenCalledWith('Scanned Desk Dragon');
+  });
+
+  it('shows barcode scan errors without mutating the cart', async () => {
+    const user = userEvent.setup();
+    apiPost.mockRejectedValue({
+      response: {
+        data: {
+          detail: "No active product matches barcode '000000000000'",
+        },
+      },
+    });
+
+    renderPOSPage();
+
+    await screen.findByText('Desk Dragon');
+    await user.type(screen.getByLabelText('Scan barcode'), '000000000000{enter}');
+
+    expect(await screen.findByText("No active product matches barcode '000000000000'")).toBeInTheDocument();
+    expect(screen.getByText('Cart is empty')).toBeInTheDocument();
+    expect(toastError).toHaveBeenCalledWith("No active product matches barcode '000000000000'");
+  });
 });

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useState } from 'react';
+import { useDeferredValue, useEffect, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { AlertTriangle, Minus, Plus, Receipt, Search, ShoppingBasket, Trash2, UserRound, XCircle } from 'lucide-react';
 import { toast } from 'sonner';
@@ -71,7 +71,11 @@ export default function POSPage() {
   const [saving, setSaving] = useState(false);
   const [checkoutError, setCheckoutError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [scanCode, setScanCode] = useState('');
+  const [scanStatus, setScanStatus] = useState<string | null>(null);
   const deferredSearch = useDeferredValue(search);
+  const scanBufferRef = useRef('');
+  const scanTimeoutRef = useRef<number | null>(null);
 
   const { data: productsData, isLoading: productsLoading, isError: productsError } = useQuery<PaginatedProducts>({
     queryKey: ['products', 'pos'],
@@ -133,8 +137,79 @@ export default function POSPage() {
   const handleAddProduct = (product: Product) => {
     setSuccessMessage(null);
     setCheckoutError(null);
+    setScanStatus(null);
     setCart((prev) => addProductToCart(prev, product));
   };
+
+  const handleResolveScan = async (code: string) => {
+    const normalizedCode = code.trim();
+    if (!normalizedCode) return;
+
+    setCheckoutError(null);
+    setSuccessMessage(null);
+    setScanStatus(null);
+
+    try {
+      const response = await api.post<Product>('/pos/scan/resolve', { code: normalizedCode });
+      const product = response.data;
+      setCart((prev) => addProductToCart(prev, product));
+      setScanStatus(`Scanned ${product.name} (${product.sku})`);
+      toast.success(`Scanned ${product.name}`);
+      setScanCode('');
+    } catch (error: unknown) {
+      const detail = getErrorDetail(error);
+      setScanStatus(detail);
+      toast.error(detail);
+    }
+  };
+
+  useEffect(() => {
+    const clearBuffer = () => {
+      scanBufferRef.current = '';
+      if (scanTimeoutRef.current) {
+        window.clearTimeout(scanTimeoutRef.current);
+        scanTimeoutRef.current = null;
+      }
+    };
+
+    const isEditableTarget = (target: EventTarget | null) =>
+      target instanceof HTMLElement &&
+      (target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable);
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isEditableTarget(event.target)) return;
+
+      if (event.key === 'Enter') {
+        if (scanBufferRef.current.length >= 8) {
+          event.preventDefault();
+          void handleResolveScan(scanBufferRef.current);
+        }
+        clearBuffer();
+        return;
+      }
+
+      if (event.key.length !== 1 || event.ctrlKey || event.metaKey || event.altKey) {
+        return;
+      }
+
+      scanBufferRef.current += event.key;
+      if (scanTimeoutRef.current) {
+        window.clearTimeout(scanTimeoutRef.current);
+      }
+      scanTimeoutRef.current = window.setTimeout(() => {
+        clearBuffer();
+      }, 150);
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      clearBuffer();
+    };
+  }, []);
 
   const handleCheckout = async () => {
     if (!cart.length) {
@@ -230,7 +305,7 @@ export default function POSPage() {
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
               <div>
                 <h2 className="text-xl font-semibold">Product Catalog</h2>
-                <p className="text-sm text-muted-foreground">Search by name, SKU, or UPC and tap products into the cart.</p>
+                <p className="text-sm text-muted-foreground">Search by name, SKU, or UPC and keep scanner traffic in the dedicated scan lane below.</p>
               </div>
               <div className="relative w-full md:max-w-sm">
                 <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -243,6 +318,48 @@ export default function POSPage() {
                 />
               </div>
             </div>
+          </div>
+
+          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold">Barcode Scan</h2>
+                <p className="text-sm text-muted-foreground">
+                  Supports keyboard-wedge scanners using the product UPC field. Scan into this field or scan while focus is outside form inputs.
+                </p>
+              </div>
+              <div className="w-full md:max-w-sm">
+                <label className="mb-1 block text-sm font-medium" htmlFor="pos-scan-code">
+                  Scan barcode
+                </label>
+                <form
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void handleResolveScan(scanCode);
+                  }}
+                >
+                  <input
+                    id="pos-scan-code"
+                    value={scanCode}
+                    onChange={(e) => setScanCode(e.target.value)}
+                    placeholder="Scan UPC and press Enter"
+                    aria-label="Scan barcode"
+                    className="w-full rounded-xl border border-input bg-background px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                </form>
+              </div>
+            </div>
+
+            {scanStatus ? (
+              <div className={cn(
+                'mt-4 rounded-2xl border px-4 py-3 text-sm',
+                scanStatus.startsWith('Scanned ')
+                  ? 'border-emerald-300 bg-emerald-50 text-emerald-900'
+                  : 'border-amber-300 bg-amber-50 text-amber-900'
+              )}>
+                {scanStatus}
+              </div>
+            ) : null}
           </div>
 
           {productsLoading ? (
@@ -286,6 +403,11 @@ export default function POSPage() {
                           <p className="shrink-0 font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
                             {product.sku}
                           </p>
+                          {product.upc ? (
+                            <p className="shrink-0 text-xs uppercase tracking-[0.15em] text-muted-foreground">
+                              UPC {product.upc}
+                            </p>
+                          ) : null}
                           <h3 className="min-w-0 flex-1 truncate text-base font-semibold leading-tight">
                             {product.name}
                           </h3>


### PR DESCRIPTION
Implements #123.

## Summary
- add POS barcode resolution endpoint and service for exact UPC scans
- extend products search and duplicate UPC validation
- add POS scan lane UI and tests for scanner-driven cart adds
- document the keyboard-wedge barcode workflow

## Validation
- source .venv/bin/activate && python -m pytest backend/tests/test_api_products.py backend/tests/test_api_pos.py -q
- source .venv/bin/activate && python -m pytest backend/tests -q
- cd frontend && npm test
- cd frontend && npm run build