### PR TITLE
feat: redesign frontend into role-based workspaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# Claude Code Configuration
+
+## Primary Working Guide
+
+**Read and follow `agents.md` in the repo root.** It is the authoritative source for:
+- Repository map and architecture
+- Working rules and collaboration style
+- Validation commands and expected change patterns
+- UX laws for frontend work
+- Documentation standards
+- Commit, PR, and deployment guidelines
+- Known risks and operational sensitivities
+
+## Quick Reference
+
+### Validation Commands
+- Backend tests: `python3 -m pytest backend/tests -q`
+- Frontend build: `cd frontend && npm run build`
+
+### Key Rules
+- Treat GitHub issues as the source of truth for all work.
+- Keep API, schema, model, and frontend type changes in sync.
+- Prefer service-layer changes over business logic in route handlers or React components.
+- Inventory, accounting, sales, and printer monitoring are operationally sensitive — inspect existing tests first.
+- Every completed task includes explicit validation and documentation updates.
+- When creating issues, use plan mode and produce detailed, actionable user stories.
+- Default to test-driven development when practical.
+- Ask clarifying questions when requirements are materially ambiguous.
+
+### Deployment
+- Live host: `root@web01.bengtson.local`
+- App root: `/srv/3d-print-sales`
+- Deploy: `scripts/web01-compose.sh up -d --build` or `/srv/3d-print-sales/deploy.sh`
+- Post-deploy checks: container health, `curl /health`, `curl /`, review logs if relevant.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Full-stack web application for managing a 3D printing business — job costing, 
 | Layer | Technology |
 |-------|-----------|
 | **Backend** | Python 3.13, FastAPI, SQLAlchemy 2 (async), PostgreSQL 16 |
-| **Frontend** | React 18, TypeScript, Vite, Tailwind CSS, TanStack Query |
+| **Frontend** | React 19, TypeScript, Vite, Tailwind CSS 4, TanStack Query, Zustand |
 | **Auth** | JWT (python-jose) + bcrypt |
 | **API Docs** | OpenAPI 3.1 / Swagger UI |
 | **Infrastructure** | Docker Compose, multi-stage builds, nginx (production) |
@@ -134,6 +134,7 @@ Net Profit          = not yet exposed for sales reporting until overhead allocat
 
 - **Protected Routes** — Auto-redirect to login, preserves original URL
 - **Dark/Light Theme** — Persisted to localStorage, respects system preference
+- **Workspace Shell** — Role-aware workspace navigation for Control Center, Print Floor, Sell, Stock, Product Studio, Orders, Insights, and Admin while preserving legacy deep links
 - **Active Navigation** — Current route highlighted, admin-only items
 - **Error Boundary** — Global error catch with reload action
 - **Empty States** — Contextual illustrations and CTA buttons on empty lists
@@ -146,16 +147,20 @@ Net Profit          = not yet exposed for sales reporting until overhead allocat
 
 ### Pages
 
-- **Dashboard** — Summary cards + 3 charts (revenue line, material pie, profit bar) + low-stock alerts + sales metrics (orders, gross sales, item COGS, gross profit, contribution margin) + revenue by channel chart
-- **Jobs** — List with search, status filter, pagination; detail with cost breakdown; create/edit with live cost preview
+- **Control Center** — Role-aware landing workspace with urgent printer, stock, sales, finance, and draft-job priorities plus quick actions into the main operational areas
+- **Print Floor** — Dedicated printer wall with grouped machine states, queue-pressure and utilization signals, reduced-chrome wall mode via `/print-floor?mode=wall`, console-style printer detail pages for live monitoring, and a defined camera-tile integration path for issue `#129`
+- **Stock** — Exceptions-first inventory workspace at `/stock` with product-impacting low-stock triage, quick reconcile/adjust actions, material signals separated from finished-goods alerts, and the full ledger preserved as a secondary surface
+- **Orders** — Unified queue workspace at `/orders` that stitches production jobs, fulfillment-relevant sales, printer readiness, and customer load into one operational surface while preserving the existing jobs and sales detail flows
+- **Dashboard** — Classic metrics view with summary cards + 3 charts (revenue line, material pie, profit bar) + low-stock alerts + sales metrics (orders, gross sales, item COGS, gross profit, contribution margin) + revenue by channel chart
+- **Jobs** — List with search, status filter, pagination; detail with cost breakdown; create/edit with live cost preview, now reachable inside the Orders workspace at `/orders/jobs`
 - **Materials** — Full CRUD with modal, cost-per-gram preview, active/inactive toggle, mobile card layout
 - **Rates** — Full CRUD with modal, unit dropdown, active/inactive toggle, mobile card layout
 - **Customers** — Full CRUD with modal, search, delete, job count
-- **Products** — Product catalog with CRUD modal, SKU/UPC, stock tracking, reorder alerts, search, pagination
-- **Product Detail** — Product info with margin, inventory value, transaction history, stock adjustment
-- **Sales** — Sales list with search, status/channel filters, pagination; sale detail with line items, gross profit + contribution margin breakdown, status management, refund
-- **Sales** — Sales list with search, status/channel/payment-method filters, pagination; sale detail with line items, payment method, gross profit + contribution margin breakdown, status management, refund
-- **POS** — Dedicated `/pos` cashier page with searchable product catalog, keyboard-wedge barcode scanning by product UPC, touch-friendly cart controls, guest or attached customer checkout, tax entry, and success reset flow
+- **Product Studio** — Catalog workspace at `/product-studio` with product search, readiness signals, archive/restore controls, and direct navigation into the full-page product editor
+- **Product Editor** — Full-page create/edit workflow at `/product-studio/products/new` and `/product-studio/products/:id/edit` with identity, SKU/UPC, pricing, material selection, reorder policy, margin preview, readiness context, and recent stock activity
+- **Product Detail** — Existing record-style detail page remains available during migration, with inventory history and stock adjustment actions plus a link into the new editor
+- **Sales Inbox** — `Sell` workspace queue for recent sales with search, status/channel/payment-method filters, pagination, detail drill-in, payment method visibility, and refund/status follow-up
+- **POS** — Dedicated `Sell` workspace register at `/sell` and `/sell/pos` with a split cashier layout, keyboard-wedge barcode scanning by product UPC, touch-friendly cart/payment controls, explicit guest/existing/new customer modes, and faster success/error recovery
 - **New Sale** — Sale creation form with customer autocomplete, channel select, product-linked line items, shipping/tax, live total
 - **Sales Channels** — CRUD for sales platforms (Etsy, Amazon, etc.) with platform fee and fixed fee configuration
 - **Reports** — Tab-based sub-navigation (Inventory, Sales, P&L) with shared date range/period controls and CSV export
@@ -167,6 +172,10 @@ Net Profit          = not yet exposed for sales reporting until overhead allocat
 - **Admin Users** — User management with create, edit, role assignment, deactivate/reactivate
 - **Admin Data** — CSV export for jobs, materials, rates, customers, settings
 - **Login** — JWT authentication with Zod validation
+
+## Design Briefs
+
+- [Role-Based Frontend Redesign User Story](docs/frontend_role_based_redesign_user_story.md) — issue-ready redesign brief for print monitoring, live views, POS, inventory, product studio, and role-based workspaces.
 
 ## Testing
 

--- a/agents.md
+++ b/agents.md
@@ -67,10 +67,74 @@
 
 ## Collaboration Notes
 
-- Friendly, clear communication is preferred; light humor is fine when it does not get in the way.
-- Thoroughness matters more than brevity for task execution, issue definition, validation, and documentation.
-- Skills may be installed and used when they materially improve execution.
-- Sub-agents may be used for implementation, research, or parallel investigation when helpful.
+## Working Style
+- Work is tracked and driven through GitHub issues. Prefer starting from an issue, implementing against that issue, and closing the loop in the issue or linked PR instead of treating chat alone as the source of truth.
+- When creating or refining issues, use Plan mode and write a detailed, actionable user story. The body should include the user problem, scope, acceptance criteria, and concrete implementation guidance with examples across code, UI, data, and testing.
+- Default to test-driven development when practical: outline the expected behavior first, add or update tests close to the change, then implement until the tests pass. If strict TDD is not practical for a slice, still add validation coverage before calling the work done.
+- Every completed task should include explicit validation. Run the relevant commands, smoke tests, or manual verification steps and capture what was validated.
+- Before marking work complete, update any impacted repository documentation so it stays accurate, detailed, and current. This includes `README.md`, `docs/`, runbooks, deployment notes, env docs, and feature-specific documentation whenever behavior or workflows change.
+- Sub-agents may be used when they improve quality or speed, especially for bounded research, implementation, or testing work. Use them deliberately, keep scopes narrow, and integrate the results rather than duplicating effort.
+- Collaboration tone should stay friendly, calm, and thorough. A little humor is welcome when it helps, but the work product should still be crisp, complete, and dependable.
+
+## UX Laws For Frontend Work
+- Treat UX laws as strong heuristics, not rigid commandments. When laws conflict, prioritize task clarity, accessibility, and operational speed.
+- Aesthetic-Usability Effect: visual polish matters because users perceive polished interfaces as easier to use, but do not let attractive styling hide weak information architecture or broken flows.
+- Doherty Threshold: acknowledge user actions within roughly `400ms` when practical. If real work will take longer, show immediate feedback with optimistic state changes, skeletons, spinners, or progress indicators.
+- Fitts's Law: keep primary and frequent actions large, close, and easy to hit. Avoid tiny icon-only controls, especially in dense operational tables and mobile layouts.
+- Hick's Law: reduce the number and complexity of choices shown at once. Prefer progressive disclosure, sensible defaults, recommended actions, and chunked workflows over dumping every option on screen.
+- Jakob's Law: default to familiar interface patterns unless there is a strong product reason not to. Novel UI is acceptable only when it meaningfully improves the task and still provides clear cues.
+- Law of Common Region, Law of Proximity, Law of Similarity, and Law of Uniform Connectedness: use spacing, containers, repeated styling, and visible connections to make relationships obvious. Do not rely on color alone to imply grouping.
+- Law of Prägnanz: simplify layouts until the intended structure is obvious at a glance. Favor clean hierarchy, clear grouping, and low visual noise over decorative complexity.
+- Miller's Law: chunk information so users do not have to hold too much in working memory. Do not treat `7 +/- 2` as a hard UI limit or as an excuse for arbitrary navigation/menu rules.
+- Occam's Razor: prefer the simplest interaction model that still solves the real problem. Every new control, panel, filter, or modal should justify its existence.
+- Pareto Principle: optimize the highest-frequency workflows and the biggest pain points first. The most used `20%` of the interface usually deserves the most design, testing, and polish attention.
+- When proposing or reviewing frontend changes, name the relevant law or tradeoff when it helps explain why a design decision is better, faster, or easier to learn.
+- Reviewed for this repo on `2026-04-08` against the Laws of UX reference set and related articles, including:
+  - `https://lawsofux.com/laws/`
+  - `https://lawsofux.com/doherty-threshold/`
+  - `https://lawsofux.com/jakobs-law/`
+  - `https://lawsofux.com/law-of-common-region/`
+  - `https://lawsofux.com/law-of-pr%C3%A4gnanz/`
+  - `https://lawsofux.com/law-of-proximity/`
+  - `https://lawsofux.com/law-of-similarity/`
+  - `https://lawsofux.com/law-of-uniform-connectedness/`
+  - `https://lawsofux.com/millers-law/`
+  - `https://lawsofux.com/pareto-principle/`
+  - `https://lawsofux.com/articles/2018/the-psychology-of-design/`
+
+## Documentation UX And Freshness
+- Treat documentation as a product surface. Docs should help readers orient quickly, build the right mental model, and find the authoritative answer without hunting through overlapping files.
+- Keep the documentation entry points aligned:
+  - `README.md` is the repo-root orientation layer.
+  - `docs/index.md` is the main audience and task-based documentation hub.
+  - `docs/reference/index.md` is the authoritative technical reference map tied to the current codebase.
+  - `docs/README.md` is only a compatibility pointer for older links and should not become a competing hub.
+- Apply the UX laws to documentation structure:
+  - Hick's Law: reduce competing entry points and avoid too many equal-weight navigation choices.
+  - Jakob's Law: use familiar documentation patterns such as overview, quick start, architecture, workflows, troubleshooting, and reference.
+  - Law of Prägnanz plus Common Region / Proximity / Similarity / Uniform Connectedness: make structure obvious with clean sections, grouped links, tables, and clear document families.
+  - Miller's Law: chunk long explanations into short sections, diagrams, tables, and step-by-step flows.
+  - Occam's Razor and Pareto Principle: optimize the docs for the most common questions first and do not add extra prose when a diagram, table, or shorter explanation would be clearer.
+- Prefer editable visuals for relationship-heavy concepts:
+  - use `mermaid` directly in markdown when practical
+  - use source-controlled SVG assets in `docs/assets/` when more layout control is needed
+  - avoid non-editable screenshots unless a real UI capture is the point
+- When behavior changes affect architecture, request flow, auth/session flow, deployment topology, feature-area maps, or workflow understanding, update the related diagrams and visual assets in the same change.
+- Mark source-of-truth status clearly. If a document is historical, contextual, or legacy-oriented, label it so readers do not mistake it for the maintained reference path.
+- Keep major docs structurally consistent when practical:
+  - purpose / audience
+  - quick summary or start-here guidance
+  - main content
+  - validation / verification or troubleshooting when relevant
+  - related docs
+- Before calling documentation work complete, validate the documentation itself:
+  - verify internal markdown links and asset references
+  - review diagrams for accuracy against the current codebase
+  - make sure updated docs still align with the intended docs information architecture and source-of-truth model
+
+  ## Commit & Pull Request Guidelines
+- Commits: concise, present-tense summaries (e.g., `feat: add incident filter`, `fix: tighten auth middleware`). Group related changes.
+- PRs: include context, linked ticket, and key commands run. Note API contract, route, feature-flag, or schema changes and update OpenAPI, docs, and UI consumers together. Attach screenshots or sample JSON for UI/endpoint changes; list env vars or workflow inputs touched. If documentation changed as part of the work, call that out explicitly in the PR summary.
 
 ## Deployment Notes
 

--- a/docs/frontend_role_based_redesign_user_story.md
+++ b/docs/frontend_role_based_redesign_user_story.md
@@ -1,0 +1,710 @@
+# Frontend Redesign User Story: Role-Based 3D Print Operations Console
+
+## Proposed Issue Title
+
+`Epic: redesign the frontend into role-based workspaces for print operations, POS, inventory, product studio, and business oversight`
+
+## User Story
+
+As a 3D print business team member working in one or more roles such as print operator, floor lead, cashier, inventory manager, product manager, or owner, I need the application to present the right tools, signals, and actions for my current job so I can run the business from one interface without hunting across disconnected CRUD pages.
+
+## Why This Work Exists
+
+The current frontend is competent but mostly route-first and page-first:
+
+- Navigation is flat in [frontend/src/components/layout/appNav.ts](/Users/brentbengtson/github-files/3d-print-sales/frontend/src/components/layout/appNav.ts).
+- The shell in [frontend/src/components/layout/Layout.tsx](/Users/brentbengtson/github-files/3d-print-sales/frontend/src/components/layout/Layout.tsx) treats every domain as an equal destination instead of a role-oriented workspace.
+- Operationally important areas already exist, but they are fragmented:
+  - Printer monitoring and live thumbnails in [frontend/src/pages/PrintersPage.tsx](/Users/brentbengtson/github-files/3d-print-sales/frontend/src/pages/PrintersPage.tsx) and [frontend/src/pages/PrinterDetailPage.tsx](/Users/brentbengtson/github-files/3d-print-sales/frontend/src/pages/PrinterDetailPage.tsx)
+  - POS in [frontend/src/pages/POSPage.tsx](/Users/brentbengtson/github-files/3d-print-sales/frontend/src/pages/POSPage.tsx)
+  - Inventory reconciliation and stock adjustments in [frontend/src/pages/InventoryPage.tsx](/Users/brentbengtson/github-files/3d-print-sales/frontend/src/pages/InventoryPage.tsx)
+  - Product management in [frontend/src/pages/ProductsPage.tsx](/Users/brentbengtson/github-files/3d-print-sales/frontend/src/pages/ProductDetailPage.tsx)
+  - Jobs and quoting logic in [frontend/src/pages/JobsPage.tsx](/Users/brentbengtson/github-files/3d-print-sales/frontend/src/pages/JobsPage.tsx), [frontend/src/pages/JobDetailPage.tsx](/Users/brentbengtson/github-files/3d-print-sales/frontend/src/pages/JobDetailPage.tsx), and [frontend/src/pages/CalculatorPage.tsx](/Users/brentbengtson/github-files/3d-print-sales/frontend/src/pages/CalculatorPage.tsx)
+- The visual system in [frontend/src/index.css](/Users/brentbengtson/github-files/3d-print-sales/frontend/src/index.css) is serviceable but generic. It defaults to familiar dashboard styling instead of a deliberate operational identity.
+
+This redesign should optimize for the most frequent workflows first, which follows the repo’s UX guidance around Pareto Principle, Hick’s Law, Jakob’s Law, Fitts’s Law, and Doherty Threshold.
+
+## Current-State Findings
+
+### What already works
+
+- Protected app shell, persisted auth, and basic responsive behavior are already in place.
+- The printer domain is stronger than the rest of the UI suggests:
+  - normalized live status
+  - WebSocket freshness for Moonraker
+  - print progress, temperatures, ETA, layers
+  - backend-served print thumbnails through `/api/v1/printers/{id}/thumbnail`
+- POS already supports:
+  - product-first checkout
+  - barcode scan resolution
+  - touch-friendly cart controls
+  - guest or attached customer checkout
+- Inventory already supports:
+  - low-stock alerts
+  - reconciliation
+  - manual adjustments
+  - transaction ledger
+
+### Main UX problems
+
+- The app is organized around tables and forms instead of operator intent.
+- Print monitoring is available, but there is no “war room” or “printer wall” mode for floor use.
+- Live camera views are not modeled in the backend or frontend today. The redesign should introduce a camera capability intentionally rather than pretending thumbnails are cameras.
+- Product creation is still a modal CRUD flow, even though products sit at the intersection of pricing, material, stock, POS, and sales.
+- Inventory actions are mixed into a ledger page instead of a task-driven control surface.
+- Dashboard cards expose many metrics, but the page is not opinionated about what each role needs next.
+
+## Roles To Support
+
+### Print Operator
+
+Primary goals:
+
+- know which printers are healthy
+- see what is printing now
+- spot errors, pauses, stale sockets, and ETAs immediately
+- jump from printer to assigned job without context switching
+
+### Floor Lead
+
+Primary goals:
+
+- manage fleet utilization
+- rebalance jobs across printers
+- see blocked printers and work queues
+- coordinate labor, rush jobs, and attention events
+
+### Cashier / Retail Staff
+
+Primary goals:
+
+- complete walk-up sales fast
+- scan products reliably
+- avoid mis-taps on touch screens
+- handle guest checkout and common payment methods with low friction
+
+### Inventory Manager
+
+Primary goals:
+
+- see low stock by severity
+- reconcile counts quickly
+- understand stock movement by reason
+- act on exceptions without reading a full ledger first
+
+### Product Manager / Maker
+
+Primary goals:
+
+- create or refine a sellable product
+- connect pricing, cost model, UPC, stock policy, imagery, and channel readiness
+- validate margin before publishing to POS and catalog
+
+### Owner / Admin
+
+Primary goals:
+
+- monitor revenue, print utilization, margin, inventory risk, and open exceptions
+- move between operations and business views without losing context
+
+## Scope
+
+### In scope
+
+- new information architecture
+- role-based navigation and home experiences
+- printer wall and printer detail redesign
+- live camera view concept and required model additions
+- POS redesign
+- inventory control redesign
+- product creation redesign
+- dashboard and global shell redesign
+- implementation scaffolding and route/component guidance
+
+### Out of scope for the first slice
+
+- replacing backend business rules
+- changing accounting logic
+- redesigning every admin screen
+- inventing a video streaming backend without a camera configuration model
+
+## Proposed Information Architecture
+
+Replace the flat navigation with workspaces:
+
+- `Control Center`
+- `Print Floor`
+- `Sell`
+- `Stock`
+- `Product Studio`
+- `Orders`
+- `Insights`
+- `Admin`
+
+Each workspace gets its own local navigation and default view. Users still have deep links, but the primary mental model becomes “where am I working right now?” instead of “which table page am I on?”
+
+```mermaid
+flowchart LR
+    A["Global Shell"] --> B["Control Center"]
+    A --> C["Print Floor"]
+    A --> D["Sell"]
+    A --> E["Stock"]
+    A --> F["Product Studio"]
+    A --> G["Orders"]
+    A --> H["Insights"]
+    A --> I["Admin"]
+    C --> C1["Printer Wall"]
+    C --> C2["Printer Detail"]
+    C --> C3["Queue + Assignments"]
+    D --> D1["POS Register"]
+    D --> D2["Sales Inbox"]
+    E --> E1["Exceptions"]
+    E --> E2["Ledger"]
+    E --> E3["Reconciliation"]
+    F --> F1["Catalog"]
+    F --> F2["Product Editor"]
+    F --> F3["Pricing + Materials"]
+```
+
+## Experience Direction
+
+Use an operations-first visual system:
+
+- dark-biased control-room shell for printer and POS workspaces
+- lighter analytical surfaces for stock, product, and reporting screens
+- typography:
+  - heading: `Rubik`
+  - body: `Nunito Sans`
+- palette:
+  - shell background: deep slate or near-black
+  - primary action: saturated green for “go / complete / ready”
+  - warning: amber
+  - fault: red
+  - informational highlights: cyan or blue
+
+This direction is consistent with the UI skill guidance returned for a real-time monitoring product and is a better fit than the current default indigo-on-white token set.
+
+## Workspace Concepts
+
+### 1. Control Center
+
+Purpose:
+
+- landing space after login
+- tailored summary by user role
+- immediate queue of urgent work
+
+Layout:
+
+- top row: active shift, urgent exceptions, cash drawer state, floor utilization
+- center: role-specific cards
+- right rail: “needs attention now”
+
+Example modules:
+
+- `Printers needing attention`
+- `Low stock that blocks production`
+- `Open POS session`
+- `Today’s sales and margin`
+- `Products below reorder point`
+- `Draft jobs missing printer assignment`
+
+### 2. Print Floor
+
+Purpose:
+
+- primary operational workspace for printers and jobs
+
+Key views:
+
+- `Printer Wall`
+- `Printer Detail`
+- `Queue & Assignments`
+
+#### Printer Wall
+
+This becomes the high-frequency page for operators and floor leads.
+
+Core behavior:
+
+- large cards sized for glanceability from a distance
+- status grouping: printing, ready, attention, offline
+- auto-refresh cadence based on provider freshness
+- wall mode with reduced chrome
+- optional camera quadrant when cameras are configured
+
+Card contents:
+
+- printer name and location
+- current job and product
+- progress ring
+- layer and ETA
+- tool and bed temperatures
+- socket freshness
+- latest message
+- camera or thumbnail tile
+- actions: `Open`, `Reassign`, `Pause note`, `Refresh`
+
+#### Camera support
+
+The repo currently exposes print thumbnails, not live video streams. A real camera experience needs new fields, likely on `Printer`:
+
+- `camera_enabled`
+- `camera_provider`
+- `camera_stream_url`
+- `camera_snapshot_url`
+- `camera_label`
+
+The UI should support:
+
+- grid of live camera tiles
+- snapshot fallback when stream is unavailable
+- privacy-safe opt-in configuration
+- full-screen focus mode for one machine
+
+### 3. Sell
+
+Purpose:
+
+- cashier-first and counter-first selling
+
+Views:
+
+- `POS Register`
+- `Sales Inbox`
+- `Receipt / Sale Detail`
+
+#### POS Register
+
+The current POS page is already the closest thing to a role-specific workspace. The redesign should deepen it.
+
+Improvements:
+
+- scanner lane always visible
+- larger touch targets
+- fewer competing inputs on initial view
+- sticky totals and payment actions
+- quick product category filters
+- optional image tiles for high-frequency products
+- explicit “guest / existing customer / create customer” switch
+- checkout success state with next-action shortcuts
+
+### 4. Stock
+
+Purpose:
+
+- exception-first inventory management
+
+Views:
+
+- `Exceptions`
+- `Reconciliation`
+- `Ledger`
+- `Materials`
+
+The default screen should not be the ledger. It should be an action queue:
+
+- stockouts affecting POS
+- stockouts affecting active jobs
+- products near reorder point
+- suspicious adjustments and waste spikes
+
+### 5. Product Studio
+
+Purpose:
+
+- replace modal CRUD with a product workflow
+
+Views:
+
+- `Catalog`
+- `Product Editor`
+- `Pricing & Margin`
+- `Readiness`
+
+The editor should feel like a studio:
+
+- left: identity, naming, SKU, UPC
+- middle: pricing, material, cost, reorder point
+- right: margin preview, stock readiness, POS visibility, channel readiness
+
+### 6. Orders
+
+Purpose:
+
+- unify jobs, quotes, and sales-adjacent production work
+
+Views:
+
+- `Production Jobs`
+- `Quotes`
+- `Open Sales Requiring Fulfillment`
+
+This reduces the gap between the sales side and the print floor.
+
+## UX Laws Applied
+
+- `Hick’s Law`: the flat nav becomes workspace nav plus local nav so users see fewer equal-weight choices at once.
+- `Jakob’s Law`: each workspace still uses familiar patterns such as split panes, tabs, command bars, and detail drawers.
+- `Fitts’s Law`: POS actions and printer-card actions get larger targets and spacing suitable for touch and shop-floor use.
+- `Doherty Threshold`: all polling, refresh, and checkout actions should show feedback within roughly 400ms.
+- `Law of Common Region` and `Proximity`: printer status, job, and telemetry belong in a single card region instead of scattered text rows.
+- `Pareto Principle`: the redesign favors the high-frequency workflows already visible in the repo: print monitoring, POS, stock response, and product setup.
+
+## Acceptance Criteria
+
+### Global shell
+
+- Users can enter the app into a workspace-oriented shell instead of the current flat nav.
+- Navigation can be filtered by role without breaking deep links.
+- The shell supports a dense desktop mode and a touch-friendly mode.
+
+### Print floor
+
+- Operators can identify any paused, offline, error, or stale printer within 5 seconds on the wall screen.
+- Each printer card shows live telemetry and current print context using existing printer monitoring fields.
+- The system supports camera tiles when a camera source is configured and snapshot fallback when it is not.
+
+### POS
+
+- Cashiers can complete a common sale with fewer decisions visible at once than the current form.
+- Barcode scanning remains first-class and works with keyboard-wedge devices.
+- Checkout, success, and error states are obvious and touch-friendly.
+
+### Stock
+
+- Inventory managers land on exceptions first, not the historical ledger.
+- Reconciliation and quick adjustment actions are reachable without scrolling through transaction history.
+- Product-impacting stock problems are visually distinguished from material-only problems.
+
+### Product Studio
+
+- Product creation no longer relies on a modal as the primary authoring surface.
+- Margin, stock policy, and POS readiness are visible during editing.
+- The flow supports both a fast create path and a detailed setup path.
+
+### Documentation and implementation
+
+- The redesign brief lives in repo docs and can be used as the source document for an implementation epic.
+- Code examples map to the existing React, Vite, TanStack Query, Zustand, and Tailwind stack.
+
+## UX Examples
+
+### Example A: Printer Wall
+
+```text
++----------------------------------------------------------------------------------+
+| Print Floor                                                     Shift: Day       |
+| 18 printers | 11 printing | 3 ready | 2 attention | 2 offline                   |
++----------------------------------------------------------------------------------+
+| ATTENTION                                                                       |
+| [A1 MK4]  Error: filament runout     Job J-2418  ETA --    Open  Reassign       |
+| [X1C-02]  Paused by operator         Job J-2420  ETA 0:38  Open  Resume note    |
++----------------------------------------------------------------------------------+
+| PRINTING                                                                        |
+| [P1S-01]  72%   Layer 181/244   ETA 1h12m   nozzle 218 / bed 60   socket live   |
+| [MK4-03]  15%   Layer 24/210    ETA 4h40m   nozzle 215 / bed 60   poll fallback |
++----------------------------------------------------------------------------------+
+| READY                                                                           |
+| [Voron-01] Idle in Bay 2                         Assign next job                 |
++----------------------------------------------------------------------------------+
+```
+
+### Example B: POS Register
+
+```text
++------------------------------------------+--------------------------------------+
+| Scan / Search                            | Cart                                 |
+| [ Scan barcode ]                         | 3 items                              |
+| [ Search products ]                      | Widget A            2 x $12.00       |
+|                                          | Spacer Clip         1 x $4.00        |
+| Quick Picks                              |                                      |
+| [Best Sellers] [PLA Kits] [Accessories]  | Customer: Guest                      |
+|                                          | Tax: $2.31                           |
+| Product Tiles                            | Total: $30.31                        |
+| [Image][Image][Image][Image]             |                                      |
+|                                          | [Cash] [Card] [Other]                |
+|                                          | [Complete Sale]                      |
++------------------------------------------+--------------------------------------+
+```
+
+### Example C: Product Studio
+
+```text
++----------------------------------------------------------------------------------+
+| Product Studio > Hydroponic Tower Clip                            Draft          |
++----------------------------------------------------------------------------------+
+| Identity                | Pricing & Cost           | Readiness                   |
+| Name                    | Unit Price               | POS visible: Yes            |
+| SKU                     | Unit Cost                | UPC ready: Missing          |
+| UPC                     | Target margin            | Reorder point: 12           |
+| Description             | Material                 | Low-stock risk: Medium      |
+|                         | Calculator link          | Sales channels: Direct      |
++----------------------------------------------------------------------------------+
+| Recent stock activity                                                         |
++----------------------------------------------------------------------------------+
+```
+
+## Implementation Sketch
+
+### Routing model
+
+```tsx
+// frontend/src/app/routes.tsx
+export const appRoutes = [
+  {
+    path: '/',
+    element: <AppShell />,
+    children: [
+      { index: true, element: <Navigate to="/control-center" replace /> },
+      { path: 'control-center', element: <ControlCenterPage /> },
+      {
+        path: 'print-floor',
+        element: <PrintFloorLayout />,
+        children: [
+          { index: true, element: <PrinterWallPage /> },
+          { path: 'printers/:id', element: <PrinterConsolePage /> },
+          { path: 'queue', element: <PrintQueuePage /> },
+        ],
+      },
+      {
+        path: 'sell',
+        element: <SellLayout />,
+        children: [
+          { index: true, element: <POSRegisterPage /> },
+          { path: 'sales', element: <SalesInboxPage /> },
+        ],
+      },
+      {
+        path: 'stock',
+        element: <StockLayout />,
+        children: [
+          { index: true, element: <StockExceptionsPage /> },
+          { path: 'ledger', element: <InventoryLedgerPage /> },
+          { path: 'reconcile', element: <StockReconciliationPage /> },
+        ],
+      },
+      {
+        path: 'product-studio',
+        element: <ProductStudioLayout />,
+        children: [
+          { index: true, element: <ProductCatalogPage /> },
+          { path: 'new', element: <ProductEditorPage mode="create" /> },
+          { path: ':id', element: <ProductEditorPage mode="edit" /> },
+        ],
+      },
+    ],
+  },
+];
+```
+
+### Role-aware navigation
+
+```ts
+// frontend/src/components/layout/workspaceNav.ts
+type Role = 'admin' | 'floor' | 'cashier' | 'inventory' | 'catalog';
+
+type WorkspaceLink = {
+  to: string;
+  label: string;
+  roles: Role[];
+};
+
+export const workspaceLinks: WorkspaceLink[] = [
+  { to: '/control-center', label: 'Control Center', roles: ['admin', 'floor', 'cashier', 'inventory', 'catalog'] },
+  { to: '/print-floor', label: 'Print Floor', roles: ['admin', 'floor'] },
+  { to: '/sell', label: 'Sell', roles: ['admin', 'cashier'] },
+  { to: '/stock', label: 'Stock', roles: ['admin', 'inventory', 'floor'] },
+  { to: '/product-studio', label: 'Product Studio', roles: ['admin', 'catalog'] },
+  { to: '/orders', label: 'Orders', roles: ['admin', 'floor', 'catalog'] },
+  { to: '/insights', label: 'Insights', roles: ['admin'] },
+];
+```
+
+### Visual tokens
+
+```css
+/* frontend/src/index.css */
+@import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;500;600;700&family=Rubik:wght@500;600;700&display=swap');
+
+@theme {
+  --font-sans: 'Nunito Sans', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'Rubik', ui-sans-serif, system-ui, sans-serif;
+
+  --color-shell: #08111f;
+  --color-panel: #0f1728;
+  --color-panel-2: #152133;
+  --color-ink: #e8eef7;
+  --color-muted-foreground: #8fa3bf;
+  --color-primary: #22c55e;
+  --color-primary-foreground: #04110a;
+  --color-warning: #f59e0b;
+  --color-danger: #ef4444;
+  --color-info: #38bdf8;
+  --color-border: #22324a;
+}
+
+body {
+  background:
+    radial-gradient(circle at top left, rgba(56, 189, 248, 0.08), transparent 24%),
+    radial-gradient(circle at top right, rgba(34, 197, 94, 0.06), transparent 20%),
+    var(--color-shell);
+  color: var(--color-ink);
+}
+```
+
+### Printer wall card
+
+```tsx
+type PrinterWallCardProps = {
+  printer: Printer;
+  urgent?: boolean;
+};
+
+export function PrinterWallCard({ printer, urgent = false }: PrinterWallCardProps) {
+  const status = printer.monitor_status || printer.status;
+
+  return (
+    <article
+      className={cn(
+        'grid gap-4 rounded-3xl border p-4 transition-colors',
+        urgent ? 'border-amber-400/50 bg-amber-500/10' : 'border-border bg-card/70'
+      )}
+    >
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="font-display text-lg font-semibold">{printer.name}</h3>
+          <p className="text-sm text-muted-foreground">{printer.location || 'Unassigned bay'}</p>
+        </div>
+        <StatusPill status={status} />
+      </header>
+
+      <div className="grid grid-cols-[96px_minmax(0,1fr)] gap-4">
+        <PrinterThumbnail
+          src={printer.current_print_thumbnail_url}
+          alt={printer.current_print_name || `${printer.name} live thumbnail`}
+          className="h-24 w-24 rounded-2xl"
+          imgClassName="object-cover"
+          fallbackLabel="No view"
+        />
+
+        <div className="space-y-2">
+          <p className="truncate text-sm font-medium">
+            {printer.current_print_name || 'No active print'}
+          </p>
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+            <div>
+              <dt className="text-muted-foreground">Progress</dt>
+              <dd>{printer.monitor_progress_percent?.toFixed(0) ?? '0'}%</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">ETA</dt>
+              <dd>{formatDuration(printer.monitor_remaining_seconds)}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Layer</dt>
+              <dd>{formatLayer(printer.monitor_current_layer, printer.monitor_total_layers)}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Transport</dt>
+              <dd>{printer.monitor_ws_connected ? 'Socket live' : 'Polling'}</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+
+      <footer className="flex gap-2">
+        <Link to={`/print-floor/printers/${printer.id}`} className="rounded-xl bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground no-underline">
+          Open
+        </Link>
+        <button className="rounded-xl border border-border px-3 py-2 text-sm">Reassign</button>
+      </footer>
+    </article>
+  );
+}
+```
+
+### POS split-pane frame
+
+```tsx
+export function POSRegisterPage() {
+  return (
+    <main className="grid min-h-[calc(100vh-5rem)] gap-4 xl:grid-cols-[minmax(0,1.5fr)_420px]">
+      <section className="rounded-[28px] border border-border bg-card/80 p-5">
+        <POSScannerLane />
+        <POSQuickFilters />
+        <POSProductTileGrid />
+      </section>
+
+      <aside className="rounded-[28px] border border-border bg-[#09121d] p-5">
+        <POSCustomerPanel />
+        <POSCart />
+        <POSPaymentBar />
+      </aside>
+    </main>
+  );
+}
+```
+
+### Product editor frame
+
+```tsx
+export function ProductEditorPage({ mode }: { mode: 'create' | 'edit' }) {
+  return (
+    <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)_360px]">
+      <ProductIdentityPanel mode={mode} />
+      <ProductPricingPanel />
+      <ProductReadinessRail />
+      <ProductActivityPanel className="xl:col-span-3" />
+    </div>
+  );
+}
+```
+
+## Data And API Follow-Ups
+
+The redesign can start with current APIs, but these additions would materially improve the interface:
+
+- printer camera metadata on the printer model and schema
+- lightweight queue endpoints for jobs awaiting printer assignment
+- product readiness fields or computed endpoint:
+  - has UPC
+  - active in POS
+  - low-stock risk
+  - margin health
+- inventory exception summary endpoint so the stock home page is not built by client-side stitching alone
+
+## Delivery Plan
+
+### Phase 1
+
+- introduce workspace shell
+- move existing routes into role-based layouts without changing business logic
+- launch `Control Center`, `Print Floor`, and redesigned `Sell`
+
+### Phase 2
+
+- build `Stock` exceptions home
+- build `Product Studio`
+- unify jobs, sales, and queue surfaces
+
+### Phase 3
+
+- add camera support
+- add wall mode
+- add richer operational analytics
+
+## Validation
+
+For the design implementation epic, validation should include:
+
+- `cd frontend && npm run build`
+- `cd frontend && npm test`
+- keyboard-only navigation through shell, POS, and printer wall
+- touch-target checks on POS and printer actions
+- manual validation at `375px`, `768px`, `1024px`, and `1440px`
+- reduced-motion behavior for live or animated modules
+
+## Summary Recommendation
+
+Do not redesign this app as “a nicer dashboard.” Redesign it as a set of role-based workspaces built on the backend strengths the repo already has: printer telemetry, POS checkout, inventory actions, and product economics. The highest-value first release is `Control Center` + `Print Floor` + improved `Sell`, followed by `Stock` and `Product Studio`.

--- a/docs/pos_barcode_scanning.md
+++ b/docs/pos_barcode_scanning.md
@@ -15,8 +15,8 @@ This implementation is intentionally narrow:
 
 ## Operator Workflow
 
-1. Open the POS page at `/pos`.
-2. Scan into the `Barcode Scan` field, or scan while focus is outside other form controls.
+1. Open the POS register at `/sell`, `/sell/pos`, or the legacy-compatible `/pos` route.
+2. Scan into the `Scan barcode` field, or scan while focus is outside other form controls.
 3. The app sends the scanned code to `POST /api/v1/pos/scan/resolve`.
 4. If one sellable product matches, that product is added to the cart.
 5. Complete checkout using the existing POS checkout flow.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import AdminLayout from '@/components/layout/AdminLayout';
 import ProtectedRoute from '@/components/auth/ProtectedRoute';
 
 const DashboardPage = lazy(() => import('@/pages/DashboardPage'));
+const ControlCenterPage = lazy(() => import('@/pages/ControlCenterPage'));
 const JobsPage = lazy(() => import('@/pages/JobsPage'));
 const JobDetailPage = lazy(() => import('@/pages/JobDetailPage'));
 const JobFormPage = lazy(() => import('@/pages/JobFormPage'));
@@ -15,6 +16,7 @@ const MaterialsPage = lazy(() => import('@/pages/MaterialsPage'));
 const RatesPage = lazy(() => import('@/pages/RatesPage'));
 const CustomersPage = lazy(() => import('@/pages/CustomersPage'));
 const ProductsPage = lazy(() => import('@/pages/ProductsPage'));
+const ProductEditorPage = lazy(() => import('@/pages/ProductEditorPage'));
 const ProductDetailPage = lazy(() => import('@/pages/ProductDetailPage'));
 const PrintersPage = lazy(() => import('@/pages/PrintersPage'));
 const PrinterDetailPage = lazy(() => import('@/pages/PrinterDetailPage'));
@@ -26,6 +28,7 @@ const SaleFormPage = lazy(() => import('@/pages/SaleFormPage'));
 const SalesChannelsPage = lazy(() => import('@/pages/SalesChannelsPage'));
 const POSPage = lazy(() => import('@/pages/POSPage'));
 const CalculatorPage = lazy(() => import('@/pages/CalculatorPage'));
+const OrdersPage = lazy(() => import('@/pages/OrdersPage'));
 const ReportsLayout = lazy(() => import('@/pages/reports/ReportsLayout'));
 const InventoryReportPage = lazy(() => import('@/pages/reports/InventoryReportPage'));
 const SalesReportPage = lazy(() => import('@/pages/reports/SalesReportPage'));
@@ -73,7 +76,45 @@ export default function App() {
                   </ProtectedRoute>
                 }
               >
-                <Route path="/" element={<DashboardPage />} />
+                <Route path="/" element={<Navigate to="/control-center" replace />} />
+                <Route path="/control-center" element={<ControlCenterPage />} />
+                <Route path="/dashboard" element={<DashboardPage />} />
+
+                <Route path="/print-floor" element={<PrintersPage />} />
+                <Route path="/print-floor/printers" element={<PrintersPage />} />
+                <Route path="/print-floor/printers/new" element={<PrinterFormPage />} />
+                <Route path="/print-floor/printers/:id" element={<PrinterDetailPage />} />
+                <Route path="/print-floor/printers/:id/edit" element={<PrinterFormPage />} />
+
+                <Route path="/sell" element={<POSPage />} />
+                <Route path="/sell/pos" element={<POSPage />} />
+                <Route path="/sell/sales" element={<SalesPage />} />
+                <Route path="/sell/sales/new" element={<SaleFormPage />} />
+                <Route path="/sell/sales/:id" element={<SaleDetailPage />} />
+                <Route path="/sell/channels" element={<SalesChannelsPage />} />
+
+                <Route path="/stock" element={<InventoryPage />} />
+                <Route path="/stock/inventory" element={<InventoryPage />} />
+                <Route path="/stock/materials" element={<MaterialsPage />} />
+
+                <Route path="/product-studio" element={<ProductsPage />} />
+                <Route path="/product-studio/products" element={<ProductsPage />} />
+                <Route path="/product-studio/products/new" element={<ProductEditorPage />} />
+                <Route path="/product-studio/products/:id" element={<ProductDetailPage />} />
+                <Route path="/product-studio/products/:id/edit" element={<ProductEditorPage />} />
+                <Route path="/product-studio/calculator" element={<CalculatorPage />} />
+                <Route path="/product-studio/rates" element={<RatesPage />} />
+
+                <Route path="/orders" element={<OrdersPage />} />
+                <Route path="/orders/jobs" element={<JobsPage />} />
+                <Route path="/orders/jobs/new" element={<JobFormPage />} />
+                <Route path="/orders/jobs/:id" element={<JobDetailPage />} />
+                <Route path="/orders/jobs/:id/edit" element={<JobFormPage />} />
+                <Route path="/orders/customers" element={<CustomersPage />} />
+
+                <Route path="/insights" element={<Navigate to="/reports/inventory" replace />} />
+                <Route path="/insights/reports" element={<Navigate to="/reports/inventory" replace />} />
+
                 <Route path="/jobs" element={<JobsPage />} />
                 <Route path="/jobs/new" element={<JobFormPage />} />
                 <Route path="/jobs/:id" element={<JobDetailPage />} />

--- a/frontend/src/components/layout/AdminLayout.tsx
+++ b/frontend/src/components/layout/AdminLayout.tsx
@@ -13,7 +13,7 @@ export default function AdminLayout() {
   const { user } = useAuthStore();
 
   if (user?.role !== 'admin') {
-    return <Navigate to="/" replace />;
+    return <Navigate to="/control-center" replace />;
   }
 
   return (

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,8 +1,11 @@
 export default function Footer() {
   return (
-    <footer className="border-t border-border py-6 mt-auto">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center text-sm text-muted-foreground">
-        &copy; {new Date().getFullYear()} 3D Print Sales. All rights reserved.
+    <footer className="mt-auto border-t border-border bg-card/30 py-6 backdrop-blur">
+      <div className="mx-auto flex max-w-[96rem] flex-col gap-2 px-4 text-center text-sm text-muted-foreground sm:px-6 lg:px-8 lg:flex-row lg:items-center lg:justify-between">
+        <p>&copy; {new Date().getFullYear()} 3D Print Sales.</p>
+        <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground/90">
+          Control Center • Print Floor • Sell • Stock • Product Studio
+        </p>
       </div>
     </footer>
   );

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,7 +1,8 @@
-import { Link, useNavigate } from 'react-router-dom';
-import { Moon, Sun, Printer, LogOut, Menu, Settings, User } from 'lucide-react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Moon, Sun, Printer, LogOut, Menu, User } from 'lucide-react';
 import { useAuthStore } from '@/store/auth';
 import { useTheme } from '@/hooks/useTheme';
+import { getWorkspaceForPath } from './workspaces';
 
 interface HeaderProps {
   onOpenMobileNav?: () => void;
@@ -11,6 +12,8 @@ export default function Header({ onOpenMobileNav }: HeaderProps) {
   const { dark, toggle } = useTheme();
   const { user, logout } = useAuthStore();
   const navigate = useNavigate();
+  const location = useLocation();
+  const workspace = getWorkspaceForPath(location.pathname);
 
   const handleLogout = () => {
     logout();
@@ -18,50 +21,56 @@ export default function Header({ onOpenMobileNav }: HeaderProps) {
   };
 
   return (
-    <header className="border-b border-border bg-card/95 backdrop-blur sticky top-0 z-40">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between h-16 gap-4">
-          <div className="flex items-center gap-3 min-w-0">
+    <header className="sticky top-0 z-40 border-b border-border bg-[color:var(--color-shell)] backdrop-blur-xl">
+      <div className="mx-auto max-w-[96rem] px-4 sm:px-6 lg:px-8">
+        <div className="flex min-h-18 items-center justify-between gap-4 py-3">
+          <div className="flex min-w-0 items-center gap-3">
             <button
               onClick={onOpenMobileNav}
-              className="md:hidden p-2 rounded-md hover:bg-accent transition-colors text-muted-foreground"
+              className="rounded-xl border border-border bg-card/70 p-2 text-muted-foreground transition-colors hover:text-foreground md:hidden"
               aria-label="Open navigation menu"
             >
               <Menu className="w-5 h-5" />
             </button>
 
-            <Link to="/" className="flex items-center gap-2 text-primary font-bold text-xl no-underline min-w-0">
-              <Printer className="w-6 h-6 shrink-0" />
-              <span className="truncate">3D Print Sales</span>
+            <Link to="/control-center" className="flex min-w-0 items-center gap-3 no-underline">
+              <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-primary/30 bg-primary text-primary-foreground shadow-[0_14px_40px_rgba(34,197,94,0.28)]">
+                <Printer className="h-5 w-5 shrink-0" />
+              </div>
+              <div className="min-w-0">
+                <span className="block truncate font-display text-lg font-semibold text-foreground">
+                  3D Print Sales
+                </span>
+                <span className="block truncate text-xs uppercase tracking-[0.22em] text-muted-foreground">
+                  {workspace.label}
+                </span>
+              </div>
             </Link>
           </div>
 
-          <div className="flex items-center gap-2 shrink-0">
-            {user?.role === 'admin' && (
-              <Link
-                to="/admin/settings"
-                className="hidden sm:inline-flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium no-underline text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-              >
-                <Settings className="w-4 h-4" />
-                Admin
-              </Link>
-            )}
-
+          <div className="flex shrink-0 items-center gap-2">
             <button
               onClick={toggle}
-              className="p-2 rounded-md hover:bg-accent transition-colors text-muted-foreground"
+              className="rounded-xl border border-border bg-card/70 p-2 text-muted-foreground transition-colors hover:text-foreground"
               aria-label="Toggle theme"
             >
               {dark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
             </button>
 
             {user && (
-              <div className="hidden sm:flex items-center gap-2 text-sm text-muted-foreground border-l border-border pl-3 ml-1 min-w-0 max-w-[220px]">
-                <User className="w-4 h-4 shrink-0" />
-                <span className="truncate">{user.full_name}</span>
+              <div className="hidden min-w-0 max-w-[280px] items-center gap-3 rounded-2xl border border-border bg-card/70 px-3 py-2 text-sm text-muted-foreground sm:flex">
+                <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-background/80 text-foreground">
+                  <User className="h-4 w-4 shrink-0" />
+                </div>
+                <div className="min-w-0">
+                  <span className="block truncate font-medium text-foreground">{user.full_name}</span>
+                  <span className="block truncate text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                    {user.role}
+                  </span>
+                </div>
                 <button
                   onClick={handleLogout}
-                  className="p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-destructive"
+                  className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-destructive"
                   aria-label="Logout"
                   title="Sign out"
                 >
@@ -73,7 +82,7 @@ export default function Header({ onOpenMobileNav }: HeaderProps) {
             {user && (
               <button
                 onClick={handleLogout}
-                className="sm:hidden p-2 rounded-md hover:bg-accent transition-colors text-muted-foreground"
+                className="rounded-xl border border-border bg-card/70 p-2 text-muted-foreground transition-colors hover:text-destructive sm:hidden"
                 aria-label="Logout"
                 title="Sign out"
               >

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,64 +1,77 @@
 import { useState } from 'react';
-import { NavLink, Outlet } from 'react-router-dom';
-import { ChevronLeft, Settings, X } from 'lucide-react';
+import { NavLink, Outlet, useLocation } from 'react-router-dom';
+import { ChevronLeft, PanelsTopLeft, X } from 'lucide-react';
 import Header from './Header';
 import Footer from './Footer';
 import { useAuthStore } from '@/store/auth';
 import { cn } from '@/lib/utils';
-import { appNavLinks } from './appNav';
+import WorkspaceLocalNav from './WorkspaceLocalNav';
+import { getVisibleWorkspaces, getWorkspaceForPath, isWorkspaceLinkActive } from './workspaces';
 
 function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
   const { user } = useAuthStore();
+  const location = useLocation();
+  const activeWorkspace = getWorkspaceForPath(location.pathname);
+  const visibleWorkspaces = getVisibleWorkspaces(user?.role);
 
   return (
     <div className="flex h-full flex-col">
-      <div className="px-3 pb-3">
-        <p className="px-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-          Main Navigation
+      <div className="px-3 pb-4">
+        <div className="rounded-2xl border border-border bg-background/70 p-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-[0_12px_32px_rgba(34,197,94,0.25)]">
+              <PanelsTopLeft className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+                Active Workspace
+              </p>
+              <p className="mt-1 font-display text-base font-semibold text-foreground">
+                {activeWorkspace.label}
+              </p>
+            </div>
+          </div>
+          <p className="mt-3 text-sm text-muted-foreground">
+            {activeWorkspace.description}
+          </p>
+        </div>
+      </div>
+
+      <div className="px-3 pb-2">
+        <p className="px-3 text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+          Workspaces
         </p>
       </div>
 
       <nav className="space-y-1 px-3">
-        {appNavLinks.map(({ to, label, icon: Icon, end }) => (
+        {visibleWorkspaces.map(({ key, to, label, icon: Icon, matchPrefixes }) => (
           <NavLink
-            key={to}
+            key={key}
             to={to}
-            end={end}
             onClick={onNavigate}
-            className={({ isActive }) =>
+            className={() =>
               cn(
-                'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors no-underline',
-                isActive
-                  ? 'bg-primary/10 text-primary shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+                'flex items-center gap-3 rounded-2xl px-3 py-3 text-sm font-medium transition-colors no-underline',
+                isWorkspaceLinkActive(location.pathname, matchPrefixes)
+                  ? 'bg-primary text-primary-foreground shadow-[0_18px_40px_rgba(34,197,94,0.18)]'
+                  : 'text-muted-foreground hover:bg-accent hover:text-foreground'
               )
             }
           >
-            <Icon className="w-4 h-4 shrink-0" />
+            <span
+              className={cn(
+                'flex h-9 w-9 items-center justify-center rounded-xl border transition-colors',
+                isWorkspaceLinkActive(location.pathname, matchPrefixes)
+                  ? 'border-primary-foreground/15 bg-primary-foreground/10'
+                  : 'border-border bg-background/70'
+              )}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+            </span>
             <span>{label}</span>
           </NavLink>
         ))}
       </nav>
-
-      {user?.role === 'admin' && (
-        <div className="mt-6 border-t border-border px-3 pt-6">
-          <NavLink
-            to="/admin/settings"
-            onClick={onNavigate}
-            className={({ isActive }) =>
-              cn(
-                'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors no-underline',
-                isActive
-                  ? 'bg-primary/10 text-primary shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-              )
-            }
-          >
-            <Settings className="w-4 h-4 shrink-0" />
-            <span>Admin</span>
-          </NavLink>
-        </div>
-      )}
     </div>
   );
 }
@@ -70,15 +83,16 @@ export default function Layout() {
     <div className="min-h-screen flex flex-col bg-background">
       <Header onOpenMobileNav={() => setMobileNavOpen(true)} />
 
-      <div className="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 lg:py-8">
-        <div className="flex gap-6 lg:gap-8 min-h-full">
-          <aside className="hidden md:block w-64 shrink-0">
-            <div className="sticky top-24 rounded-2xl border border-border bg-card p-3 shadow-sm">
+      <div className="mx-auto flex-1 w-full max-w-[96rem] px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+        <div className="flex min-h-full gap-6 lg:gap-8">
+          <aside className="hidden w-80 shrink-0 xl:block">
+            <div className="sticky top-24 rounded-[1.9rem] border border-border bg-card/80 p-3 shadow-[0_20px_60px_rgba(8,17,31,0.10)] backdrop-blur">
               <SidebarContent />
             </div>
           </aside>
 
-          <main className="flex-1 min-w-0">
+          <main className="min-w-0 flex-1 space-y-5">
+            <WorkspaceLocalNav />
             <Outlet />
           </main>
         </div>
@@ -93,11 +107,11 @@ export default function Layout() {
             onClick={() => setMobileNavOpen(false)}
           />
 
-          <aside className="relative flex h-full w-full max-w-xs flex-col border-r border-border bg-card shadow-xl">
+          <aside className="relative flex h-full w-full max-w-sm flex-col border-r border-border bg-card shadow-xl">
             <div className="flex items-center justify-between border-b border-border px-4 py-4">
               <div>
-                <p className="text-sm font-semibold">Navigation</p>
-                <p className="text-xs text-muted-foreground">Jump to any section</p>
+                <p className="text-sm font-semibold">Workspaces</p>
+                <p className="text-xs text-muted-foreground">Jump to the right operating context</p>
               </div>
               <button
                 onClick={() => setMobileNavOpen(false)}

--- a/frontend/src/components/layout/WorkspaceLocalNav.tsx
+++ b/frontend/src/components/layout/WorkspaceLocalNav.tsx
@@ -1,0 +1,50 @@
+import { NavLink, useLocation } from 'react-router-dom';
+import { cn } from '@/lib/utils';
+import { getWorkspaceForPath, isWorkspaceLinkActive } from './workspaces';
+
+export default function WorkspaceLocalNav() {
+  const location = useLocation();
+  const workspace = getWorkspaceForPath(location.pathname);
+
+  return (
+    <section className="rounded-[1.75rem] border border-border bg-card/80 p-4 shadow-[0_16px_48px_rgba(8,17,31,0.08)] backdrop-blur">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div className="min-w-0">
+          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.26em] text-muted-foreground">
+            Workspace
+          </p>
+          <h2 className="mt-1 font-display text-xl font-semibold text-foreground">
+            {workspace.label}
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {workspace.description}
+          </p>
+        </div>
+
+        <nav
+          aria-label={`${workspace.label} navigation`}
+          className="flex flex-wrap gap-2"
+        >
+          {workspace.localLinks.map((link) => {
+            const prefixes = link.matchPrefixes ?? [link.to];
+            const active = isWorkspaceLinkActive(location.pathname, prefixes);
+            return (
+              <NavLink
+                key={link.to}
+                to={link.to}
+                className={cn(
+                  'rounded-full border px-3 py-2 text-sm font-medium no-underline transition-colors',
+                  active
+                    ? 'border-primary/40 bg-primary text-primary-foreground shadow-[0_10px_30px_rgba(34,197,94,0.28)]'
+                    : 'border-border bg-background/70 text-muted-foreground hover:border-primary/30 hover:text-foreground'
+                )}
+              >
+                {link.label}
+              </NavLink>
+            );
+          })}
+        </nav>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/layout/workspaces.ts
+++ b/frontend/src/components/layout/workspaces.ts
@@ -1,0 +1,176 @@
+import {
+  BarChart3,
+  Blocks,
+  ClipboardList,
+  Gauge,
+  type LucideIcon,
+  Package,
+  Printer,
+  Receipt,
+  Settings,
+} from 'lucide-react';
+
+export type WorkspaceRole =
+  | 'admin'
+  | 'cashier'
+  | 'floor'
+  | 'inventory'
+  | 'catalog'
+  | 'analyst'
+  | 'general';
+
+export interface WorkspaceLocalLink {
+  to: string;
+  label: string;
+  matchPrefixes?: string[];
+}
+
+export interface WorkspaceDefinition {
+  key: string;
+  label: string;
+  description: string;
+  to: string;
+  icon: LucideIcon;
+  roles: WorkspaceRole[];
+  matchPrefixes: string[];
+  localLinks: WorkspaceLocalLink[];
+}
+
+export const workspaces: WorkspaceDefinition[] = [
+  {
+    key: 'control-center',
+    label: 'Control Center',
+    description: 'Shift priorities, alerts, and business pulse.',
+    to: '/control-center',
+    icon: Gauge,
+    roles: ['admin', 'cashier', 'floor', 'inventory', 'catalog', 'analyst', 'general'],
+    matchPrefixes: ['/', '/control-center'],
+    localLinks: [
+      { to: '/control-center', label: 'Overview', matchPrefixes: ['/', '/control-center'] },
+      { to: '/dashboard', label: 'Classic Dashboard', matchPrefixes: ['/dashboard'] },
+    ],
+  },
+  {
+    key: 'print-floor',
+    label: 'Print Floor',
+    description: 'Printers, telemetry, and live floor operations.',
+    to: '/print-floor',
+    icon: Printer,
+    roles: ['admin', 'floor', 'general'],
+    matchPrefixes: ['/print-floor', '/printers'],
+    localLinks: [
+      { to: '/print-floor', label: 'Fleet Overview', matchPrefixes: ['/print-floor', '/printers'] },
+      { to: '/print-floor/printers/new', label: 'Add Printer', matchPrefixes: ['/print-floor/printers/new', '/printers/new'] },
+    ],
+  },
+  {
+    key: 'sell',
+    label: 'Sell',
+    description: 'Counter checkout, retail flow, and sales activity.',
+    to: '/sell',
+    icon: Receipt,
+    roles: ['admin', 'cashier', 'general'],
+    matchPrefixes: ['/sell', '/pos', '/sales'],
+    localLinks: [
+      { to: '/sell', label: 'POS Register', matchPrefixes: ['/sell', '/pos'] },
+      { to: '/sell/sales', label: 'Sales Inbox', matchPrefixes: ['/sell/sales', '/sales'] },
+      { to: '/sell/channels', label: 'Channels', matchPrefixes: ['/sell/channels', '/sales/channels'] },
+    ],
+  },
+  {
+    key: 'stock',
+    label: 'Stock',
+    description: 'Inventory movement, exceptions, and materials.',
+    to: '/stock',
+    icon: Blocks,
+    roles: ['admin', 'inventory', 'floor', 'general'],
+    matchPrefixes: ['/stock', '/inventory', '/materials'],
+    localLinks: [
+      { to: '/stock', label: 'Exceptions', matchPrefixes: ['/stock', '/inventory'] },
+      { to: '/stock/materials', label: 'Materials', matchPrefixes: ['/stock/materials', '/materials'] },
+    ],
+  },
+  {
+    key: 'product-studio',
+    label: 'Product Studio',
+    description: 'Catalog, pricing, and product authoring.',
+    to: '/product-studio',
+    icon: Package,
+    roles: ['admin', 'catalog', 'inventory', 'general'],
+    matchPrefixes: ['/product-studio', '/products', '/calculator', '/rates'],
+    localLinks: [
+      { to: '/product-studio', label: 'Products', matchPrefixes: ['/product-studio', '/products'] },
+      { to: '/product-studio/calculator', label: 'Calculator', matchPrefixes: ['/product-studio/calculator', '/calculator'] },
+      { to: '/product-studio/rates', label: 'Rates', matchPrefixes: ['/product-studio/rates', '/rates'] },
+    ],
+  },
+  {
+    key: 'orders',
+    label: 'Orders',
+    description: 'Jobs, customers, and fulfillment-facing work.',
+    to: '/orders',
+    icon: ClipboardList,
+    roles: ['admin', 'cashier', 'floor', 'catalog', 'general'],
+    matchPrefixes: ['/orders', '/jobs', '/customers'],
+    localLinks: [
+      { to: '/orders', label: 'Queue', matchPrefixes: ['/orders'] },
+      { to: '/orders/jobs', label: 'Jobs', matchPrefixes: ['/orders/jobs', '/jobs'] },
+      { to: '/orders/customers', label: 'Customers', matchPrefixes: ['/orders/customers', '/customers'] },
+    ],
+  },
+  {
+    key: 'insights',
+    label: 'Insights',
+    description: 'Reports, trends, and financial visibility.',
+    to: '/insights',
+    icon: BarChart3,
+    roles: ['admin', 'analyst', 'general'],
+    matchPrefixes: ['/insights', '/reports'],
+    localLinks: [
+      { to: '/insights', label: 'Reports', matchPrefixes: ['/insights', '/reports'] },
+    ],
+  },
+  {
+    key: 'admin',
+    label: 'Admin',
+    description: 'Settings, users, and data export.',
+    to: '/admin',
+    icon: Settings,
+    roles: ['admin'],
+    matchPrefixes: ['/admin'],
+    localLinks: [
+      { to: '/admin/settings', label: 'Settings', matchPrefixes: ['/admin/settings'] },
+      { to: '/admin/users', label: 'Users', matchPrefixes: ['/admin/users'] },
+      { to: '/admin/data', label: 'Data Export', matchPrefixes: ['/admin/data'] },
+    ],
+  },
+];
+
+function normalizeRole(role: string | null | undefined): WorkspaceRole {
+  const value = (role || '').trim().toLowerCase();
+
+  if (value === 'admin') return 'admin';
+  if (['cashier', 'sales', 'retail'].includes(value)) return 'cashier';
+  if (['floor', 'operator', 'printer_operator', 'production'].includes(value)) return 'floor';
+  if (['inventory', 'warehouse'].includes(value)) return 'inventory';
+  if (['catalog', 'product_manager', 'product'].includes(value)) return 'catalog';
+  if (['analyst', 'finance', 'owner'].includes(value)) return 'analyst';
+  return 'general';
+}
+
+export function getVisibleWorkspaces(role: string | null | undefined) {
+  const normalized = normalizeRole(role);
+  if (normalized === 'admin') return workspaces;
+  return workspaces.filter((workspace) => workspace.roles.includes(normalized) || workspace.roles.includes('general'));
+}
+
+export function getWorkspaceForPath(pathname: string) {
+  const match = workspaces.find((workspace) =>
+    workspace.matchPrefixes.some((prefix) => (prefix === '/' ? pathname === '/' : pathname.startsWith(prefix)))
+  );
+  return match ?? workspaces[0];
+}
+
+export function isWorkspaceLinkActive(pathname: string, prefixes: string[]) {
+  return prefixes.some((prefix) => (prefix === '/' ? pathname === '/' : pathname.startsWith(prefix)));
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,53 +1,69 @@
+@import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;500;600;700;800&family=Rubik:wght@500;600;700&display=swap');
 @import "tailwindcss";
 
 @theme {
-  --color-primary: #6366f1;
-  --color-primary-foreground: #ffffff;
-  --color-secondary: #f1f5f9;
-  --color-secondary-foreground: #0f172a;
+  --color-primary: #22c55e;
+  --color-primary-foreground: #04110a;
+  --color-secondary: #dbeafe;
+  --color-secondary-foreground: #08111f;
   --color-destructive: #ef4444;
   --color-destructive-foreground: #ffffff;
-  --color-muted: #f1f5f9;
-  --color-muted-foreground: #64748b;
-  --color-accent: #f1f5f9;
-  --color-accent-foreground: #0f172a;
-  --color-card: #ffffff;
-  --color-card-foreground: #0f172a;
-  --color-border: #e2e8f0;
-  --color-input: #e2e8f0;
-  --color-ring: #6366f1;
-  --color-background: #ffffff;
-  --color-foreground: #0f172a;
+  --color-muted: #ecf3fb;
+  --color-muted-foreground: #617892;
+  --color-accent: #e5eef8;
+  --color-accent-foreground: #08111f;
+  --color-card: rgba(255, 255, 255, 0.88);
+  --color-card-foreground: #08111f;
+  --color-border: #cad8e7;
+  --color-input: #bfd0e2;
+  --color-ring: #22c55e;
+  --color-background: #f4f8fb;
+  --color-foreground: #08111f;
+  --color-shell: #08111f;
+  --color-panel: #0f1728;
+  --color-panel-2: #152133;
+  --color-warning: #f59e0b;
+  --color-info: #38bdf8;
   --radius-sm: 0.375rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 0.75rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
 
-  --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-sans: 'Nunito Sans', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'Rubik', ui-sans-serif, system-ui, sans-serif;
 }
 
 .dark {
-  --color-primary: #818cf8;
-  --color-primary-foreground: #0f172a;
-  --color-secondary: #1e293b;
-  --color-secondary-foreground: #f8fafc;
+  --color-primary: #22c55e;
+  --color-primary-foreground: #04110a;
+  --color-secondary: #17314d;
+  --color-secondary-foreground: #eff6ff;
   --color-destructive: #f87171;
-  --color-destructive-foreground: #0f172a;
-  --color-muted: #1e293b;
-  --color-muted-foreground: #94a3b8;
-  --color-accent: #1e293b;
-  --color-accent-foreground: #f8fafc;
-  --color-card: #0f172a;
-  --color-card-foreground: #f8fafc;
-  --color-border: #334155;
-  --color-input: #334155;
-  --color-ring: #818cf8;
-  --color-background: #020617;
-  --color-foreground: #f8fafc;
+  --color-destructive-foreground: #120607;
+  --color-muted: #142033;
+  --color-muted-foreground: #8fa3bf;
+  --color-accent: #152133;
+  --color-accent-foreground: #eff6ff;
+  --color-card: rgba(15, 23, 40, 0.86);
+  --color-card-foreground: #eff6ff;
+  --color-border: #22324a;
+  --color-input: #2b3c56;
+  --color-ring: #22c55e;
+  --color-background: #08111f;
+  --color-foreground: #eff6ff;
+  --color-shell: #040914;
+  --color-panel: #0b1424;
+  --color-panel-2: #122038;
+  --color-warning: #fbbf24;
+  --color-info: #38bdf8;
 }
 
 body {
   margin: 0;
   font-family: var(--font-sans);
+  background:
+    radial-gradient(circle at top left, rgba(56, 189, 248, 0.1), transparent 22%),
+    radial-gradient(circle at top right, rgba(34, 197, 94, 0.08), transparent 20%),
+    linear-gradient(180deg, color-mix(in srgb, var(--color-background) 92%, white 8%) 0%, var(--color-background) 100%);
   background-color: var(--color-background);
   color: var(--color-foreground);
   -webkit-font-smoothing: antialiased;
@@ -56,4 +72,14 @@ body {
 
 #root {
   min-height: 100vh;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-display);
+  letter-spacing: -0.02em;
 }

--- a/frontend/src/pages/ControlCenterPage.tsx
+++ b/frontend/src/pages/ControlCenterPage.tsx
@@ -1,0 +1,552 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import {
+  AlertTriangle,
+  ArrowRight,
+  BarChart3,
+  Boxes,
+  ClipboardList,
+  DollarSign,
+  Package,
+  Printer,
+  Receipt,
+  Sparkles,
+  TrendingUp,
+} from 'lucide-react';
+import api from '@/api/client';
+import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
+import { useAuthStore } from '@/store/auth';
+import { cn, formatCurrency, formatPercent } from '@/lib/utils';
+import type {
+  DashboardSummary,
+  FinanceDashboardSummary,
+  InventoryAlert,
+  PaginatedJobs,
+  PaginatedPrinters,
+  Printer as PrinterType,
+  SalesMetrics,
+} from '@/types';
+
+const ATTENTION_STATUSES = new Set(['paused', 'maintenance', 'offline', 'error']);
+
+type ControlCenterRole = 'admin' | 'cashier' | 'floor' | 'inventory' | 'general';
+
+function getControlCenterRole(role: string | null | undefined): ControlCenterRole {
+  const value = (role || '').trim().toLowerCase();
+  if (value === 'admin' || value === 'owner' || value === 'finance') return 'admin';
+  if (['cashier', 'sales', 'retail'].includes(value)) return 'cashier';
+  if (['floor', 'operator', 'printer_operator', 'production'].includes(value)) return 'floor';
+  if (['inventory', 'warehouse'].includes(value)) return 'inventory';
+  return 'general';
+}
+
+function formatDuration(seconds: number | null | undefined) {
+  if (seconds == null || Number.isNaN(seconds)) return '—';
+  const total = Math.max(0, Math.round(seconds));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+function formatLayer(printer: PrinterType) {
+  if (printer.monitor_current_layer == null && printer.monitor_total_layers == null) return '—';
+  if (printer.monitor_current_layer != null && printer.monitor_total_layers != null) {
+    return `${printer.monitor_current_layer}/${printer.monitor_total_layers}`;
+  }
+  return String(printer.monitor_current_layer ?? printer.monitor_total_layers ?? '—');
+}
+
+function ModuleCard({
+  title,
+  description,
+  action,
+  children,
+  tone = 'default',
+}: {
+  title: string;
+  description: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+  tone?: 'default' | 'warning' | 'success';
+}) {
+  return (
+    <section
+      className={cn(
+        'rounded-[1.9rem] border p-5 shadow-[0_18px_50px_rgba(8,17,31,0.08)] backdrop-blur',
+        tone === 'warning' && 'border-amber-300/60 bg-amber-50/90 dark:border-amber-500/30 dark:bg-amber-500/10',
+        tone === 'success' && 'border-emerald-300/60 bg-emerald-50/90 dark:border-emerald-500/30 dark:bg-emerald-500/10',
+        tone === 'default' && 'border-border bg-card/85'
+      )}
+    >
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        </div>
+        {action}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function PriorityStat({
+  icon: Icon,
+  label,
+  value,
+  subtext,
+  emphasis = 'default',
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: string;
+  subtext?: string;
+  emphasis?: 'default' | 'warning' | 'success';
+}) {
+  return (
+    <div className="rounded-[1.6rem] border border-border bg-card/80 p-4 shadow-[0_14px_40px_rgba(8,17,31,0.06)]">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            {label}
+          </p>
+          <p
+            className={cn(
+              'mt-3 text-3xl font-semibold',
+              emphasis === 'warning' && 'text-amber-600 dark:text-amber-300',
+              emphasis === 'success' && 'text-emerald-600 dark:text-emerald-300',
+              emphasis === 'default' && 'text-foreground'
+            )}
+          >
+            {value}
+          </p>
+          {subtext ? <p className="mt-1 text-sm text-muted-foreground">{subtext}</p> : null}
+        </div>
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+          <Icon className="h-5 w-5" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ActionLink({ to, label }: { to: string; label: string }) {
+  return (
+    <Link
+      to={to}
+      className="inline-flex items-center gap-2 rounded-full border border-border bg-background/70 px-4 py-2 text-sm font-medium text-foreground no-underline transition-colors hover:border-primary/30 hover:text-primary"
+    >
+      {label}
+      <ArrowRight className="h-4 w-4" />
+    </Link>
+  );
+}
+
+export default function ControlCenterPage() {
+  const { user } = useAuthStore();
+  const roleMode = getControlCenterRole(user?.role);
+
+  const { data: summary } = useQuery<DashboardSummary>({
+    queryKey: ['dashboard'],
+    queryFn: () => api.get('/dashboard/summary').then((r) => r.data),
+  });
+
+  const { data: financeData } = useQuery<FinanceDashboardSummary>({
+    queryKey: ['dashboard', 'finance-summary'],
+    queryFn: () => api.get('/dashboard/finance-summary').then((r) => r.data),
+  });
+
+  const { data: alerts = [] } = useQuery<InventoryAlert[]>({
+    queryKey: ['inventory', 'alerts'],
+    queryFn: () => api.get('/inventory/alerts').then((r) => r.data),
+  });
+
+  const { data: salesMetrics } = useQuery<SalesMetrics>({
+    queryKey: ['sales', 'metrics'],
+    queryFn: () => api.get('/sales/metrics').then((r) => r.data),
+  });
+
+  const { data: printersData } = useQuery<PaginatedPrinters>({
+    queryKey: ['dashboard', 'printers-live'],
+    queryFn: () => api.get('/printers', { params: { is_active: true, limit: 8 } }).then((r) => r.data),
+    refetchInterval: 10000,
+  });
+
+  const { data: draftJobsData } = useQuery<PaginatedJobs>({
+    queryKey: ['jobs', 'control-center-drafts'],
+    queryFn: () => api.get('/jobs', { params: { status: 'draft', limit: 12 } }).then((r) => r.data),
+  });
+
+  const printers = printersData?.items || [];
+  const draftJobs = draftJobsData?.items || [];
+
+  const attentionPrinters = useMemo(
+    () => printers.filter((printer) => ATTENTION_STATUSES.has(printer.monitor_status || printer.status)),
+    [printers]
+  );
+
+  const busyPrinters = useMemo(
+    () => printers.filter((printer) => (printer.monitor_status || printer.status) === 'printing'),
+    [printers]
+  );
+
+  const unassignedDraftJobs = useMemo(
+    () => draftJobs.filter((job) => !job.printer_id),
+    [draftJobs]
+  );
+
+  const blockerAlerts = alerts.slice(0, 6);
+  const roleHeadline = {
+    admin: 'Owner and admin focus',
+    cashier: 'Cashier focus',
+    floor: 'Print-floor focus',
+    inventory: 'Inventory focus',
+    general: 'Operations focus',
+  }[roleMode];
+
+  const roleDescription = {
+    admin: 'Monitor urgent exceptions first, then scan revenue, inventory value, and open production risk.',
+    cashier: 'Keep checkout moving, watch stock blockers, and stay close to the POS lane.',
+    floor: 'Use this page to spot machine exceptions, draft jobs needing assignment, and printing progress.',
+    inventory: 'Prioritize stock blockers, reconciliation pressure, and products drifting below reorder points.',
+    general: 'Start from urgent work, then move into the workspace that matches your next task.',
+  }[roleMode];
+
+  const quickActions = {
+    admin: [
+      { to: '/print-floor', label: 'Open Print Floor' },
+      { to: '/sell', label: 'Open Sell Workspace' },
+      { to: '/stock', label: 'Open Stock Workspace' },
+    ],
+    cashier: [
+      { to: '/sell', label: 'Open POS Register' },
+      { to: '/sell/sales', label: 'Review Sales' },
+      { to: '/orders/customers', label: 'Customers' },
+    ],
+    floor: [
+      { to: '/print-floor', label: 'Open Printer Wall' },
+      { to: '/orders', label: 'Review Draft Jobs' },
+      { to: '/stock', label: 'Check Stock Risk' },
+    ],
+    inventory: [
+      { to: '/stock', label: 'Open Stock Workspace' },
+      { to: '/stock/materials', label: 'Review Materials' },
+      { to: '/product-studio', label: 'Review Products' },
+    ],
+    general: [
+      { to: '/print-floor', label: 'Print Floor' },
+      { to: '/sell', label: 'Sell' },
+      { to: '/stock', label: 'Stock' },
+    ],
+  }[roleMode];
+
+  return (
+    <div className="space-y-6">
+      <section className="overflow-hidden rounded-[2rem] border border-border bg-[linear-gradient(135deg,rgba(8,17,31,0.98),rgba(17,34,53,0.96))] px-6 py-6 text-white shadow-[0_24px_70px_rgba(8,17,31,0.18)]">
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.65fr)]">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-cyan-200/75">
+              {roleHeadline}
+            </p>
+            <h1 className="mt-3 text-3xl font-semibold md:text-4xl">
+              Control Center
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-200/82 md:text-base">
+              {roleDescription}
+            </p>
+            <div className="mt-5 flex flex-wrap gap-3">
+              {quickActions.map((action) => (
+                <Link
+                  key={action.to}
+                  to={action.to}
+                  className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline shadow-[0_16px_40px_rgba(34,197,94,0.28)] transition-transform hover:-translate-y-0.5"
+                >
+                  {action.label}
+                </Link>
+              ))}
+              <Link
+                to="/dashboard"
+                className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-2 text-sm font-medium text-white no-underline transition-colors hover:bg-white/12"
+              >
+                Classic Dashboard
+              </Link>
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+            <PriorityStat
+              icon={AlertTriangle}
+              label="Needs Attention"
+              value={String(attentionPrinters.length + blockerAlerts.length)}
+              subtext={`${attentionPrinters.length} printers • ${blockerAlerts.length} stock blockers`}
+              emphasis={attentionPrinters.length + blockerAlerts.length > 0 ? 'warning' : 'success'}
+            />
+            <PriorityStat
+              icon={ClipboardList}
+              label="Draft Queue"
+              value={String(unassignedDraftJobs.length)}
+              subtext="Draft jobs without printer assignment"
+              emphasis={unassignedDraftJobs.length > 0 ? 'warning' : 'default'}
+            />
+          </div>
+        </div>
+      </section>
+
+      <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
+        <PriorityStat
+          icon={Printer}
+          label="Printing Now"
+          value={String(busyPrinters.length)}
+          subtext={`${printers.length} active printers in view`}
+          emphasis={busyPrinters.length > 0 ? 'success' : 'default'}
+        />
+        <PriorityStat
+          icon={Boxes}
+          label="Low-Stock Blockers"
+          value={String(alerts.length)}
+          subtext={alerts.length ? 'Products or materials below reorder point' : 'No stock blockers right now'}
+          emphasis={alerts.length ? 'warning' : 'success'}
+        />
+        <PriorityStat
+          icon={Receipt}
+          label="Sales Pulse"
+          value={salesMetrics ? formatCurrency(salesMetrics.gross_sales) : '—'}
+          subtext={salesMetrics ? `${salesMetrics.total_sales} orders • AOV ${formatCurrency(salesMetrics.avg_order_value)}` : 'Sales metrics unavailable'}
+        />
+        <PriorityStat
+          icon={DollarSign}
+          label="Business Pulse"
+          value={financeData ? formatCurrency(financeData.current_month_net_income) : '—'}
+          subtext={financeData ? `Inventory asset ${formatCurrency(financeData.inventory_asset_value)}` : 'Finance summary unavailable'}
+        />
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.75fr)]">
+        <div className="space-y-6">
+          {(roleMode === 'floor' || roleMode === 'admin' || roleMode === 'general') && (
+            <ModuleCard
+              title="Print-floor priorities"
+              description="Machine conditions and print progress that need fast operational awareness."
+              action={<ActionLink to="/print-floor" label="Open Print Floor" />}
+              tone={attentionPrinters.length > 0 ? 'warning' : 'default'}
+            >
+              {!printers.length ? (
+                <p className="text-sm text-muted-foreground">No active printers are available.</p>
+              ) : (
+                <div className="grid gap-3 lg:grid-cols-2">
+                  {printers.slice(0, 4).map((printer) => {
+                    const needsAttention = ATTENTION_STATUSES.has(printer.monitor_status || printer.status);
+                    return (
+                      <Link
+                        key={printer.id}
+                        to={`/print-floor/printers/${printer.id}`}
+                        className={cn(
+                          'grid grid-cols-[88px_minmax(0,1fr)] gap-4 rounded-[1.4rem] border p-3 no-underline transition-colors',
+                          needsAttention
+                            ? 'border-amber-300/70 bg-amber-50/80 dark:border-amber-500/30 dark:bg-amber-500/10'
+                            : 'border-border bg-background/70 hover:border-primary/30'
+                        )}
+                      >
+                        <PrinterThumbnail
+                          src={printer.current_print_thumbnail_url}
+                          alt={printer.current_print_name || `${printer.name} thumbnail`}
+                          className="h-[88px] w-[88px] rounded-2xl"
+                          imgClassName="object-cover"
+                          fallbackLabel="No view"
+                        />
+                        <div className="min-w-0">
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <p className="truncate font-semibold text-foreground">{printer.name}</p>
+                              <p className="truncate text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                                {printer.monitor_status || printer.status}
+                              </p>
+                            </div>
+                            <span className="text-sm font-semibold text-foreground">
+                              {printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}
+                            </span>
+                          </div>
+                          <p className="mt-2 truncate text-sm text-muted-foreground">
+                            {printer.current_print_name || 'No active print'}
+                          </p>
+                          <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+                            <p>Layer {formatLayer(printer)}</p>
+                            <p>ETA {formatDuration(printer.monitor_remaining_seconds)}</p>
+                            <p>{printer.location || 'No bay assigned'}</p>
+                            <p>{printer.monitor_ws_connected ? 'Socket live' : 'Polling'}</p>
+                          </div>
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
+              )}
+            </ModuleCard>
+          )}
+
+          {(roleMode === 'cashier' || roleMode === 'admin' || roleMode === 'general') && (
+            <ModuleCard
+              title="Retail and sales pulse"
+              description="Keep counter checkout moving and watch order mix without leaving the landing page."
+              action={<ActionLink to="/sell" label="Open Sell Workspace" />}
+            >
+              {salesMetrics ? (
+                <div className="grid gap-3 md:grid-cols-3">
+                  <PriorityStat
+                    icon={Receipt}
+                    label="Orders"
+                    value={String(salesMetrics.total_sales)}
+                    subtext={`${salesMetrics.total_units_sold} units sold`}
+                  />
+                  <PriorityStat
+                    icon={TrendingUp}
+                    label="Contribution"
+                    value={formatCurrency(salesMetrics.contribution_margin)}
+                    subtext={
+                      salesMetrics.refund_count > 0
+                        ? `${salesMetrics.refund_count} refunds • ${formatPercent(salesMetrics.refund_rate)} rate`
+                        : 'No refunds recorded'
+                    }
+                  />
+                  <PriorityStat
+                    icon={BarChart3}
+                    label="Avg Order"
+                    value={formatCurrency(salesMetrics.avg_order_value)}
+                    subtext={salesMetrics.payment_method_breakdown[0] ? `Top method ${salesMetrics.payment_method_breakdown[0].payment_method}` : 'Payment mix unavailable'}
+                  />
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">Sales metrics are unavailable.</p>
+              )}
+            </ModuleCard>
+          )}
+
+          {(roleMode === 'inventory' || roleMode === 'admin' || roleMode === 'general') && (
+            <ModuleCard
+              title="Stock blockers"
+              description="Products and materials drifting below reorder points or creating near-term operational risk."
+              action={<ActionLink to="/stock" label="Open Stock Workspace" />}
+              tone={blockerAlerts.length ? 'warning' : 'success'}
+            >
+              {!blockerAlerts.length ? (
+                <p className="text-sm text-muted-foreground">No low-stock blockers are currently open.</p>
+              ) : (
+                <div className="grid gap-3 md:grid-cols-2">
+                  {blockerAlerts.map((alert) => (
+                    <Link
+                      key={`${alert.type}-${alert.id}`}
+                      to={alert.type === 'product' ? `/product-studio/products/${alert.id}` : '/stock/materials'}
+                      className="flex items-center justify-between rounded-[1.25rem] border border-border bg-background/70 px-4 py-3 text-sm no-underline transition-colors hover:border-primary/30"
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate font-medium text-foreground">{alert.name}</p>
+                        <p className="truncate text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                          {alert.type === 'product' ? alert.sku || 'Product' : 'Material'}
+                        </p>
+                      </div>
+                      <div className="text-right">
+                        <p className="font-semibold text-amber-600 dark:text-amber-300">{alert.current_stock}</p>
+                        <p className="text-xs text-muted-foreground">reorder {alert.reorder_point}</p>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </ModuleCard>
+          )}
+        </div>
+
+        <div className="space-y-6">
+          <ModuleCard
+            title="Needs attention now"
+            description="The shortest path to urgent work across printing, stock, and queue pressure."
+            tone={attentionPrinters.length + unassignedDraftJobs.length + blockerAlerts.length > 0 ? 'warning' : 'success'}
+          >
+            <div className="space-y-3">
+              <div className="rounded-[1.25rem] border border-border bg-background/70 p-4">
+                <div className="flex items-center gap-3">
+                  <AlertTriangle className="h-5 w-5 text-amber-500" />
+                  <div>
+                    <p className="font-medium text-foreground">Printers needing attention</p>
+                    <p className="text-sm text-muted-foreground">
+                      {attentionPrinters.length ? `${attentionPrinters.length} printers are paused, offline, or in error.` : 'No printer exceptions currently open.'}
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div className="rounded-[1.25rem] border border-border bg-background/70 p-4">
+                <div className="flex items-center gap-3">
+                  <Package className="h-5 w-5 text-primary" />
+                  <div>
+                    <p className="font-medium text-foreground">Draft jobs needing assignment</p>
+                    <p className="text-sm text-muted-foreground">
+                      {unassignedDraftJobs.length ? `${unassignedDraftJobs.length} draft jobs are still missing a printer.` : 'No unassigned draft jobs.'}
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div className="rounded-[1.25rem] border border-border bg-background/70 p-4">
+                <div className="flex items-center gap-3">
+                  <Sparkles className="h-5 w-5 text-cyan-500" />
+                  <div>
+                    <p className="font-medium text-foreground">Classic metrics still available</p>
+                    <p className="text-sm text-muted-foreground">
+                      Jump into the previous dashboard if you need the older chart-heavy overview.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </ModuleCard>
+
+          <ModuleCard
+            title="Business pulse"
+            description="A compact owner view built from the existing finance and dashboard summaries."
+            action={<ActionLink to="/dashboard" label="Classic Dashboard" />}
+          >
+            <div className="space-y-3">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <PriorityStat
+                  icon={DollarSign}
+                  label="Revenue"
+                  value={summary ? formatCurrency(summary.total_revenue) : '—'}
+                  subtext={summary ? `${summary.total_jobs} jobs • ${summary.total_pieces} pieces` : 'Dashboard summary unavailable'}
+                />
+                <PriorityStat
+                  icon={TrendingUp}
+                  label="Net Profit"
+                  value={summary ? formatCurrency(summary.total_net_profit) : '—'}
+                  subtext={summary ? `Avg margin ${formatPercent(summary.avg_margin_pct)}` : 'Margin unavailable'}
+                />
+              </div>
+              {financeData ? (
+                <div className="rounded-[1.25rem] border border-border bg-background/70 p-4">
+                  <dl className="grid gap-3 text-sm">
+                    <div className="flex items-center justify-between gap-3">
+                      <dt className="text-muted-foreground">Inventory asset value</dt>
+                      <dd className="font-medium text-foreground">{formatCurrency(financeData.inventory_asset_value)}</dd>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <dt className="text-muted-foreground">Cash on hand</dt>
+                      <dd className="font-medium text-foreground">{formatCurrency(financeData.cash_on_hand)}</dd>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <dt className="text-muted-foreground">Unpaid invoices</dt>
+                      <dd className="font-medium text-foreground">{formatCurrency(financeData.unpaid_invoices)}</dd>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <dt className="text-muted-foreground">Tax payable</dt>
+                      <dd className="font-medium text-foreground">{formatCurrency(financeData.tax_payable)}</dd>
+                    </div>
+                  </dl>
+                </div>
+              ) : null}
+            </div>
+          </ModuleCard>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -1,11 +1,23 @@
 import { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { X } from 'lucide-react';
+import {
+  ArrowRight,
+  Boxes,
+  ClipboardCheck,
+  Clock3,
+  PackageSearch,
+  Plus,
+  ScrollText,
+  TrendingDown,
+  TriangleAlert,
+  X,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
-import { formatCurrency } from '@/lib/utils';
+import EmptyState from '@/components/ui/EmptyState';
 import { SkeletonTable } from '@/components/ui/Skeleton';
+import { cn, formatCurrency } from '@/lib/utils';
 import type { InventoryAlert, InventoryReconcileResponse, PaginatedProducts, PaginatedTransactions } from '@/types';
 
 const TYPE_OPTIONS = [
@@ -15,7 +27,7 @@ const TYPE_OPTIONS = [
   { value: 'adjustment', label: 'Adjustment' },
   { value: 'return', label: 'Return' },
   { value: 'waste', label: 'Waste' },
-];
+] as const;
 
 const TYPE_COLORS: Record<string, string> = {
   production: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
@@ -25,8 +37,93 @@ const TYPE_COLORS: Record<string, string> = {
   waste: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
 };
 
+type StockSurface = 'exceptions' | 'ledger';
+
+interface SurfaceButtonProps {
+  active: boolean;
+  label: string;
+  detail: string;
+  onClick: () => void;
+}
+
+function SurfaceButton({ active, label, detail, onClick }: SurfaceButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        'rounded-2xl border px-4 py-3 text-left transition-colors',
+        active
+          ? 'border-primary bg-primary text-primary-foreground shadow-sm'
+          : 'border-border bg-background/80 text-foreground hover:border-primary/35'
+      )}
+    >
+      <p className="text-sm font-semibold">{label}</p>
+      <p className={cn('mt-1 text-xs', active ? 'text-primary-foreground/80' : 'text-muted-foreground')}>{detail}</p>
+    </button>
+  );
+}
+
+interface HeroMetricProps {
+  label: string;
+  value: string;
+  detail: string;
+}
+
+function HeroMetric({ label, value, detail }: HeroMetricProps) {
+  return (
+    <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+      <p className="text-xs uppercase tracking-[0.24em] text-white/55">{label}</p>
+      <p className="mt-3 text-2xl font-semibold">{value}</p>
+      <p className="mt-2 text-sm text-white/70">{detail}</p>
+    </div>
+  );
+}
+
+function TaskCard({
+  title,
+  detail,
+  actionLabel,
+  onAction,
+  tone = 'default',
+}: {
+  title: string;
+  detail: string;
+  actionLabel: string;
+  onAction: () => void;
+  tone?: 'default' | 'warning';
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-3xl border p-5 shadow-sm',
+        tone === 'warning' ? 'border-amber-300/70 bg-amber-50' : 'border-border bg-card'
+      )}
+    >
+      <p className="text-lg font-semibold">{title}</p>
+      <p className={cn('mt-2 text-sm', tone === 'warning' ? 'text-amber-900/80' : 'text-muted-foreground')}>{detail}</p>
+      <button
+        type="button"
+        onClick={onAction}
+        className={cn(
+          'mt-4 inline-flex items-center gap-2 rounded-2xl px-4 py-2 text-sm font-semibold transition-colors',
+          tone === 'warning'
+            ? 'bg-amber-900 text-white hover:opacity-90'
+            : 'bg-primary text-primary-foreground hover:opacity-90'
+        )}
+      >
+        {actionLabel}
+        <ArrowRight className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
 export default function InventoryPage() {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [surface, setSurface] = useState<StockSurface>('exceptions');
   const [search, setSearch] = useState('');
   const [type, setType] = useState('');
   const [dateFrom, setDateFrom] = useState('');
@@ -40,21 +137,24 @@ export default function InventoryPage() {
   const [adjustForm, setAdjustForm] = useState({ product_id: '', type: 'adjustment', quantity: 0, notes: '' });
   const limit = 25;
 
-  const params = useMemo(() => ({
-    skip: page * limit,
-    limit,
-    ...(search ? { search } : {}),
-    ...(type ? { type } : {}),
-    ...(dateFrom ? { date_from: dateFrom } : {}),
-    ...(dateTo ? { date_to: dateTo } : {}),
-  }), [page, limit, search, type, dateFrom, dateTo]);
+  const params = useMemo(
+    () => ({
+      skip: page * limit,
+      limit,
+      ...(search ? { search } : {}),
+      ...(type ? { type } : {}),
+      ...(dateFrom ? { date_from: dateFrom } : {}),
+      ...(dateTo ? { date_to: dateTo } : {}),
+    }),
+    [page, limit, search, type, dateFrom, dateTo]
+  );
 
   const { data, isLoading } = useQuery<PaginatedTransactions>({
     queryKey: ['inventory-transactions', params],
     queryFn: () => api.get('/inventory/transactions', { params }).then((r) => r.data),
   });
 
-  const { data: alerts } = useQuery<InventoryAlert[]>({
+  const { data: alerts = [] } = useQuery<InventoryAlert[]>({
     queryKey: ['inventory-alerts'],
     queryFn: () => api.get('/inventory/alerts').then((r) => r.data),
   });
@@ -64,19 +164,49 @@ export default function InventoryPage() {
     queryFn: () => api.get('/products?is_active=true&limit=200').then((r) => r.data),
   });
 
+  const products = productsData?.items || [];
   const items = data?.items || [];
-  const selectedProduct = productsData?.items.find((product) => product.id === reconcileForm.product_id) || null;
-  const adjustProduct = productsData?.items.find((product) => product.id === adjustForm.product_id) || null;
+  const selectedProduct = products.find((product) => product.id === reconcileForm.product_id) || null;
+  const adjustProduct = products.find((product) => product.id === adjustForm.product_id) || null;
   const variance = selectedProduct ? reconcileForm.counted_qty - selectedProduct.stock_qty : 0;
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / limit)) : 1;
+
+  const productAlerts = alerts.filter((alert) => alert.type === 'product');
+  const materialAlerts = alerts.filter((alert) => alert.type !== 'product');
+  const criticalProductAlerts = productAlerts.filter((alert) => alert.current_stock <= 0);
+  const outOfStockProducts = products.filter((product) => product.stock_qty <= 0);
+  const nearReorderProducts = products.filter(
+    (product) => product.stock_qty > 0 && product.stock_qty <= product.reorder_point
+  );
+  const recentRiskTransactions = items
+    .filter((transaction) => transaction.type === 'adjustment' || transaction.type === 'waste')
+    .slice(0, 5);
 
   const openReconcile = (productId?: string) => {
-    setReconcileForm({ product_id: productId || '', counted_qty: 0, reason: '', notes: '' });
+    const presetProduct = products.find((product) => product.id === productId);
+    setReconcileForm({
+      product_id: productId || '',
+      counted_qty: presetProduct?.stock_qty || 0,
+      reason: '',
+      notes: '',
+    });
     setShowReconcile(true);
   };
 
+  const openAdjust = (productId?: string) => {
+    setAdjustForm({ product_id: productId || '', type: 'adjustment', quantity: 0, notes: '' });
+    setShowAdjust(true);
+  };
+
   const submitReconcile = async () => {
-    if (!reconcileForm.product_id) { toast.error('Select a product'); return; }
-    if (!reconcileForm.reason.trim()) { toast.error('Reason is required'); return; }
+    if (!reconcileForm.product_id) {
+      toast.error('Select a product');
+      return;
+    }
+    if (!reconcileForm.reason.trim()) {
+      toast.error('Reason is required');
+      return;
+    }
     setReconcileSaving(true);
     try {
       const { data } = await api.post<InventoryReconcileResponse>('/inventory/reconcile', reconcileForm);
@@ -92,15 +222,19 @@ export default function InventoryPage() {
     }
   };
 
-  const openAdjust = (productId?: string) => {
-    setAdjustForm({ product_id: productId || '', type: 'adjustment', quantity: 0, notes: '' });
-    setShowAdjust(true);
-  };
-
   const submitAdjust = async () => {
-    if (!adjustForm.product_id) { toast.error('Select a product'); return; }
-    if (adjustForm.quantity === 0) { toast.error('Quantity cannot be 0'); return; }
-    if (adjustForm.type === 'adjustment' && !adjustForm.notes.trim()) { toast.error('Adjustment notes are required'); return; }
+    if (!adjustForm.product_id) {
+      toast.error('Select a product');
+      return;
+    }
+    if (adjustForm.quantity === 0) {
+      toast.error('Quantity cannot be 0');
+      return;
+    }
+    if (adjustForm.type === 'adjustment' && !adjustForm.notes.trim()) {
+      toast.error('Adjustment notes are required');
+      return;
+    }
     setAdjustSaving(true);
     try {
       await api.post('/inventory/transactions', {
@@ -121,209 +255,690 @@ export default function InventoryPage() {
       setAdjustSaving(false);
     }
   };
-  const totalPages = data ? Math.max(1, Math.ceil(data.total / limit)) : 1;
 
   return (
     <div className="max-w-7xl mx-auto space-y-6">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-bold">Inventory</h1>
-          <p className="text-sm text-muted-foreground mt-1">Global stock ledger, recent movements, and low-stock operational view.</p>
-        </div>
-        <button onClick={() => openReconcile()} className="bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90">
-          Reconcile Stock
-        </button>
-      </div>
+      <section className="rounded-[2rem] border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(19,52,34,0.96)_100%)] p-6 text-white shadow-sm">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-sm uppercase tracking-[0.3em] text-white/65">Stock Workspace</p>
+            <h1 className="mt-3 flex items-center gap-3 text-3xl font-bold">
+              <Boxes className="h-8 w-8" />
+              Exceptions first
+            </h1>
+            <p className="mt-3 text-sm text-white/80">
+              Lead with stock problems that affect selling and fulfillment. The ledger is still here, but it no longer gets the best seat in the room.
+            </p>
+          </div>
 
-      {showReconcile && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={(e) => e.target === e.currentTarget && setShowReconcile(false)}>
-          <div className="bg-card border border-border rounded-lg p-6 w-full max-w-lg">
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="text-lg font-semibold">Stock Reconciliation</h2>
-              <button type="button" onClick={() => setShowReconcile(false)} className="p-1 hover:bg-accent rounded-md"><X className="w-5 h-5" /></button>
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={() => openReconcile()}
+              className="inline-flex min-h-12 items-center gap-2 rounded-2xl bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+            >
+              <ClipboardCheck className="h-4 w-4" />
+              Reconcile stock
+            </button>
+            <button
+              type="button"
+              onClick={() => openAdjust()}
+              className="inline-flex min-h-12 items-center gap-2 rounded-2xl border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white transition-colors hover:bg-white/15"
+            >
+              <Plus className="h-4 w-4" />
+              Quick adjustment
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-3 lg:grid-cols-4">
+          <HeroMetric
+            label="Product Alerts"
+            value={String(productAlerts.length)}
+            detail="POS and finished-goods issues requiring action"
+          />
+          <HeroMetric
+            label="Critical Stockouts"
+            value={String(criticalProductAlerts.length)}
+            detail="Products already at zero stock"
+          />
+          <HeroMetric
+            label="Near Reorder"
+            value={String(nearReorderProducts.length)}
+            detail="Products still sellable but nearing depletion"
+          />
+          <HeroMetric
+            label="Material Signals"
+            value={String(materialAlerts.length)}
+            detail="Lower-priority material stock issues"
+          />
+        </div>
+      </section>
+
+      {showReconcile ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={(event) => event.target === event.currentTarget && setShowReconcile(false)}
+        >
+          <div className="w-full max-w-lg rounded-2xl border border-border bg-card p-6 shadow-xl">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-lg font-semibold">Stock reconciliation</h2>
+              <button
+                type="button"
+                onClick={() => setShowReconcile(false)}
+                className="rounded-md p-1 transition-colors hover:bg-accent"
+              >
+                <X className="h-5 w-5" />
+              </button>
             </div>
+
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium mb-1">Product</label>
-                <select value={reconcileForm.product_id} onChange={(e) => setReconcileForm((f) => ({ ...f, product_id: e.target.value }))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring">
+                <label className="mb-1 block text-sm font-medium">Product</label>
+                <select
+                  value={reconcileForm.product_id}
+                  onChange={(event) => setReconcileForm((form) => ({ ...form, product_id: event.target.value }))}
+                  className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+                >
                   <option value="">Select product...</option>
-                  {productsData?.items.map((product) => (
-                    <option key={product.id} value={product.id}>{product.name} ({product.sku})</option>
+                  {products.map((product) => (
+                    <option key={product.id} value={product.id}>
+                      {product.name} ({product.sku})
+                    </option>
                   ))}
                 </select>
               </div>
-              {selectedProduct && (
-                <div className="grid grid-cols-2 gap-4 text-sm bg-accent/40 rounded-md p-3">
+
+              {selectedProduct ? (
+                <div className="grid grid-cols-2 gap-4 rounded-xl bg-accent/40 p-3 text-sm">
                   <div>
                     <p className="text-muted-foreground">Current system qty</p>
                     <p className="text-lg font-semibold">{selectedProduct.stock_qty}</p>
                   </div>
                   <div>
                     <p className="text-muted-foreground">Variance</p>
-                    <p className={`text-lg font-semibold ${variance > 0 ? 'text-green-600 dark:text-green-400' : variance < 0 ? 'text-red-600 dark:text-red-400' : ''}`}>{variance > 0 ? '+' : ''}{variance}</p>
+                    <p
+                      className={cn(
+                        'text-lg font-semibold',
+                        variance > 0 && 'text-green-600 dark:text-green-400',
+                        variance < 0 && 'text-red-600 dark:text-red-400'
+                      )}
+                    >
+                      {variance > 0 ? '+' : ''}
+                      {variance}
+                    </p>
                   </div>
                 </div>
-              )}
+              ) : null}
+
               <div>
-                <label className="block text-sm font-medium mb-1">Counted quantity</label>
-                <input type="number" min="0" value={reconcileForm.counted_qty} onChange={(e) => setReconcileForm((f) => ({ ...f, counted_qty: Number(e.target.value) }))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+                <label className="mb-1 block text-sm font-medium">Counted quantity</label>
+                <input
+                  type="number"
+                  min="0"
+                  value={reconcileForm.counted_qty}
+                  onChange={(event) =>
+                    setReconcileForm((form) => ({ ...form, counted_qty: Number(event.target.value) }))
+                  }
+                  className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+                />
               </div>
+
               <div>
-                <label className="block text-sm font-medium mb-1">Reason</label>
-                <input value={reconcileForm.reason} onChange={(e) => setReconcileForm((f) => ({ ...f, reason: e.target.value }))} placeholder="Cycle count, shelf recount, received correction..." className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+                <label className="mb-1 block text-sm font-medium">Reason</label>
+                <input
+                  value={reconcileForm.reason}
+                  onChange={(event) => setReconcileForm((form) => ({ ...form, reason: event.target.value }))}
+                  placeholder="Cycle count, shelf recount, received correction..."
+                  className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+                />
               </div>
+
               <div>
-                <label className="block text-sm font-medium mb-1">Notes</label>
-                <textarea value={reconcileForm.notes} onChange={(e) => setReconcileForm((f) => ({ ...f, notes: e.target.value }))} rows={3} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+                <label className="mb-1 block text-sm font-medium">Notes</label>
+                <textarea
+                  value={reconcileForm.notes}
+                  onChange={(event) => setReconcileForm((form) => ({ ...form, notes: event.target.value }))}
+                  rows={3}
+                  className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+                />
               </div>
             </div>
-            <div className="flex gap-3 mt-6">
-              <button onClick={submitReconcile} disabled={reconcileSaving} className="flex-1 bg-primary text-primary-foreground py-2 rounded-md font-medium hover:opacity-90 disabled:opacity-50">{reconcileSaving ? 'Submitting...' : 'Submit Reconciliation'}</button>
-              <button onClick={() => setShowReconcile(false)} className="px-4 py-2 border border-border rounded-md hover:bg-accent">Cancel</button>
+
+            <div className="mt-6 flex gap-3">
+              <button
+                type="button"
+                onClick={submitReconcile}
+                disabled={reconcileSaving}
+                className="flex-1 rounded-xl bg-primary py-2.5 font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+              >
+                {reconcileSaving ? 'Submitting...' : 'Submit Reconciliation'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowReconcile(false)}
+                className="rounded-xl border border-border px-4 py-2.5 transition-colors hover:bg-accent"
+              >
+                Cancel
+              </button>
             </div>
           </div>
         </div>
-      )}
+      ) : null}
 
-      {showAdjust && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={(e) => e.target === e.currentTarget && setShowAdjust(false)}>
-          <div className="bg-card border border-border rounded-lg p-6 w-full max-w-md">
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="text-lg font-semibold">Quick Stock Adjustment</h2>
-              <button type="button" onClick={() => setShowAdjust(false)} className="p-1 hover:bg-accent rounded-md"><X className="w-5 h-5" /></button>
+      {showAdjust ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={(event) => event.target === event.currentTarget && setShowAdjust(false)}
+        >
+          <div className="w-full max-w-md rounded-2xl border border-border bg-card p-6 shadow-xl">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-lg font-semibold">Quick stock adjustment</h2>
+              <button
+                type="button"
+                onClick={() => setShowAdjust(false)}
+                className="rounded-md p-1 transition-colors hover:bg-accent"
+              >
+                <X className="h-5 w-5" />
+              </button>
             </div>
+
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium mb-1">Product</label>
-                <select value={adjustForm.product_id} onChange={(e) => setAdjustForm((f) => ({ ...f, product_id: e.target.value }))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring">
+                <label className="mb-1 block text-sm font-medium">Product</label>
+                <select
+                  value={adjustForm.product_id}
+                  onChange={(event) => setAdjustForm((form) => ({ ...form, product_id: event.target.value }))}
+                  className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+                >
                   <option value="">Select product...</option>
-                  {productsData?.items.map((product) => (
-                    <option key={product.id} value={product.id}>{product.name} ({product.sku})</option>
+                  {products.map((product) => (
+                    <option key={product.id} value={product.id}>
+                      {product.name} ({product.sku})
+                    </option>
                   ))}
                 </select>
               </div>
-              {adjustProduct && (
-                <div className="text-sm bg-accent/40 rounded-md p-3">
+
+              {adjustProduct ? (
+                <div className="rounded-xl bg-accent/40 p-3 text-sm">
                   <p className="text-muted-foreground">Current stock</p>
                   <p className="text-lg font-semibold">{adjustProduct.stock_qty}</p>
                 </div>
-              )}
+              ) : null}
+
               <div>
-                <label className="block text-sm font-medium mb-1">Type</label>
-                <select value={adjustForm.type} onChange={(e) => setAdjustForm((f) => ({ ...f, type: e.target.value }))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring">
+                <label className="mb-1 block text-sm font-medium">Type</label>
+                <select
+                  value={adjustForm.type}
+                  onChange={(event) => setAdjustForm((form) => ({ ...form, type: event.target.value }))}
+                  className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+                >
                   {TYPE_OPTIONS.filter((option) => option.value).map((option) => (
-                    <option key={option.value} value={option.value}>{option.label}</option>
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
                   ))}
                 </select>
               </div>
+
               <div>
-                <label className="block text-sm font-medium mb-1">Quantity</label>
-                <input type="number" value={adjustForm.quantity} onChange={(e) => setAdjustForm((f) => ({ ...f, quantity: Number(e.target.value) }))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" placeholder="Positive to add, negative to remove" />
+                <label className="mb-1 block text-sm font-medium">Quantity</label>
+                <input
+                  type="number"
+                  value={adjustForm.quantity}
+                  onChange={(event) => setAdjustForm((form) => ({ ...form, quantity: Number(event.target.value) }))}
+                  placeholder="Positive to add, negative to remove"
+                  className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+                />
               </div>
+
               <div>
-                <label className="block text-sm font-medium mb-1">Notes</label>
-                <textarea value={adjustForm.notes} onChange={(e) => setAdjustForm((f) => ({ ...f, notes: e.target.value }))} rows={3} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" placeholder="Reason for adjustment" />
+                <label className="mb-1 block text-sm font-medium">Notes</label>
+                <textarea
+                  value={adjustForm.notes}
+                  onChange={(event) => setAdjustForm((form) => ({ ...form, notes: event.target.value }))}
+                  rows={3}
+                  placeholder="Reason for adjustment"
+                  className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+                />
               </div>
             </div>
-            <div className="flex gap-3 mt-6">
-              <button onClick={submitAdjust} disabled={adjustSaving} className="flex-1 bg-primary text-primary-foreground py-2 rounded-md font-medium hover:opacity-90 disabled:opacity-50">{adjustSaving ? 'Submitting...' : 'Submit Adjustment'}</button>
-              <button onClick={() => setShowAdjust(false)} className="px-4 py-2 border border-border rounded-md hover:bg-accent">Cancel</button>
+
+            <div className="mt-6 flex gap-3">
+              <button
+                type="button"
+                onClick={submitAdjust}
+                disabled={adjustSaving}
+                className="flex-1 rounded-xl bg-primary py-2.5 font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+              >
+                {adjustSaving ? 'Submitting...' : 'Submit Adjustment'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowAdjust(false)}
+                className="rounded-xl border border-border px-4 py-2.5 transition-colors hover:bg-accent"
+              >
+                Cancel
+              </button>
             </div>
           </div>
         </div>
-      )}
+      ) : null}
 
-      <div className="bg-card border border-border rounded-lg p-4 grid grid-cols-1 md:grid-cols-4 gap-4">
-        <input
-          value={search}
-          onChange={(e) => { setSearch(e.target.value); setPage(0); }}
-          placeholder="Search product name or SKU"
-          className="px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <TaskCard
+          title="Cycle counts"
+          detail="Start a reconciliation without digging through historical transactions first."
+          actionLabel="Open reconcile"
+          onAction={() => openReconcile()}
         />
-        <select value={type} onChange={(e) => { setType(e.target.value); setPage(0); }} className="px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring">
-          {TYPE_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
-        </select>
-        <input type="date" value={dateFrom} onChange={(e) => { setDateFrom(e.target.value); setPage(0); }} className="px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
-        <input type="date" value={dateTo} onChange={(e) => { setDateTo(e.target.value); setPage(0); }} className="px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
-      </div>
+        <TaskCard
+          title="Manual correction"
+          detail="Record a quick adjustment when the shelf count is already understood."
+          actionLabel="Open adjustment"
+          onAction={() => openAdjust()}
+        />
+        <TaskCard
+          title="Materials lane"
+          detail="Material spool inventory is still available, but it stays out of the urgent product queue."
+          actionLabel="Open materials"
+          onAction={() => navigate('/stock/materials')}
+        />
+        <TaskCard
+          title="Risk ledger"
+          detail="Recent waste and adjustment entries are visible below, with the full ledger one tap away."
+          actionLabel="Open ledger"
+          onAction={() => setSurface('ledger')}
+          tone="warning"
+        />
+      </section>
 
-      <div className="bg-card border border-border rounded-lg p-4">
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold">Low-stock alerts</h2>
-          <span className="text-xs text-muted-foreground">Quick links only for now; reconcile flow comes next.</span>
+      <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-[0.24em] text-muted-foreground">Workspace Surfaces</p>
+            <h2 className="mt-2 text-2xl font-semibold">Stock home</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Exceptions stay above the fold. The ledger is still accessible, but it is now a deliberate secondary view.
+            </p>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <SurfaceButton
+              active={surface === 'exceptions'}
+              label="Exceptions"
+              detail="Urgent inventory issues and task-driven actions"
+              onClick={() => setSurface('exceptions')}
+            />
+            <SurfaceButton
+              active={surface === 'ledger'}
+              label="Ledger"
+              detail="Historical transaction search and audit trail"
+              onClick={() => setSurface('ledger')}
+            />
+          </div>
         </div>
-        {!alerts?.length ? (
-          <p className="text-sm text-muted-foreground">No low-stock alerts.</p>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {alerts.map((alert) => (
-              <div key={`${alert.type}-${alert.id}`} className="border border-border rounded-md p-3 flex items-center justify-between gap-4">
-                <div>
-                  <p className="font-medium">{alert.name}</p>
-                  <p className="text-xs text-muted-foreground">{alert.type === 'product' ? (alert.sku || 'No SKU') : 'Material'} · Stock {alert.current_stock} / Reorder {alert.reorder_point}</p>
+      </section>
+
+      {surface === 'exceptions' ? (
+        <div className="space-y-6">
+          <section className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]">
+            <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+              <div className="flex items-center gap-2">
+                <TriangleAlert className="h-5 w-5 text-destructive" />
+                <h2 className="text-xl font-semibold">Product exceptions</h2>
+              </div>
+              <p className="mt-2 text-sm text-muted-foreground">
+                These issues affect sellable finished goods first. Product-impacting stock problems stay visually separate from raw-material status.
+              </p>
+
+              {!productAlerts.length ? (
+                <EmptyState
+                  icon="products"
+                  title="No product exceptions"
+                  description="Finished-goods stock is currently above its urgent exception threshold."
+                  className="py-10"
+                />
+              ) : (
+                <div className="mt-4 space-y-3">
+                  {productAlerts.map((alert) => {
+                    const isCritical = alert.current_stock <= 0;
+                    return (
+                      <div
+                        key={`${alert.type}-${alert.id}`}
+                        className={cn(
+                          'rounded-2xl border p-4',
+                          isCritical ? 'border-destructive/35 bg-destructive/5' : 'border-amber-300/60 bg-amber-50/70'
+                        )}
+                      >
+                        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                          <div>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <p className="font-semibold">{alert.name}</p>
+                              <span
+                                className={cn(
+                                  'rounded-full px-2.5 py-0.5 text-xs font-semibold',
+                                  isCritical
+                                    ? 'bg-destructive text-destructive-foreground'
+                                    : 'bg-amber-100 text-amber-900'
+                                )}
+                              >
+                                {isCritical ? 'Stockout' : 'Reorder risk'}
+                              </span>
+                            </div>
+                            <p className="mt-2 text-sm text-muted-foreground">
+                              {(alert.sku || 'No SKU')} • Stock {alert.current_stock} / Reorder {alert.reorder_point}
+                            </p>
+                          </div>
+
+                          <div className="flex flex-wrap gap-2 text-sm">
+                            <button
+                              type="button"
+                              onClick={() => openAdjust(alert.id)}
+                              className="rounded-xl bg-primary px-3 py-2 font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+                            >
+                              Adjust
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => openReconcile(alert.id)}
+                              className="rounded-xl border border-border px-3 py-2 font-semibold transition-colors hover:bg-accent"
+                            >
+                              Reconcile
+                            </button>
+                            <Link
+                              className="inline-flex items-center rounded-xl border border-border px-3 py-2 font-semibold text-foreground no-underline transition-colors hover:bg-accent"
+                              to={`/product-studio/products/${alert.id}`}
+                            >
+                              View product
+                            </Link>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
-                <div className="flex gap-2 text-sm">
-                  {alert.type === 'product' ? (
-                    <>
-                      <button type="button" onClick={() => openAdjust(alert.id)} className="text-primary hover:underline">Adjust</button>
-                      <button type="button" onClick={() => openReconcile(alert.id)} className="text-primary hover:underline">Reconcile</button>
-                      <Link className="text-primary hover:underline" to={`/products/${alert.id}`}>View product</Link>
-                    </>
-                  ) : (
-                    <Link className="text-primary hover:underline" to="/materials">View materials</Link>
-                  )}
+              )}
+            </div>
+
+            <div className="space-y-4">
+              <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+                <div className="flex items-center gap-2">
+                  <PackageSearch className="h-5 w-5 text-muted-foreground" />
+                  <h2 className="text-xl font-semibold">Exception summary</h2>
+                </div>
+                <div className="mt-4 space-y-3">
+                  <div className="rounded-2xl bg-background px-4 py-3">
+                    <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Out of stock</p>
+                    <p className="mt-2 text-2xl font-semibold">{outOfStockProducts.length}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">Products that cannot be sold from POS right now.</p>
+                  </div>
+                  <div className="rounded-2xl bg-background px-4 py-3">
+                    <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Near reorder</p>
+                    <p className="mt-2 text-2xl font-semibold">{nearReorderProducts.length}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">Products that still have stock but need floor attention soon.</p>
+                  </div>
+                  <div className="rounded-2xl bg-background px-4 py-3">
+                    <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Material signals</p>
+                    <p className="mt-2 text-2xl font-semibold">{materialAlerts.length}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">Raw-material alerts kept in a separate lane.</p>
+                  </div>
                 </div>
               </div>
-            ))}
-          </div>
-        )}
-      </div>
 
-      {isLoading ? (
-        <SkeletonTable rows={8} cols={8} />
-      ) : !items.length ? (
-        <div className="bg-card border border-border rounded-lg p-8 text-center text-muted-foreground">No inventory transactions found</div>
+              <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+                <div className="flex items-center gap-2">
+                  <ScrollText className="h-5 w-5 text-muted-foreground" />
+                  <h2 className="text-xl font-semibold">Recent risky movements</h2>
+                </div>
+
+                {!recentRiskTransactions.length ? (
+                  <p className="mt-4 text-sm text-muted-foreground">No recent adjustment or waste transactions in the current ledger window.</p>
+                ) : (
+                  <div className="mt-4 space-y-3">
+                    {recentRiskTransactions.map((transaction) => (
+                      <div key={transaction.id} className="rounded-2xl border border-border bg-background/80 px-4 py-3">
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <p className="font-medium">{transaction.product_name || transaction.product_id}</p>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {transaction.created_at ? new Date(transaction.created_at).toLocaleString() : '-'}
+                            </p>
+                          </div>
+                          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[transaction.type] || ''}`}>
+                            {transaction.type}
+                          </span>
+                        </div>
+                        <div className="mt-3 flex items-center justify-between text-sm">
+                          <p className="text-muted-foreground">{transaction.notes || 'No notes provided'}</p>
+                          <p className={cn('font-semibold', transaction.quantity < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400')}>
+                            {transaction.quantity > 0 ? '+' : ''}
+                            {transaction.quantity}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                <button
+                  type="button"
+                  onClick={() => setSurface('ledger')}
+                  className="mt-4 inline-flex items-center gap-2 rounded-2xl border border-border px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent"
+                >
+                  Open full ledger
+                  <ArrowRight className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <section className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
+            <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+              <div className="flex items-center gap-2">
+                <TrendingDown className="h-5 w-5 text-amber-600" />
+                <h2 className="text-xl font-semibold">Materials lane</h2>
+              </div>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Material shortages still matter, but they are separated from finished-goods actions so the stock workspace favors immediate selling and fulfillment risk first.
+              </p>
+
+              {!materialAlerts.length ? (
+                <p className="mt-4 text-sm text-muted-foreground">No material-specific low-stock alerts right now.</p>
+              ) : (
+                <div className="mt-4 space-y-3">
+                  {materialAlerts.map((alert) => (
+                    <div key={`${alert.type}-${alert.id}`} className="rounded-2xl border border-border bg-background/80 px-4 py-3">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="font-medium">{alert.name}</p>
+                          <p className="mt-1 text-sm text-muted-foreground">
+                            Stock {alert.current_stock} / Reorder {alert.reorder_point}
+                          </p>
+                        </div>
+                        <Link
+                          to="/stock/materials"
+                          className="inline-flex items-center rounded-xl border border-border px-3 py-2 text-sm font-semibold text-foreground no-underline transition-colors hover:bg-accent"
+                        >
+                          View materials
+                        </Link>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+              <div className="flex items-center gap-2">
+                <Clock3 className="h-5 w-5 text-muted-foreground" />
+                <h2 className="text-xl font-semibold">Quick reminders</h2>
+              </div>
+              <div className="mt-4 space-y-3 text-sm text-muted-foreground">
+                <p>Reconcile when the shelf count is uncertain.</p>
+                <p>Use quick adjustment only when the count is already understood.</p>
+                <p>Finished-product issues should be handled before material-only cleanup.</p>
+              </div>
+            </div>
+          </section>
+        </div>
       ) : (
-        <div className="overflow-x-auto bg-card border border-border rounded-lg">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border text-left text-muted-foreground">
-                <th className="px-4 py-3 font-medium">Date</th>
-                <th className="px-4 py-3 font-medium">Product</th>
-                <th className="px-4 py-3 font-medium">SKU</th>
-                <th className="px-4 py-3 font-medium">Type</th>
-                <th className="px-4 py-3 font-medium text-right">Qty</th>
-                <th className="px-4 py-3 font-medium text-right">Unit Cost</th>
-                <th className="px-4 py-3 font-medium">Job</th>
-                <th className="px-4 py-3 font-medium">Notes</th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.map((t) => (
-                <tr key={t.id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                  <td className="px-4 py-3 text-xs">{t.created_at ? new Date(t.created_at).toLocaleString() : '-'}</td>
-                  <td className="px-4 py-3">
-                    {t.product_name ? <Link className="font-medium hover:underline" to={`/products/${t.product_id}`}>{t.product_name}</Link> : t.product_id}
-                  </td>
-                  <td className="px-4 py-3 font-mono text-xs">{t.product_sku || '-'}</td>
-                  <td className="px-4 py-3"><span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${TYPE_COLORS[t.type] || ''}`}>{t.type}</span></td>
-                  <td className={`px-4 py-3 text-right font-medium ${t.quantity > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>{t.quantity > 0 ? '+' : ''}{t.quantity}</td>
-                  <td className="px-4 py-3 text-right">{formatCurrency(t.unit_cost)}</td>
-                  <td className="px-4 py-3 font-mono text-xs">{t.job_id || '-'}</td>
-                  <td className="px-4 py-3 text-xs text-muted-foreground">{t.notes || '-'}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="space-y-6">
+          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <div className="flex items-center gap-2">
+                  <ScrollText className="h-5 w-5 text-muted-foreground" />
+                  <h2 className="text-xl font-semibold">Inventory ledger</h2>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Full transaction history stays available for audit work and troubleshooting, but it is intentionally a secondary surface.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSurface('exceptions')}
+                className="inline-flex items-center gap-2 rounded-2xl border border-border px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent"
+              >
+                Back to exceptions
+              </button>
+            </div>
+
+            <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-4">
+              <input
+                value={search}
+                onChange={(event) => {
+                  setSearch(event.target.value);
+                  setPage(0);
+                }}
+                placeholder="Search product name or SKU"
+                className="rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+              <select
+                value={type}
+                onChange={(event) => {
+                  setType(event.target.value);
+                  setPage(0);
+                }}
+                className="rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                {TYPE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="date"
+                value={dateFrom}
+                onChange={(event) => {
+                  setDateFrom(event.target.value);
+                  setPage(0);
+                }}
+                className="rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+              <input
+                type="date"
+                value={dateTo}
+                onChange={(event) => {
+                  setDateTo(event.target.value);
+                  setPage(0);
+                }}
+                className="rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+          </section>
+
+          {isLoading ? (
+            <SkeletonTable rows={8} cols={8} />
+          ) : !items.length ? (
+            <div className="rounded-3xl border border-border bg-card p-8 text-center text-muted-foreground">
+              No inventory transactions found
+            </div>
+          ) : (
+            <div className="overflow-x-auto rounded-3xl border border-border bg-card shadow-sm">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border text-left text-muted-foreground">
+                    <th className="px-4 py-3 font-medium">Date</th>
+                    <th className="px-4 py-3 font-medium">Product</th>
+                    <th className="px-4 py-3 font-medium">SKU</th>
+                    <th className="px-4 py-3 font-medium">Type</th>
+                    <th className="px-4 py-3 font-medium text-right">Qty</th>
+                    <th className="px-4 py-3 font-medium text-right">Unit Cost</th>
+                    <th className="px-4 py-3 font-medium">Job</th>
+                    <th className="px-4 py-3 font-medium">Notes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((transaction) => (
+                    <tr key={transaction.id} className="border-b border-border last:border-0 hover:bg-accent/50">
+                      <td className="px-4 py-3 text-xs">
+                        {transaction.created_at ? new Date(transaction.created_at).toLocaleString() : '-'}
+                      </td>
+                      <td className="px-4 py-3">
+                        {transaction.product_name ? (
+                          <Link className="font-medium hover:underline" to={`/products/${transaction.product_id}`}>
+                            {transaction.product_name}
+                          </Link>
+                        ) : (
+                          transaction.product_id
+                        )}
+                      </td>
+                      <td className="px-4 py-3 font-mono text-xs">{transaction.product_sku || '-'}</td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[transaction.type] || ''}`}>
+                          {transaction.type}
+                        </span>
+                      </td>
+                      <td
+                        className={cn(
+                          'px-4 py-3 text-right font-medium',
+                          transaction.quantity > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                        )}
+                      >
+                        {transaction.quantity > 0 ? '+' : ''}
+                        {transaction.quantity}
+                      </td>
+                      <td className="px-4 py-3 text-right">{formatCurrency(transaction.unit_cost)}</td>
+                      <td className="px-4 py-3 font-mono text-xs">{transaction.job_id || '-'}</td>
+                      <td className="px-4 py-3 text-xs text-muted-foreground">{transaction.notes || '-'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <div className="flex items-center justify-between text-sm">
+            <p className="text-muted-foreground">
+              Page {page + 1} of {totalPages}
+            </p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setPage((current) => Math.max(0, current - 1))}
+                disabled={page === 0}
+                className="rounded-xl border border-border px-3 py-2 transition-colors hover:bg-accent disabled:opacity-50"
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                onClick={() => setPage((current) => (current + 1 < totalPages ? current + 1 : current))}
+                disabled={page + 1 >= totalPages}
+                className="rounded-xl border border-border px-3 py-2 transition-colors hover:bg-accent disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          </div>
         </div>
       )}
 
-      <div className="flex items-center justify-between text-sm">
-        <p className="text-muted-foreground">Page {page + 1} of {totalPages}</p>
-        <div className="flex gap-2">
-          <button onClick={() => setPage((p) => Math.max(0, p - 1))} disabled={page === 0} className="px-3 py-2 border border-border rounded-md disabled:opacity-50 hover:bg-accent">Previous</button>
-          <button onClick={() => setPage((p) => (p + 1 < totalPages ? p + 1 : p))} disabled={page + 1 >= totalPages} className="px-3 py-2 border border-border rounded-md disabled:opacity-50 hover:bg-accent">Next</button>
-        </div>
+      <div className="sr-only" aria-live="polite">
+        Stock surface: {surface}
       </div>
     </div>
   );

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -32,7 +32,7 @@ export default function JobDetailPage() {
     try {
       await api.delete(`/jobs/${id}`);
       toast.success('Job deleted');
-      navigate('/jobs');
+      navigate('/orders/jobs');
     } catch {
       toast.error('Failed to delete job');
     }
@@ -44,7 +44,7 @@ export default function JobDetailPage() {
       const { data } = await api.post(`/jobs/${id}/duplicate`);
       queryClient.invalidateQueries({ queryKey: ['jobs'] });
       toast.success('Job copied to draft successfully');
-      navigate(`/jobs/${data.id}`);
+      navigate(`/orders/jobs/${data.id}`);
     } catch (err: any) {
       toast.error(err.response?.data?.detail || 'Failed to copy job');
     } finally {
@@ -66,7 +66,7 @@ export default function JobDetailPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
-          <Link to="/jobs" className="p-2 rounded-md hover:bg-accent text-muted-foreground no-underline">
+          <Link to="/orders/jobs" className="p-2 rounded-md hover:bg-accent text-muted-foreground no-underline">
             <ArrowLeft className="w-5 h-5" />
           </Link>
           <div>
@@ -81,7 +81,7 @@ export default function JobDetailPage() {
           <button onClick={handleDuplicate} disabled={duplicating} className="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium hover:bg-accent transition-colors disabled:opacity-50 cursor-pointer">
             <Copy className="w-4 h-4" /> {duplicating ? 'Copying...' : 'Copy to New Job'}
           </button>
-          <Link to={`/jobs/${id}/edit`} className="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium hover:bg-accent transition-colors no-underline">
+          <Link to={`/orders/jobs/${id}/edit`} className="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium hover:bg-accent transition-colors no-underline">
             <Edit className="w-4 h-4" /> Edit
           </Link>
           <button onClick={handleDelete} className="px-4 py-2 border border-destructive/30 text-destructive rounded-lg text-sm font-medium hover:bg-destructive/10 transition-colors">

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -45,7 +45,7 @@ export default function JobsPage() {
       const { data } = await api.post(`/jobs/${job.id}/duplicate`);
       queryClient.invalidateQueries({ queryKey: ['jobs'] });
       toast.success('Job copied to draft successfully');
-      navigate(`/jobs/${data.id}`);
+      navigate(`/orders/jobs/${data.id}`);
     } catch (err: any) {
       toast.error(err.response?.data?.detail || 'Failed to copy job');
     } finally {
@@ -58,7 +58,7 @@ export default function JobsPage() {
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-3xl font-bold">Jobs</h1>
         <Link
-          to="/jobs/new"
+          to="/orders/jobs/new"
           className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 transition-opacity no-underline"
         >
           <Plus className="w-4 h-4" /> New Job
@@ -118,7 +118,7 @@ export default function JobsPage() {
                 {jobs.map((job) => (
                   <tr key={job.id} className="border-b border-border last:border-0 hover:bg-accent/50 transition-colors">
                     <td className="px-4 py-3">
-                      <Link to={`/jobs/${job.id}`} className="text-primary hover:underline font-medium no-underline">
+                      <Link to={`/orders/jobs/${job.id}`} className="text-primary hover:underline font-medium no-underline">
                         {job.job_number}
                       </Link>
                     </td>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -23,7 +23,7 @@ export default function LoginPage() {
   const location = useLocation();
   const { dark, toggle } = useTheme();
 
-  const from = (location.state as { from?: { pathname: string } })?.from?.pathname || '/';
+  const from = (location.state as { from?: { pathname: string } })?.from?.pathname || '/control-center';
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/pages/OrdersPage.tsx
+++ b/frontend/src/pages/OrdersPage.tsx
@@ -1,0 +1,375 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import {
+  ArrowRight,
+  Boxes,
+  ClipboardList,
+  Eye,
+  PackageOpen,
+  Printer,
+  Receipt,
+  TriangleAlert,
+  User,
+} from 'lucide-react';
+import api from '@/api/client';
+import EmptyState from '@/components/ui/EmptyState';
+import { SkeletonTable } from '@/components/ui/Skeleton';
+import { cn, formatCurrency } from '@/lib/utils';
+import type { Customer, Job, PaginatedJobs, PaginatedPrinters, PaginatedSales, SaleListItem } from '@/types';
+
+const ATTENTION_PRINTER_STATUSES = new Set(['paused', 'maintenance', 'offline', 'error']);
+
+function QueueStat({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+      <p className="text-xs uppercase tracking-[0.24em] text-white/55">{label}</p>
+      <p className="mt-3 text-2xl font-semibold">{value}</p>
+      <p className="mt-2 text-sm text-white/70">{detail}</p>
+    </div>
+  );
+}
+
+function statusTone(status: string) {
+  if (status === 'completed' || status === 'delivered' || status === 'shipped') {
+    return 'bg-emerald-50 text-emerald-900 border-emerald-300/50';
+  }
+  if (status === 'in_progress' || status === 'paid' || status === 'printing') {
+    return 'bg-blue-50 text-blue-900 border-blue-300/50';
+  }
+  if (status === 'pending' || status === 'draft') {
+    return 'bg-amber-50 text-amber-900 border-amber-300/50';
+  }
+  return 'bg-slate-100 text-slate-800 border-slate-300/50';
+}
+
+export default function OrdersPage() {
+  const [jobStatusFilter, setJobStatusFilter] = useState<'all' | 'needs-assignment' | 'in-progress' | 'draft'>('all');
+
+  const { data: jobsData, isLoading: jobsLoading } = useQuery<PaginatedJobs>({
+    queryKey: ['jobs', 'orders-queue'],
+    queryFn: () => api.get('/jobs?limit=50').then((r) => r.data),
+  });
+
+  const { data: salesData, isLoading: salesLoading } = useQuery<PaginatedSales>({
+    queryKey: ['sales', 'orders-queue'],
+    queryFn: () => api.get('/sales?limit=20').then((r) => r.data),
+  });
+
+  const { data: printersData, isLoading: printersLoading } = useQuery<PaginatedPrinters>({
+    queryKey: ['printers', 'orders-queue'],
+    queryFn: () => api.get('/printers?is_active=true&limit=100').then((r) => r.data),
+  });
+
+  const { data: customers = [], isLoading: customersLoading } = useQuery<Customer[]>({
+    queryKey: ['customers', 'orders-queue'],
+    queryFn: () => api.get('/customers').then((r) => r.data),
+  });
+
+  const jobs = jobsData?.items || [];
+  const sales = salesData?.items || [];
+  const printers = printersData?.items || [];
+
+  const jobsNeedingAssignment = jobs.filter(
+    (job) => job.status !== 'completed' && job.status !== 'cancelled' && !job.printer_id
+  );
+  const productionActive = jobs.filter((job) => job.status === 'in_progress');
+  const draftJobs = jobs.filter((job) => job.status === 'draft');
+  const fulfillmentSales = sales.filter((sale) => sale.status === 'pending' || sale.status === 'paid');
+  const readyPrinters = printers.filter((printer) => (printer.monitor_status || printer.status) === 'idle');
+  const attentionPrinters = printers.filter((printer) =>
+    ATTENTION_PRINTER_STATUSES.has(printer.monitor_status || printer.status)
+  );
+  const topCustomers = [...customers].sort((a, b) => b.job_count - a.job_count).slice(0, 5);
+
+  const visibleJobs = useMemo(() => {
+    switch (jobStatusFilter) {
+      case 'needs-assignment':
+        return jobsNeedingAssignment;
+      case 'in-progress':
+        return productionActive;
+      case 'draft':
+        return draftJobs;
+      default:
+        return jobs.slice(0, 12);
+    }
+  }, [draftJobs, jobStatusFilter, jobs, jobsNeedingAssignment, productionActive]);
+
+  const loading = jobsLoading || salesLoading || printersLoading;
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-[2rem] border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(27,55,44,0.96)_100%)] p-6 text-white shadow-sm">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-sm uppercase tracking-[0.3em] text-white/65">Orders Workspace</p>
+            <h1 className="mt-3 flex items-center gap-3 text-3xl font-bold">
+              <ClipboardList className="h-8 w-8" />
+              Production and fulfillment queue
+            </h1>
+            <p className="mt-3 text-sm text-white/80">
+              Bring together print jobs, fulfillment-relevant sales, and printer readiness so floor and owner workflows stop bouncing between unrelated pages.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <Link
+              to="/orders/jobs/new"
+              className="inline-flex min-h-12 items-center gap-2 rounded-2xl bg-primary px-5 py-3 font-semibold text-primary-foreground no-underline transition-opacity hover:opacity-90"
+            >
+              <PackageOpen className="h-4 w-4" />
+              New job
+            </Link>
+            <Link
+              to="/orders/jobs"
+              className="inline-flex min-h-12 items-center gap-2 rounded-2xl border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white no-underline transition-colors hover:bg-white/15"
+            >
+              Open jobs
+            </Link>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-3 lg:grid-cols-4">
+          <QueueStat label="Needs Assignment" value={String(jobsNeedingAssignment.length)} detail="Jobs without a printer assignment" />
+          <QueueStat label="In Progress" value={String(productionActive.length)} detail="Jobs currently on the production floor" />
+          <QueueStat label="Fulfillment Queue" value={String(fulfillmentSales.length)} detail="Sales still pending shipment/delivery follow-up" />
+          <QueueStat label="Ready Printers" value={String(readyPrinters.length)} detail="Idle printers available for reassignment" />
+        </div>
+      </section>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.92fr)]">
+        <section className="space-y-6">
+          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <div className="flex items-center gap-2">
+                  <Boxes className="h-5 w-5 text-muted-foreground" />
+                  <h2 className="text-xl font-semibold">Production queue</h2>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Surface missing printer assignments first, then the active floor queue. The existing job detail pages stay intact behind these links.
+                </p>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                {[
+                  ['all', 'All queue', `${jobs.length} recent jobs`],
+                  ['needs-assignment', 'Needs assignment', `${jobsNeedingAssignment.length} jobs`],
+                  ['in-progress', 'In progress', `${productionActive.length} jobs`],
+                  ['draft', 'Draft', `${draftJobs.length} jobs`],
+                ].map(([value, label, detail]) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setJobStatusFilter(value as typeof jobStatusFilter)}
+                    className={cn(
+                      'rounded-2xl border px-4 py-3 text-left transition-colors',
+                      jobStatusFilter === value
+                        ? 'border-primary bg-primary text-primary-foreground'
+                        : 'border-border bg-background hover:border-primary/35'
+                    )}
+                  >
+                    <p className="text-sm font-semibold">{label}</p>
+                    <p className={cn('mt-1 text-xs', jobStatusFilter === value ? 'text-primary-foreground/80' : 'text-muted-foreground')}>
+                      {detail}
+                    </p>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {loading ? (
+              <div className="mt-4">
+                <SkeletonTable rows={5} cols={6} />
+              </div>
+            ) : !visibleJobs.length ? (
+              <EmptyState
+                icon="jobs"
+                title="No queue items in this view"
+                description="Try another queue filter or open the full jobs list."
+                className="py-10"
+              />
+            ) : (
+              <div className="mt-4 space-y-3">
+                {visibleJobs.map((job: Job) => {
+                  const missingAssignment = !job.printer_id && job.status !== 'completed' && job.status !== 'cancelled';
+                  return (
+                    <div key={job.id} className={cn('rounded-2xl border p-4', missingAssignment ? 'border-amber-300/60 bg-amber-50/70' : 'border-border bg-background/80')}>
+                      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <Link to={`/orders/jobs/${job.id}`} className="font-semibold text-foreground no-underline hover:underline">
+                              {job.job_number}
+                            </Link>
+                            <span className={cn('rounded-full border px-2.5 py-0.5 text-xs font-semibold capitalize', statusTone(job.status))}>
+                              {job.status.replace('_', ' ')}
+                            </span>
+                            {missingAssignment ? (
+                              <span className="rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold text-amber-900">
+                                Missing printer
+                              </span>
+                            ) : null}
+                          </div>
+                          <p className="mt-2 text-sm font-medium">{job.product_name}</p>
+                          <p className="mt-1 text-sm text-muted-foreground">
+                            {job.customer_name || 'No customer'} • {job.total_pieces} pieces • {formatCurrency(job.total_revenue)}
+                          </p>
+                          <p className="mt-1 text-sm text-muted-foreground">
+                            Printer: {job.printer?.name || 'Unassigned'}
+                          </p>
+                        </div>
+
+                        <div className="flex flex-wrap gap-2">
+                          {job.printer ? (
+                            <Link
+                              to={`/print-floor/printers/${job.printer.id}`}
+                              className="inline-flex items-center gap-2 rounded-xl border border-border px-3 py-2 text-sm font-semibold text-foreground no-underline transition-colors hover:bg-accent"
+                            >
+                              <Printer className="h-4 w-4" />
+                              Printer
+                            </Link>
+                          ) : null}
+                          <Link
+                            to={`/orders/jobs/${job.id}`}
+                            className="inline-flex items-center gap-2 rounded-xl bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground no-underline transition-opacity hover:opacity-90"
+                          >
+                            <Eye className="h-4 w-4" />
+                            Open job
+                          </Link>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="flex items-center gap-2">
+                  <Receipt className="h-5 w-5 text-muted-foreground" />
+                  <h2 className="text-xl font-semibold">Fulfillment-relevant sales</h2>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  First pass uses existing sales statuses to surface orders most likely to need packaging or shipment follow-up.
+                </p>
+              </div>
+              <Link
+                to="/sell/sales"
+                className="inline-flex items-center gap-2 rounded-2xl border border-border px-4 py-2 text-sm font-semibold text-foreground no-underline transition-colors hover:bg-accent"
+              >
+                Open sales inbox
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+
+            {!fulfillmentSales.length ? (
+              <p className="mt-4 text-sm text-muted-foreground">No pending or paid sales in the current queue window.</p>
+            ) : (
+              <div className="mt-4 space-y-3">
+                {fulfillmentSales.slice(0, 8).map((sale: SaleListItem) => (
+                  <div key={sale.id} className="rounded-2xl border border-border bg-background/80 p-4">
+                    <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                      <div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Link to={`/sell/sales/${sale.id}`} className="font-semibold text-foreground no-underline hover:underline">
+                            {sale.sale_number}
+                          </Link>
+                          <span className={cn('rounded-full border px-2.5 py-0.5 text-xs font-semibold capitalize', statusTone(sale.status))}>
+                            {sale.status}
+                          </span>
+                        </div>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          {sale.customer_name || 'Guest'} • {sale.channel_name || 'Direct'} • {sale.item_count} items
+                        </p>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-sm font-semibold">{formatCurrency(sale.total)}</p>
+                        <p className="text-xs text-muted-foreground capitalize">{sale.payment_method || 'Unknown payment'}</p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+
+        <aside className="space-y-4">
+          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="flex items-center gap-2">
+              <TriangleAlert className="h-5 w-5 text-amber-600" />
+              <h2 className="text-xl font-semibold">Assignment pressure</h2>
+            </div>
+            <div className="mt-4 space-y-3">
+              <div className="rounded-2xl bg-background px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Unassigned jobs</p>
+                <p className="mt-2 text-2xl font-semibold">{jobsNeedingAssignment.length}</p>
+                <p className="mt-1 text-sm text-muted-foreground">Jobs that need printer selection or reassignment.</p>
+              </div>
+              <div className="rounded-2xl bg-background px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Ready printers</p>
+                <p className="mt-2 text-2xl font-semibold">{readyPrinters.length}</p>
+                <p className="mt-1 text-sm text-muted-foreground">Idle machines available for production work.</p>
+              </div>
+              <div className="rounded-2xl bg-background px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Attention printers</p>
+                <p className="mt-2 text-2xl font-semibold">{attentionPrinters.length}</p>
+                <p className="mt-1 text-sm text-muted-foreground">Paused, offline, maintenance, or error states.</p>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <User className="h-5 w-5 text-muted-foreground" />
+                <h2 className="text-xl font-semibold">Customer load</h2>
+              </div>
+              <Link
+                to="/orders/customers"
+                className="inline-flex items-center gap-2 rounded-2xl border border-border px-4 py-2 text-sm font-semibold text-foreground no-underline transition-colors hover:bg-accent"
+              >
+                Open customers
+              </Link>
+            </div>
+
+            {customersLoading ? (
+              <div className="mt-4">
+                <SkeletonTable rows={4} cols={2} />
+              </div>
+            ) : !topCustomers.length ? (
+              <p className="mt-4 text-sm text-muted-foreground">No customer activity yet.</p>
+            ) : (
+              <div className="mt-4 space-y-3">
+                {topCustomers.map((customer) => (
+                  <div key={customer.id} className="rounded-2xl border border-border bg-background/80 px-4 py-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="font-medium">{customer.name}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">{customer.email || customer.phone || 'No contact info'}</p>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-lg font-semibold">{customer.job_count}</p>
+                        <p className="text-xs text-muted-foreground">jobs</p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <h2 className="text-xl font-semibold">Known gap</h2>
+            <p className="mt-3 text-sm text-muted-foreground">
+              This first pass stitches jobs, sales, printers, and customers client-side. Quote-specific queueing and a dedicated backend fulfillment queue endpoint are still separate follow-on work.
+            </p>
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/POSPage.test.tsx
+++ b/frontend/src/pages/POSPage.test.tsx
@@ -141,13 +141,14 @@ describe('POSPage', () => {
 
     await screen.findByText('Desk Dragon');
     await user.click(screen.getByRole('button', { name: 'Add Desk Dragon to cart' }));
-    await user.selectOptions(screen.getByLabelText('Customer'), 'customer-1');
+    await user.click(screen.getByRole('button', { name: 'Existing customer Attach the sale to an existing customer record.' }));
+    await user.selectOptions(screen.getByLabelText('Existing customer'), 'customer-1');
 
     const taxInput = screen.getByLabelText('Tax collected');
     await user.clear(taxInput);
     await user.type(taxInput, '2.5');
 
-    await user.selectOptions(screen.getByLabelText('Payment method'), 'card');
+    await user.click(screen.getByRole('button', { name: 'Card' }));
     await user.type(screen.getByLabelText('Notes'), 'Booth sale');
     await user.click(screen.getByRole('button', { name: 'Complete checkout' }));
 
@@ -173,7 +174,7 @@ describe('POSPage', () => {
 
     expect(await screen.findByRole('status')).toHaveTextContent('Sale S-2026-0001 completed');
     expect(screen.getByText('Cart is empty')).toBeInTheDocument();
-    expect(screen.getByLabelText('Payment method')).toHaveValue('cash');
+    expect(screen.getByRole('button', { name: 'Cash' })).toHaveAttribute('aria-pressed', 'true');
     expect(toastSuccess).toHaveBeenCalledWith('POS checkout complete: S-2026-0001');
   });
 

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -1,6 +1,23 @@
 import { useDeferredValue, useEffect, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { AlertTriangle, Minus, Plus, Receipt, Search, ShoppingBasket, Trash2, UserRound, XCircle } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowRight,
+  Barcode,
+  CheckCircle2,
+  Clock3,
+  Minus,
+  Plus,
+  Receipt,
+  Search,
+  ShoppingBasket,
+  Trash2,
+  UserRound,
+  Users,
+  WalletCards,
+  XCircle,
+} from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import EmptyState from '@/components/ui/EmptyState';
@@ -16,10 +33,118 @@ import {
   updateCartLineQuantity,
   type POSCartLine,
 } from '@/pages/posCart';
-import type { Customer, PaginatedProducts, Product, Sale } from '@/types';
+import type { Customer, PaginatedProducts, PaginatedSales, Product, Sale, SaleListItem } from '@/types';
 
 const today = new Date().toISOString().split('T')[0];
 const POS_PRODUCT_PAGE_SIZE = 100;
+const SALES_INBOX_PAGE_SIZE = 6;
+
+type CustomerMode = 'guest' | 'existing' | 'new';
+type ProductFilter = 'all' | 'scannable' | 'low-stock' | 'in-cart';
+
+interface MetricCardProps {
+  label: string;
+  value: string;
+  detail: string;
+}
+
+function MetricCard({ label, value, detail }: MetricCardProps) {
+  return (
+    <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+      <p className="text-xs uppercase tracking-[0.25em] text-white/55">{label}</p>
+      <p className="mt-3 text-2xl font-semibold">{value}</p>
+      <p className="mt-2 text-sm text-white/70">{detail}</p>
+    </div>
+  );
+}
+
+interface QuickFilterButtonProps {
+  active: boolean;
+  label: string;
+  detail: string;
+  onClick: () => void;
+}
+
+function QuickFilterButton({ active, label, detail, onClick }: QuickFilterButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'rounded-2xl border px-4 py-3 text-left transition-colors',
+        active
+          ? 'border-primary bg-primary/10 text-foreground shadow-sm'
+          : 'border-border bg-background/80 text-muted-foreground hover:border-primary/40 hover:text-foreground'
+      )}
+    >
+      <p className="text-sm font-semibold">{label}</p>
+      <p className="mt-1 text-xs">{detail}</p>
+    </button>
+  );
+}
+
+interface CustomerModeButtonProps {
+  active: boolean;
+  icon: typeof UserRound;
+  label: string;
+  detail: string;
+  onClick: () => void;
+}
+
+function CustomerModeButton({ active, icon: Icon, label, detail, onClick }: CustomerModeButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        'rounded-2xl border px-4 py-4 text-left transition-colors',
+        active
+          ? 'border-primary bg-primary/10 text-foreground shadow-sm'
+          : 'border-border bg-background/85 text-muted-foreground hover:border-primary/40 hover:text-foreground'
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className={cn(
+            'rounded-2xl p-2',
+            active ? 'bg-primary text-primary-foreground' : 'bg-accent text-accent-foreground'
+          )}
+        >
+          <Icon className="h-4 w-4" />
+        </div>
+        <div>
+          <p className="font-semibold">{label}</p>
+          <p className="mt-1 text-xs">{detail}</p>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+interface PaymentButtonProps {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}
+
+function PaymentButton({ active, label, onClick }: PaymentButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        'rounded-2xl border px-4 py-3 text-sm font-semibold transition-colors',
+        active
+          ? 'border-primary bg-primary text-primary-foreground shadow-sm'
+          : 'border-border bg-background hover:border-primary/40 hover:text-foreground'
+      )}
+    >
+      {label}
+    </button>
+  );
+}
 
 function getErrorDetail(error: unknown): string {
   if (
@@ -59,10 +184,52 @@ function getErrorDetail(error: unknown): string {
   return 'Failed to complete POS checkout';
 }
 
+function SalesInboxCard({ sale }: { sale: SaleListItem }) {
+  const statusTone =
+    sale.status === 'refunded'
+      ? 'border-destructive/20 bg-destructive/5 text-destructive'
+      : sale.status === 'pending'
+        ? 'border-amber-300/50 bg-amber-50 text-amber-900'
+        : 'border-emerald-300/40 bg-emerald-50 text-emerald-900';
+
+  return (
+    <Link
+      to={`/sell/sales/${sale.id}`}
+      className="block rounded-2xl border border-border bg-background/85 p-4 no-underline transition-colors hover:border-primary/35"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">{sale.sale_number}</p>
+          <p className="mt-2 truncate text-base font-semibold text-foreground">{sale.customer_name || 'Guest checkout'}</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {sale.date} • {sale.channel_name || 'Direct'} • {sale.item_count} items
+          </p>
+        </div>
+        <div className={cn('rounded-full border px-3 py-1 text-xs font-semibold capitalize', statusTone)}>
+          {sale.status}
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between gap-3 text-sm">
+        <div>
+          <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Payment</p>
+          <p className="mt-1 capitalize text-foreground">{sale.payment_method || 'Unknown'}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Total</p>
+          <p className="mt-1 font-semibold text-foreground">{formatCurrency(sale.total)}</p>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
 export default function POSPage() {
   const queryClient = useQueryClient();
   const [search, setSearch] = useState('');
+  const [productFilter, setProductFilter] = useState<ProductFilter>('all');
   const [cart, setCart] = useState<POSCartLine[]>([]);
+  const [customerMode, setCustomerMode] = useState<CustomerMode>('guest');
   const [selectedCustomerId, setSelectedCustomerId] = useState('');
   const [customerName, setCustomerName] = useState('');
   const [paymentMethod, setPaymentMethod] = useState('cash');
@@ -112,20 +279,52 @@ export default function POSPage() {
     queryFn: () => api.get('/customers').then((r) => r.data),
   });
 
+  const { data: salesInboxData, isLoading: salesInboxLoading } = useQuery<PaginatedSales>({
+    queryKey: ['sales', 'sell-inbox'],
+    queryFn: () =>
+      api
+        .get('/sales', {
+          params: {
+            skip: 0,
+            limit: SALES_INBOX_PAGE_SIZE,
+          },
+        })
+        .then((r) => r.data),
+  });
+
+  const salesInbox = salesInboxData?.items || [];
   const products = (productsData?.items || []).filter((product) => product.is_active);
   const normalizedSearch = deferredSearch.trim().toLowerCase();
   const filteredProducts = products.filter((product) => {
-    if (!normalizedSearch) return true;
-    return [product.name, product.sku, product.upc || ''].some((value) =>
-      value.toLowerCase().includes(normalizedSearch)
-    );
+    const searchMatch =
+      !normalizedSearch ||
+      [product.name, product.sku, product.upc || ''].some((value) => value.toLowerCase().includes(normalizedSearch));
+
+    if (!searchMatch) return false;
+
+    const cartQty = getProductCartQuantity(cart, product.id);
+    switch (productFilter) {
+      case 'scannable':
+        return Boolean(product.upc);
+      case 'low-stock':
+        return product.stock_qty <= product.reorder_point;
+      case 'in-cart':
+        return cartQty > 0;
+      default:
+        return true;
+    }
   });
 
   const subtotal = getCartSubtotal(cart);
   const total = getCartTotal(cart, taxCollected);
+  const cartUnits = cart.reduce((sum, line) => sum + line.quantity, 0);
+  const scannableCount = products.filter((product) => Boolean(product.upc)).length;
+  const lowStockCount = products.filter((product) => product.stock_qty <= product.reorder_point).length;
+  const salesNeedingAttention = salesInbox.filter((sale) => ['pending', 'refunded'].includes(sale.status)).length;
 
   const resetCheckoutFields = () => {
     setCart([]);
+    setCustomerMode('guest');
     setSelectedCustomerId('');
     setCustomerName('');
     setPaymentMethod('cash');
@@ -224,8 +423,8 @@ export default function POSPage() {
       const payload = buildPOSCheckoutPayload({
         cart,
         date: today,
-        customerId: selectedCustomerId,
-        customerName,
+        customerId: customerMode === 'existing' ? selectedCustomerId : '',
+        customerName: customerMode === 'new' ? customerName : null,
         taxCollected,
         paymentMethod,
         notes,
@@ -253,119 +452,163 @@ export default function POSPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-4 rounded-3xl border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_28%),linear-gradient(135deg,_rgba(26,32,44,1),_rgba(60,72,88,0.98))] p-6 text-white shadow-sm">
-        <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
-          <div>
-            <p className="text-sm uppercase tracking-[0.3em] text-white/70">Cashier</p>
-            <h1 className="mt-2 flex items-center gap-3 text-3xl font-bold">
+      <section className="rounded-[2rem] border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(19,52,34,0.96)_100%)] p-6 text-white shadow-sm">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-sm uppercase tracking-[0.3em] text-white/65">Sell Workspace</p>
+            <h1 className="mt-3 flex items-center gap-3 text-3xl font-bold">
               <Receipt className="h-8 w-8" />
-              POS Checkout
+              POS register
             </h1>
-            <p className="mt-2 max-w-2xl text-sm text-white/80">
-              Product-first checkout for quick counter sales. Because making staff click through the general sales form for every walk-up sale would be a weird hobby.
+            <p className="mt-3 text-sm text-white/80">
+              Fast counter checkout with a visible scanner lane, larger touch targets, and a sales inbox that keeps follow-up work nearby instead of hidden behind a generic sales list.
             </p>
           </div>
-          <div className="rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-sm">
-            <p className="text-white/65">Checkout date</p>
-            <p className="mt-1 text-lg font-semibold">{today}</p>
-          </div>
-        </div>
 
-        <div className="grid gap-3 sm:grid-cols-3">
-          <div className="rounded-2xl border border-white/10 bg-black/15 px-4 py-3">
-            <p className="text-xs uppercase tracking-[0.25em] text-white/60">Cart Subtotal</p>
-            <p className="mt-2 text-2xl font-semibold">{formatCurrency(subtotal)}</p>
-          </div>
-          <div className="rounded-2xl border border-white/10 bg-black/15 px-4 py-3">
-            <p className="text-xs uppercase tracking-[0.25em] text-white/60">Tax Collected</p>
-            <p className="mt-2 text-2xl font-semibold">{formatCurrency(taxCollected)}</p>
-          </div>
-          <div className="rounded-2xl border border-white/10 bg-black/15 px-4 py-3">
-            <p className="text-xs uppercase tracking-[0.25em] text-white/60">Total</p>
-            <p className="mt-2 text-2xl font-semibold">{formatCurrency(total)}</p>
-          </div>
-        </div>
-      </div>
-
-      {successMessage && (
-        <div className="rounded-2xl border border-emerald-300 bg-emerald-50 px-4 py-3 text-emerald-900" role="status">
-          {successMessage}
-        </div>
-      )}
-
-      {checkoutError && (
-        <div className="rounded-2xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-destructive" role="alert">
-          {checkoutError}
-        </div>
-      )}
-
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(360px,0.9fr)]">
-        <section className="space-y-4">
-          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
-            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-              <div>
-                <h2 className="text-xl font-semibold">Product Catalog</h2>
-                <p className="text-sm text-muted-foreground">Search by name, SKU, or UPC and keep scanner traffic in the dedicated scan lane below.</p>
-              </div>
-              <div className="relative w-full md:max-w-sm">
-                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <input
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Search products..."
-                  aria-label="Search products"
-                  className="w-full rounded-xl border border-input bg-background py-2.5 pl-10 pr-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-              </div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:min-w-[320px]">
+            <div className="rounded-3xl border border-white/10 bg-white/8 px-4 py-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-white/60">Shift date</p>
+              <p className="mt-2 text-xl font-semibold">{today}</p>
+              <p className="mt-1 text-sm text-white/65">Recommended route: `/sell`</p>
+            </div>
+            <div className="rounded-3xl border border-white/10 bg-white/8 px-4 py-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-white/60">Sales inbox</p>
+              <p className="mt-2 text-xl font-semibold">{salesNeedingAttention}</p>
+              <p className="mt-1 text-sm text-white/65">Pending or refunded sales needing eyes</p>
             </div>
           </div>
+        </div>
 
+        <div className="mt-6 grid gap-3 lg:grid-cols-4">
+          <MetricCard label="Cart Total" value={formatCurrency(total)} detail={`${cartUnits} units in the current basket`} />
+          <MetricCard label="Barcode Ready" value={`${scannableCount}`} detail="Active products with UPC for wedge scanners" />
+          <MetricCard label="Low Stock" value={`${lowStockCount}`} detail="Products at or below reorder point" />
+          <MetricCard label="Sales Queue" value={`${salesInbox.length}`} detail="Recent transactions one tap away" />
+        </div>
+      </section>
+
+      {successMessage ? (
+        <div className="rounded-3xl border border-emerald-300 bg-emerald-50 px-5 py-4 text-emerald-900 shadow-sm" role="status">
+          <div className="flex items-start gap-3">
+            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0" />
+            <div>
+              <p className="font-semibold">Checkout complete</p>
+              <p className="mt-1 text-sm">{successMessage}</p>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {checkoutError ? (
+        <div className="rounded-3xl border border-destructive/35 bg-destructive/10 px-5 py-4 text-destructive shadow-sm" role="alert">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+            <div>
+              <p className="font-semibold">Checkout blocked</p>
+              <p className="mt-1 text-sm">{checkoutError}</p>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(360px,0.95fr)]">
+        <section className="space-y-4">
           <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
-            <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
               <div>
-                <h2 className="text-xl font-semibold">Barcode Scan</h2>
-                <p className="text-sm text-muted-foreground">
-                  Supports keyboard-wedge scanners using the product UPC field. Scan into this field or scan while focus is outside form inputs.
+                <div className="flex items-center gap-2">
+                  <Barcode className="h-5 w-5 text-primary" />
+                  <h2 className="text-xl font-semibold">Scanner lane</h2>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Keep wedge scanning obvious. Operators can scan into the field below or scan with focus outside other form controls.
                 </p>
-              </div>
-              <div className="w-full md:max-w-sm">
-                <label className="mb-1 block text-sm font-medium" htmlFor="pos-scan-code">
-                  Scan barcode
-                </label>
                 <form
+                  className="mt-4"
                   onSubmit={(event) => {
                     event.preventDefault();
                     void handleResolveScan(scanCode);
                   }}
                 >
-                  <input
-                    id="pos-scan-code"
-                    value={scanCode}
-                    onChange={(e) => setScanCode(e.target.value)}
-                    placeholder="Scan UPC and press Enter"
-                    aria-label="Scan barcode"
-                    className="w-full rounded-xl border border-input bg-background px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                  />
+                  <label className="mb-2 block text-sm font-medium" htmlFor="pos-scan-code">
+                    Scan barcode
+                  </label>
+                  <div className="flex flex-col gap-3 sm:flex-row">
+                    <input
+                      id="pos-scan-code"
+                      value={scanCode}
+                      onChange={(event) => setScanCode(event.target.value)}
+                      placeholder="Scan UPC and press Enter"
+                      aria-label="Scan barcode"
+                      className="min-h-14 flex-1 rounded-2xl border border-input bg-background px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                    <button
+                      type="submit"
+                      className="inline-flex min-h-14 items-center justify-center gap-2 rounded-2xl bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+                    >
+                      Resolve scan
+                      <ArrowRight className="h-4 w-4" />
+                    </button>
+                  </div>
                 </form>
+              </div>
+
+              <div className="rounded-3xl border border-border bg-background/80 p-4">
+                <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">Lane rules</p>
+                <div className="mt-3 space-y-3 text-sm text-muted-foreground">
+                  <p>Exact UPC match only.</p>
+                  <p>Only active, in-stock products resolve.</p>
+                  <p>Failed scans leave the cart unchanged.</p>
+                </div>
               </div>
             </div>
 
             {scanStatus ? (
-              <div className={cn(
-                'mt-4 rounded-2xl border px-4 py-3 text-sm',
-                scanStatus.startsWith('Scanned ')
-                  ? 'border-emerald-300 bg-emerald-50 text-emerald-900'
-                  : 'border-amber-300 bg-amber-50 text-amber-900'
-              )}>
+              <div
+                className={cn(
+                  'mt-4 rounded-2xl border px-4 py-3 text-sm',
+                  scanStatus.startsWith('Scanned ')
+                    ? 'border-emerald-300 bg-emerald-50 text-emerald-900'
+                    : 'border-amber-300 bg-amber-50 text-amber-900'
+                )}
+              >
                 {scanStatus}
               </div>
             ) : null}
           </div>
 
+          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold">Catalog lane</h2>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Search by product name, SKU, or UPC. Quick filters reduce choice overload during busy counter traffic.
+                </p>
+              </div>
+              <div className="relative w-full lg:max-w-sm">
+                <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="Search products..."
+                  aria-label="Search products"
+                  className="min-h-14 w-full rounded-2xl border border-input bg-background py-3 pl-11 pr-4 text-base focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+            </div>
+
+            <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <QuickFilterButton active={productFilter === 'all'} label="All products" detail={`${products.length} active items`} onClick={() => setProductFilter('all')} />
+              <QuickFilterButton active={productFilter === 'scannable'} label="Scanner-ready" detail={`${scannableCount} products with UPC`} onClick={() => setProductFilter('scannable')} />
+              <QuickFilterButton active={productFilter === 'low-stock'} label="Low stock" detail={`${lowStockCount} products need attention`} onClick={() => setProductFilter('low-stock')} />
+              <QuickFilterButton active={productFilter === 'in-cart'} label="In cart" detail={`${cart.length} product lines selected`} onClick={() => setProductFilter('in-cart')} />
+            </div>
+          </div>
+
           {productsLoading ? (
-            <div className="space-y-3">
+            <div className="grid gap-3 md:grid-cols-2">
               {Array.from({ length: 6 }).map((_, index) => (
-                <div key={index} className="h-28 animate-pulse rounded-3xl border border-border bg-card" />
+                <div key={index} className="h-48 animate-pulse rounded-3xl border border-border bg-card" />
               ))}
             </div>
           ) : productsError ? (
@@ -374,72 +617,69 @@ export default function POSPage() {
             </div>
           ) : !filteredProducts.length ? (
             <EmptyState
-              icon="search"
-              title={products.length ? 'No products match that search' : 'No active products available'}
+              icon="sales"
+              title={products.length ? 'No products match the current lane filters' : 'No active products available'}
               description={
                 products.length
-                  ? 'Try a different name or SKU.'
-                  : 'Add active products with stock before using the POS screen.'
+                  ? 'Try a different search term or filter combination.'
+                  : 'Add active products with stock before using the POS register.'
               }
+              className="rounded-3xl border border-border bg-card"
             />
           ) : (
-            <div className="space-y-3">
+            <div className="grid gap-3 md:grid-cols-2">
               {filteredProducts.map((product) => {
                 const cartQty = getProductCartQuantity(cart, product.id);
                 const remainingStock = product.stock_qty - cartQty;
                 const outOfStock = remainingStock <= 0;
+                const lowStock = product.stock_qty <= product.reorder_point;
 
                 return (
                   <article
                     key={product.id}
                     className={cn(
-                      'rounded-3xl border border-border bg-card p-4 shadow-sm transition-colors',
-                      outOfStock ? 'opacity-70' : 'hover:border-primary/40'
+                      'rounded-3xl border border-border bg-card p-5 shadow-sm transition-colors',
+                      outOfStock ? 'opacity-70' : 'hover:border-primary/35'
                     )}
                   >
-                    <div className="flex items-start gap-3">
-                      <div className="min-w-0 flex-1">
-                        <div className="flex min-w-0 items-center gap-3">
-                          <p className="shrink-0 font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                            {product.sku}
-                          </p>
-                          {product.upc ? (
-                            <p className="shrink-0 text-xs uppercase tracking-[0.15em] text-muted-foreground">
-                              UPC {product.upc}
-                            </p>
-                          ) : null}
-                          <h3 className="min-w-0 flex-1 truncate text-base font-semibold leading-tight">
-                            {product.name}
-                          </h3>
-                        </div>
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">{product.sku}</p>
+                        <h3 className="mt-2 text-lg font-semibold leading-tight">{product.name}</h3>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          {product.upc ? `UPC ${product.upc}` : 'No UPC assigned yet'}
+                        </p>
                       </div>
-                      <div className="inline-flex shrink-0 rounded-full bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground">
+                      <div className="rounded-2xl bg-accent px-4 py-3 text-sm font-semibold text-accent-foreground">
                         {formatCurrency(product.unit_price)}
                       </div>
                     </div>
 
-                    <div className="mt-3 flex flex-wrap items-center gap-3">
-                      <div className="inline-flex items-center gap-2 rounded-2xl bg-background px-3 py-2 text-sm">
-                        <span className="text-xs uppercase tracking-[0.15em] text-muted-foreground">Stock</span>
-                        <span className={cn('font-semibold', product.stock_qty <= product.reorder_point && 'text-amber-600')}>
-                          {product.stock_qty}
-                        </span>
+                    <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                      <div className="rounded-2xl bg-background px-3 py-3">
+                        <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Stock</p>
+                        <p className={cn('mt-2 text-lg font-semibold', lowStock && 'text-amber-600')}>{product.stock_qty}</p>
                       </div>
-                      <div className="inline-flex items-center gap-2 rounded-2xl bg-background px-3 py-2 text-sm">
-                        <span className="text-xs uppercase tracking-[0.15em] text-muted-foreground">In cart</span>
-                        <span className="font-semibold">{cartQty}</span>
+                      <div className="rounded-2xl bg-background px-3 py-3">
+                        <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">In cart</p>
+                        <p className="mt-2 text-lg font-semibold">{cartQty}</p>
                       </div>
-                      <button
-                        type="button"
-                        onClick={() => handleAddProduct(product)}
-                        disabled={outOfStock}
-                        aria-label={`Add ${product.name} to cart`}
-                        className="ml-auto inline-flex items-center justify-center gap-2 rounded-2xl bg-primary px-4 py-2.5 font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
-                      >
-                        <Plus className="h-4 w-4" />
-                        {outOfStock ? 'Stock maxed in cart' : 'Add to cart'}
-                      </button>
+                      <div className="rounded-2xl bg-background px-3 py-3">
+                        <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Scanner</p>
+                        <p className="mt-2 text-sm font-semibold">{product.upc ? 'Ready' : 'Manual only'}</p>
+                      </div>
                     </div>
+
+                    <button
+                      type="button"
+                      onClick={() => handleAddProduct(product)}
+                      disabled={outOfStock}
+                      aria-label={`Add ${product.name} to cart`}
+                      className="mt-4 inline-flex min-h-14 w-full items-center justify-center gap-2 rounded-2xl bg-primary px-4 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
+                    >
+                      <Plus className="h-4 w-4" />
+                      {outOfStock ? 'Stock maxed in cart' : 'Add to cart'}
+                    </button>
                   </article>
                 );
               })}
@@ -451,11 +691,11 @@ export default function POSPage() {
           <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <div>
-                <h2 className="text-xl font-semibold">Cart</h2>
-                <p className="text-sm text-muted-foreground">Keep it moving. This is the fast lane.</p>
+                <h2 className="text-xl font-semibold">Cart and checkout</h2>
+                <p className="mt-2 text-sm text-muted-foreground">Large controls, shorter decisions, faster recovery.</p>
               </div>
               <div className="rounded-full bg-accent px-3 py-1 text-sm font-medium text-accent-foreground">
-                {cart.reduce((sum, line) => sum + line.quantity, 0)} items
+                {cartUnits} items
               </div>
             </div>
 
@@ -463,12 +703,12 @@ export default function POSPage() {
               <div className="mt-6 rounded-3xl border border-dashed border-border bg-background/70 p-8 text-center">
                 <ShoppingBasket className="mx-auto h-10 w-10 text-muted-foreground" />
                 <p className="mt-4 text-lg font-medium">Cart is empty</p>
-                <p className="mt-2 text-sm text-muted-foreground">Add products from the catalog to start a sale.</p>
+                <p className="mt-2 text-sm text-muted-foreground">Add products from the catalog lane or scan a barcode to start a sale.</p>
               </div>
             ) : (
               <div className="mt-5 space-y-3">
                 {cart.map((line) => (
-                  <div key={line.product_id} className="rounded-2xl border border-border bg-background/80 p-4">
+                  <div key={line.product_id} className="rounded-3xl border border-border bg-background/85 p-4">
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <p className="font-medium">{line.name}</p>
@@ -478,23 +718,23 @@ export default function POSPage() {
                         type="button"
                         onClick={() => setCart((prev) => removeProductFromCart(prev, line.product_id))}
                         aria-label={`Remove ${line.name} from cart`}
-                        className="rounded-full p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                        className="rounded-2xl p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                       >
                         <Trash2 className="h-4 w-4" />
                       </button>
                     </div>
 
                     <div className="mt-4 flex items-center justify-between gap-3">
-                      <div className="inline-flex items-center rounded-full border border-border bg-card">
+                      <div className="inline-flex items-center rounded-2xl border border-border bg-card">
                         <button
                           type="button"
                           onClick={() => setCart((prev) => updateCartLineQuantity(prev, line.product_id, line.quantity - 1))}
                           aria-label={`Decrease quantity for ${line.name}`}
-                          className="rounded-l-full px-3 py-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                          className="rounded-l-2xl px-4 py-3 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                         >
                           <Minus className="h-4 w-4" />
                         </button>
-                        <span aria-label={`${line.name} quantity`} className="min-w-12 px-3 text-center font-semibold">
+                        <span aria-label={`${line.name} quantity`} className="min-w-14 px-3 text-center text-lg font-semibold">
                           {line.quantity}
                         </span>
                         <button
@@ -502,108 +742,164 @@ export default function POSPage() {
                           onClick={() => setCart((prev) => updateCartLineQuantity(prev, line.product_id, line.quantity + 1))}
                           disabled={line.quantity >= line.stock_qty}
                           aria-label={`Increase quantity for ${line.name}`}
-                          className="rounded-r-full px-3 py-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:text-muted-foreground/40"
+                          className="rounded-r-2xl px-4 py-3 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:text-muted-foreground/40"
                         >
                           <Plus className="h-4 w-4" />
                         </button>
                       </div>
+
                       <div className="text-right">
                         <p className="text-sm text-muted-foreground">{formatCurrency(line.unit_price)} each</p>
-                        <p className="font-semibold">{formatCurrency(line.unit_price * line.quantity)}</p>
+                        <p className="text-lg font-semibold">{formatCurrency(line.unit_price * line.quantity)}</p>
                       </div>
                     </div>
                   </div>
                 ))}
               </div>
             )}
-          </section>
 
-          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
-            <div className="flex items-center gap-2">
-              <UserRound className="h-5 w-5 text-muted-foreground" />
-              <h2 className="text-xl font-semibold">Checkout</h2>
-            </div>
+            <div className="mt-6 rounded-3xl border border-border bg-background/70 p-4">
+              <div className="flex items-center gap-2">
+                <Users className="h-4 w-4 text-muted-foreground" />
+                <h3 className="text-base font-semibold">Customer mode</h3>
+              </div>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Make the cashier choice explicit instead of hiding it in one select box.
+              </p>
 
-            <div className="mt-5 space-y-4">
-              <div>
-                <label className="mb-1 block text-sm font-medium">Customer</label>
-                <select
-                  value={selectedCustomerId}
-                  onChange={(e) => {
-                    setSelectedCustomerId(e.target.value);
+              <div className="mt-4 grid gap-3">
+                <CustomerModeButton
+                  active={customerMode === 'guest'}
+                  icon={UserRound}
+                  label="Guest"
+                  detail="Fastest path for walk-up checkout."
+                  onClick={() => {
+                    setCustomerMode('guest');
+                    setSelectedCustomerId('');
+                    setCustomerName('');
                     setCheckoutError(null);
-                    if (e.target.value) {
-                      setCustomerName('');
-                    }
                   }}
-                  aria-label="Customer"
-                  className="w-full rounded-xl border border-input bg-background px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                >
-                  <option value="">Guest checkout</option>
-                  {customers.map((customer) => (
-                    <option key={customer.id} value={customer.id}>
-                      {customer.name}
-                    </option>
-                  ))}
-                </select>
+                />
+                <CustomerModeButton
+                  active={customerMode === 'existing'}
+                  icon={Users}
+                  label="Existing customer"
+                  detail="Attach the sale to an existing customer record."
+                  onClick={() => {
+                    setCustomerMode('existing');
+                    setCustomerName('');
+                    setCheckoutError(null);
+                  }}
+                />
+                <CustomerModeButton
+                  active={customerMode === 'new'}
+                  icon={Receipt}
+                  label="New customer name"
+                  detail="Capture a customer name on the sale without leaving the register."
+                  onClick={() => {
+                    setCustomerMode('new');
+                    setSelectedCustomerId('');
+                    setCheckoutError(null);
+                  }}
+                />
               </div>
 
-              {!selectedCustomerId && (
-                <div>
-                  <label className="mb-1 block text-sm font-medium">Guest name</label>
+              {customerMode === 'existing' ? (
+                <div className="mt-4">
+                  <label className="mb-2 block text-sm font-medium" htmlFor="pos-existing-customer">
+                    Existing customer
+                  </label>
+                  <select
+                    id="pos-existing-customer"
+                    value={selectedCustomerId}
+                    onChange={(event) => {
+                      setSelectedCustomerId(event.target.value);
+                      setCheckoutError(null);
+                    }}
+                    aria-label="Existing customer"
+                    className="min-h-14 w-full rounded-2xl border border-input bg-background px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
+                  >
+                    <option value="">Select customer</option>
+                    {customers.map((customer) => (
+                      <option key={customer.id} value={customer.id}>
+                        {customer.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ) : null}
+
+              {customerMode === 'new' ? (
+                <div className="mt-4">
+                  <label className="mb-2 block text-sm font-medium" htmlFor="pos-customer-name">
+                    Customer name
+                  </label>
                   <input
+                    id="pos-customer-name"
                     value={customerName}
-                    onChange={(e) => setCustomerName(e.target.value)}
-                    placeholder="Optional walk-up customer name"
-                    aria-label="Guest name"
-                    className="w-full rounded-xl border border-input bg-background px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    onChange={(event) => setCustomerName(event.target.value)}
+                    placeholder="Name for receipt or follow-up"
+                    aria-label="Customer name"
+                    className="min-h-14 w-full rounded-2xl border border-input bg-background px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
                   />
                 </div>
-              )}
+              ) : null}
+            </div>
 
-              <div>
-                <label className="mb-1 block text-sm font-medium">Payment method</label>
-                <select
-                  value={paymentMethod}
-                  onChange={(e) => setPaymentMethod(e.target.value)}
-                  aria-label="Payment method"
-                  className="w-full rounded-xl border border-input bg-background px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                >
-                  {POS_PAYMENT_METHODS.map((method) => (
-                    <option key={method.value} value={method.value}>
-                      {method.label}
-                    </option>
-                  ))}
-                </select>
+            <div className="mt-4 rounded-3xl border border-border bg-background/70 p-4">
+              <div className="flex items-center gap-2">
+                <WalletCards className="h-4 w-4 text-muted-foreground" />
+                <h3 className="text-base font-semibold">Payment method</h3>
               </div>
+              <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                {POS_PAYMENT_METHODS.map((method) => (
+                  <PaymentButton
+                    key={method.value}
+                    active={paymentMethod === method.value}
+                    label={method.label}
+                    onClick={() => setPaymentMethod(method.value)}
+                  />
+                ))}
+              </div>
+              <div className="sr-only" aria-live="polite">
+                Payment method: {POS_PAYMENT_METHODS.find((method) => method.value === paymentMethod)?.label || paymentMethod}
+              </div>
+            </div>
 
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
               <div>
-                <label className="mb-1 block text-sm font-medium">Tax collected</label>
+                <label className="mb-2 block text-sm font-medium" htmlFor="pos-tax-collected">
+                  Tax collected
+                </label>
                 <input
+                  id="pos-tax-collected"
                   type="number"
                   min="0"
                   step="0.01"
                   value={taxCollected}
-                  onChange={(e) => setTaxCollected(Math.max(0, Number(e.target.value) || 0))}
+                  onChange={(event) => setTaxCollected(Math.max(0, Number(event.target.value) || 0))}
                   aria-label="Tax collected"
-                  className="w-full rounded-xl border border-input bg-background px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  className="min-h-14 w-full rounded-2xl border border-input bg-background px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
                 />
               </div>
 
               <div>
-                <label className="mb-1 block text-sm font-medium">Notes</label>
+                <label className="mb-2 block text-sm font-medium" htmlFor="pos-notes">
+                  Notes
+                </label>
                 <textarea
+                  id="pos-notes"
                   value={notes}
-                  onChange={(e) => setNotes(e.target.value)}
+                  onChange={(event) => setNotes(event.target.value)}
                   rows={3}
                   placeholder="Optional booth or counter notes"
                   aria-label="Notes"
-                  className="w-full rounded-xl border border-input bg-background px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  className="w-full rounded-2xl border border-input bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 />
               </div>
             </div>
 
-            <div className="mt-6 rounded-3xl bg-background p-4">
+            <div className="mt-4 rounded-3xl bg-background p-4">
               <div className="flex items-center justify-between text-sm">
                 <span className="text-muted-foreground">Subtotal</span>
                 <span>{formatCurrency(subtotal)}</span>
@@ -621,29 +917,76 @@ export default function POSPage() {
             <button
               type="button"
               onClick={handleCheckout}
-              disabled={saving || !cart.length}
-              className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-primary px-4 py-3 font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
+              disabled={
+                saving ||
+                !cart.length ||
+                (customerMode === 'existing' && !selectedCustomerId) ||
+                (customerMode === 'new' && !customerName.trim())
+              }
+              className="mt-6 inline-flex min-h-14 w-full items-center justify-center gap-2 rounded-2xl bg-primary px-4 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
             >
               {saving ? 'Processing checkout...' : 'Complete checkout'}
             </button>
 
-            {!!cart.length && (
+            {!!cart.length ? (
               <button
                 type="button"
                 onClick={resetCheckoutFields}
-                className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-border px-4 py-3 font-medium transition-colors hover:bg-accent"
+                className="mt-3 inline-flex min-h-14 w-full items-center justify-center gap-2 rounded-2xl border border-border px-4 py-3 font-semibold transition-colors hover:bg-accent"
               >
                 <XCircle className="h-4 w-4" />
                 Clear cart
               </button>
-            )}
+            ) : null}
 
             <div className="mt-4 rounded-2xl border border-amber-300/60 bg-amber-50 p-3 text-sm text-amber-900">
               <div className="flex items-start gap-2">
                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-                <p>POS checkout will block oversell when cart quantity exceeds available stock. Fancy concept, I know.</p>
+                <p>Checkout blocks oversell when requested quantity exceeds available stock.</p>
               </div>
             </div>
+          </section>
+
+          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="flex items-center gap-2">
+                  <Clock3 className="h-5 w-5 text-muted-foreground" />
+                  <h2 className="text-xl font-semibold">Sales inbox</h2>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Recent sales and exceptions stay adjacent to the register so staff do not need to context-switch into the full sales area.
+                </p>
+              </div>
+              <Link
+                to="/sell/sales"
+                className="inline-flex items-center gap-2 rounded-2xl border border-border px-4 py-2 text-sm font-semibold text-foreground no-underline transition-colors hover:bg-accent"
+              >
+                Open inbox
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+
+            {salesInboxLoading ? (
+              <div className="mt-4 space-y-3">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <div key={index} className="h-28 animate-pulse rounded-3xl border border-border bg-background" />
+                ))}
+              </div>
+            ) : salesInbox.length ? (
+              <div className="mt-4 space-y-3">
+                {salesInbox.map((sale) => (
+                  <SalesInboxCard key={sale.id} sale={sale} />
+                ))}
+              </div>
+            ) : (
+              <EmptyState
+                icon="sales"
+                title="No recent sales"
+                description="Completed sales will appear here so staff can review them without leaving the Sell workspace."
+                className="py-10"
+              />
+            )}
           </section>
         </aside>
       </div>

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -1,6 +1,18 @@
 import { Link, useParams } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Edit, Archive, ArchiveRestore, RefreshCw, PlugZap } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Archive,
+  ArchiveRestore,
+  Edit,
+  Gauge,
+  Layers3,
+  PlugZap,
+  RefreshCw,
+  Thermometer,
+  Timer,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { cn, formatCurrency } from '@/lib/utils';
@@ -25,7 +37,16 @@ const jobStatusClasses: Record<string, string> = {
 };
 
 function StatusBadge({ status }: { status: string }) {
-  return <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize', statusClasses[status] || 'bg-primary/10 text-primary')}>{status.replace('_', ' ')}</span>;
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium capitalize',
+        statusClasses[status] || 'bg-primary/10 text-primary'
+      )}
+    >
+      {status.replace('_', ' ')}
+    </span>
+  );
 }
 
 function formatDateTime(value: string | null) {
@@ -44,9 +65,9 @@ function formatDuration(seconds: number | null | undefined) {
 
 function formatTemperature(actual: number | null | undefined, target: number | null | undefined) {
   if (actual == null && target == null) return '—';
-  if (actual != null && target != null) return `${actual.toFixed(1)} / ${target.toFixed(1)} °C`;
-  if (actual != null) return `${actual.toFixed(1)} °C`;
-  return `Target ${target?.toFixed(1)} °C`;
+  if (actual != null && target != null) return `${actual.toFixed(1)} / ${target.toFixed(1)} C`;
+  if (actual != null) return `${actual.toFixed(1)} C`;
+  return `Target ${target?.toFixed(1)} C`;
 }
 
 function formatLayer(current: number | null | undefined, total: number | null | undefined) {
@@ -60,6 +81,43 @@ function formatEventMetaValue(value: unknown) {
   return String(value);
 }
 
+function ConsoleStat({
+  icon: Icon,
+  label,
+  value,
+  subtext,
+  emphasis = 'default',
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: string;
+  subtext?: string;
+  emphasis?: 'default' | 'warning' | 'success';
+}) {
+  return (
+    <div className="rounded-[1.45rem] border border-border bg-card/85 p-4 shadow-[0_14px_40px_rgba(8,17,31,0.06)]">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">{label}</p>
+          <p
+            className={cn(
+              'mt-3 text-2xl font-semibold',
+              emphasis === 'warning' && 'text-amber-600 dark:text-amber-300',
+              emphasis === 'success' && 'text-emerald-600 dark:text-emerald-300'
+            )}
+          >
+            {value}
+          </p>
+          {subtext ? <p className="mt-1 text-sm text-muted-foreground">{subtext}</p> : null}
+        </div>
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+          <Icon className="h-5 w-5" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function PrinterDetailPage() {
   const { id } = useParams<{ id: string }>();
   const queryClient = useQueryClient();
@@ -68,7 +126,10 @@ export default function PrinterDetailPage() {
     queryKey: ['printer', id],
     queryFn: () => api.get(`/printers/${id}`).then((response) => response.data),
     enabled: Boolean(id),
-    refetchInterval: (query) => (query.state.data?.monitor_enabled ? Math.max((query.state.data.monitor_poll_interval_seconds || 30) * 1000, 5000) : false),
+    refetchInterval: (query) =>
+      query.state.data?.monitor_enabled
+        ? Math.max((query.state.data.monitor_poll_interval_seconds || 30) * 1000, 5000)
+        : false,
   });
 
   const { data: jobs, isLoading: jobsLoading } = useQuery<PaginatedJobs>({
@@ -124,188 +185,280 @@ export default function PrinterDetailPage() {
     }
   };
 
-  if (printerLoading) return <SkeletonTable rows={4} cols={4} />;
+  if (printerLoading) return <SkeletonTable rows={5} cols={4} />;
   if (!printer) return <p className="py-16 text-center text-muted-foreground">Printer not found</p>;
 
   const recentJobs = jobs?.items || [];
   const activeJob = recentJobs.find((job) => job.status === 'in_progress' || job.status === 'draft');
+  const liveStatus = printer.monitor_status || printer.status;
+  const progress = printer.monitor_progress_percent ?? 0;
+  const needsAttention = ['paused', 'maintenance', 'offline', 'error'].includes(liveStatus);
 
   return (
-    <div className="max-w-5xl mx-auto">
-      <Link to="/printers" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-4 no-underline">
-        <ArrowLeft className="w-4 h-4" /> Back to Printers
+    <div className="space-y-6">
+      <Link
+        to="/print-floor"
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground no-underline transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" /> Back to printer wall
       </Link>
 
-      <div className="rounded-lg border border-border bg-card p-6 mb-6">
-        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+      <section className="overflow-hidden rounded-[2rem] border border-border bg-[linear-gradient(135deg,rgba(8,17,31,0.98),rgba(17,34,53,0.96))] px-6 py-6 text-white shadow-[0_24px_70px_rgba(8,17,31,0.18)]">
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
           <div>
-            <div className="flex flex-wrap items-center gap-2 mb-2">
-              <h1 className="text-2xl font-bold">{printer.name}</h1>
-              <StatusBadge status={printer.status} />
-              <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', printer.is_active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400')}>
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200/75">
+                Printer console
+              </p>
+              <StatusBadge status={liveStatus} />
+              <span className={cn('inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium', printer.is_active ? 'bg-emerald-500/15 text-emerald-200' : 'bg-amber-500/15 text-amber-200')}>
                 {printer.is_active ? 'Active' : 'Inactive'}
               </span>
+            </div>
+            <h1 className="mt-3 text-3xl font-semibold md:text-4xl">{printer.name}</h1>
+            <p className="mt-2 text-sm uppercase tracking-[0.16em] text-slate-300/80">
+              {[printer.manufacturer, printer.model, printer.location].filter(Boolean).join(' • ') || printer.slug}
+            </p>
+            <p className="mt-4 max-w-3xl text-sm leading-6 text-slate-200/82 md:text-base">
+              Live machine status, current print telemetry, recent floor activity, and assignment context in one place.
+            </p>
+
+            <div className="mt-5 flex flex-wrap gap-3">
               {printer.monitor_enabled ? (
-                <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', printer.monitor_online ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-zinc-100 text-zinc-800 dark:bg-zinc-900/50 dark:text-zinc-300')}>
-                  {printer.monitor_online ? 'Monitor online' : 'Monitor offline'}
-                </span>
+                <>
+                  <button
+                    onClick={testConnection}
+                    className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-[0_16px_40px_rgba(34,197,94,0.28)]"
+                  >
+                    <PlugZap className="h-4 w-4" /> Test connection
+                  </button>
+                  <button
+                    onClick={refreshNow}
+                    className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/12"
+                  >
+                    <RefreshCw className="h-4 w-4" /> Refresh now
+                  </button>
+                </>
               ) : null}
-              {printer.monitor_enabled && printer.monitor_provider === 'moonraker' ? (
-                <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', printer.monitor_ws_connected ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400')}>
-                  {printer.monitor_ws_connected ? 'WebSocket live' : 'Polling fallback'}
-                </span>
-              ) : null}
+              <Link
+                to={`/print-floor/printers/${printer.id}/edit`}
+                className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-2 text-sm font-medium text-white no-underline transition-colors hover:bg-white/12"
+              >
+                <Edit className="h-4 w-4" /> Edit
+              </Link>
+              <button
+                onClick={toggleActive}
+                className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/12"
+              >
+                {printer.is_active ? <Archive className="h-4 w-4" /> : <ArchiveRestore className="h-4 w-4" />}
+                {printer.is_active ? 'Deactivate' : 'Restore'}
+              </button>
             </div>
-            <p className="text-sm text-muted-foreground font-mono">{printer.slug}</p>
-            {!printer.is_active && <p className="mt-2 text-sm text-muted-foreground">This printer is inactive. Historical job assignments are still preserved.</p>}
           </div>
 
-          <div className="flex flex-wrap gap-2">
-            {printer.monitor_enabled ? (
-              <>
-                <button onClick={testConnection} className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border px-4 py-2 hover:bg-accent">
-                  <PlugZap className="w-4 h-4" /> Test connection
-                </button>
-                <button onClick={refreshNow} className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border px-4 py-2 hover:bg-accent">
-                  <RefreshCw className="w-4 h-4" /> Refresh now
-                </button>
-              </>
-            ) : null}
-            <Link to={`/printers/${printer.id}/edit`} className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 no-underline hover:bg-accent">
-              <Edit className="w-4 h-4" /> Edit
-            </Link>
-            <button onClick={toggleActive} className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border px-4 py-2 hover:bg-accent">
-              {printer.is_active ? <Archive className="w-4 h-4" /> : <ArchiveRestore className="w-4 h-4" />}
-              {printer.is_active ? 'Deactivate' : 'Restore'}
-            </button>
-          </div>
-        </div>
-
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mt-6">
-          <div>
-            <p className="text-xs text-muted-foreground">Manufacturer</p>
-            <p className="text-lg font-semibold">{printer.manufacturer || '—'}</p>
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">Model</p>
-            <p className="text-lg font-semibold">{printer.model || '—'}</p>
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">Location</p>
-            <p className="text-lg font-semibold">{printer.location || '—'}</p>
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">Serial Number</p>
-            <p className="text-lg font-semibold">{printer.serial_number || '—'}</p>
-          </div>
-        </div>
-
-        <div className="mt-6 grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
-          <div className="rounded-lg border border-border bg-background/40 p-4">
-            <p className="text-xs text-muted-foreground mb-1">Notes</p>
-            <p className="text-sm whitespace-pre-wrap">{printer.notes || 'No notes yet.'}</p>
-          </div>
-          <div className="rounded-lg border border-border bg-background/40 p-4">
-            <p className="text-xs text-muted-foreground mb-1">Current / recent assignment</p>
-            {activeJob ? (
+          <div className="rounded-[1.6rem] border border-white/10 bg-black/15 p-5">
+            <div className="flex items-start justify-between gap-3">
               <div>
-                <p className="font-semibold">{activeJob.job_number}</p>
-                <p className="text-sm text-muted-foreground">{activeJob.product_name}</p>
-                <p className="text-xs text-muted-foreground mt-1">{activeJob.total_pieces} pcs · {activeJob.date}</p>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-300/75">Current print</p>
+                <p className="mt-2 text-lg font-semibold text-white">{printer.current_print_name || 'No active print'}</p>
               </div>
-            ) : recentJobs[0] ? (
+              <span className="text-2xl font-semibold text-white">
+                {printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}
+              </span>
+            </div>
+
+            <div className="mt-4 h-2 rounded-full bg-white/10">
+              <div
+                className={cn('h-2 rounded-full transition-[width]', needsAttention ? 'bg-amber-400' : 'bg-primary')}
+                style={{ width: `${Math.max(6, progress)}%` }}
+              />
+            </div>
+
+            <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
               <div>
-                <p className="font-semibold">{recentJobs[0].job_number}</p>
-                <p className="text-sm text-muted-foreground">Last assigned: {recentJobs[0].product_name}</p>
-                <p className="text-xs text-muted-foreground mt-1">{recentJobs[0].date}</p>
+                <p className="text-xs uppercase tracking-[0.16em] text-slate-300/75">Layer</p>
+                <p className="mt-1 font-medium text-white">{formatLayer(printer.monitor_current_layer, printer.monitor_total_layers)}</p>
               </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">No jobs assigned yet.</p>
-            )}
+              <div>
+                <p className="text-xs uppercase tracking-[0.16em] text-slate-300/75">ETA</p>
+                <p className="mt-1 font-medium text-white">{formatDuration(printer.monitor_remaining_seconds)}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-[0.16em] text-slate-300/75">Transport</p>
+                <p className="mt-1 font-medium text-white">
+                  {printer.monitor_provider === 'moonraker'
+                    ? printer.monitor_ws_connected
+                      ? 'Socket live'
+                      : 'Polling fallback'
+                    : printer.monitor_enabled
+                      ? 'Polling'
+                      : 'Static record'}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-[0.16em] text-slate-300/75">Assignment</p>
+                <p className="mt-1 font-medium text-white">{activeJob ? activeJob.job_number : 'Unassigned'}</p>
+              </div>
+            </div>
           </div>
         </div>
+      </section>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <ConsoleStat
+          icon={Gauge}
+          label="Progress"
+          value={printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(1)}%` : '—'}
+          subtext={printer.current_print_name || 'No active file'}
+          emphasis={printer.monitor_progress_percent ? 'success' : 'default'}
+        />
+        <ConsoleStat
+          icon={Timer}
+          label="Elapsed / remaining"
+          value={`${formatDuration(printer.monitor_elapsed_seconds)} / ${formatDuration(printer.monitor_remaining_seconds)}`}
+          subtext={printer.monitor_eta_at ? `ETA ${formatDateTime(printer.monitor_eta_at)}` : 'ETA unavailable'}
+        />
+        <ConsoleStat
+          icon={Thermometer}
+          label="Tool temperature"
+          value={formatTemperature(printer.monitor_tool_temp_c, printer.monitor_tool_target_c)}
+          subtext={`Bed ${formatTemperature(printer.monitor_bed_temp_c, printer.monitor_bed_target_c)}`}
+        />
+        <ConsoleStat
+          icon={Layers3}
+          label="Assignment"
+          value={activeJob ? activeJob.job_number : 'Unassigned'}
+          subtext={activeJob ? `${activeJob.total_pieces} pcs • ${activeJob.product_name}` : 'No draft or in-progress job attached'}
+          emphasis={activeJob ? 'success' : needsAttention ? 'warning' : 'default'}
+        />
       </div>
 
-      <div className="mb-6 rounded-lg border border-border bg-card p-6">
-        <div className="mb-4 flex items-start justify-between gap-3">
-          <div>
-            <h2 className="text-xl font-bold">Live monitoring</h2>
-            <p className="text-sm text-muted-foreground">Normalized status pulled from the configured monitoring provider.</p>
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+        <section className="rounded-[1.8rem] border border-border bg-card/85 p-5 shadow-[0_16px_40px_rgba(8,17,31,0.06)]">
+          <div className="mb-4 flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-xl font-semibold text-foreground">Live monitoring</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                A denser, operator-friendly view of the current telemetry from the configured monitoring provider.
+              </p>
+            </div>
+            {printer.monitor_enabled ? <StatusBadge status={liveStatus} /> : null}
           </div>
-          {printer.monitor_enabled ? <StatusBadge status={printer.monitor_status || printer.status} /> : null}
-        </div>
 
-        {!printer.monitor_enabled ? (
-          <p className="text-sm text-muted-foreground">Monitoring is not configured for this printer yet. The printer still works as a static record.</p>
-        ) : (
-          <div className="space-y-4">
-            <div className="grid gap-4 lg:grid-cols-[minmax(0,1.3fr)_minmax(260px,0.7fr)]">
-              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">Provider</p><p className="truncate font-semibold capitalize" title={printer.monitor_provider || '—'}>{printer.monitor_provider || '—'}</p></div>
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">Progress</p><p className="truncate font-semibold">{printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(1)}%` : '—'}</p></div>
-            <div className="min-w-0 md:col-span-2 xl:col-span-2"><p className="text-xs text-muted-foreground">Current print</p><p className="truncate font-semibold" title={printer.current_print_name || '—'}>{printer.current_print_name || '—'}</p></div>
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">Poll interval</p><p className="truncate font-semibold">{printer.monitor_poll_interval_seconds}s</p></div>
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">Tool temp / target</p><p className="truncate font-semibold" title={formatTemperature(printer.monitor_tool_temp_c, printer.monitor_tool_target_c)}>{formatTemperature(printer.monitor_tool_temp_c, printer.monitor_tool_target_c)}</p></div>
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">Bed temp / target</p><p className="truncate font-semibold" title={formatTemperature(printer.monitor_bed_temp_c, printer.monitor_bed_target_c)}>{formatTemperature(printer.monitor_bed_temp_c, printer.monitor_bed_target_c)}</p></div>
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">Layer</p><p className="truncate font-semibold">{formatLayer(printer.monitor_current_layer, printer.monitor_total_layers)}</p></div>
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">Elapsed / remaining</p><p className="truncate font-semibold" title={`${formatDuration(printer.monitor_elapsed_seconds)} / ${formatDuration(printer.monitor_remaining_seconds)}`}>{formatDuration(printer.monitor_elapsed_seconds)} / {formatDuration(printer.monitor_remaining_seconds)}</p></div>
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">ETA</p><p className="truncate font-semibold" title={formatDateTime(printer.monitor_eta_at)}>{formatDateTime(printer.monitor_eta_at)}</p></div>
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">Last event</p><p className="truncate font-semibold" title={printer.monitor_last_event_type ? printer.monitor_last_event_type.replace('notify_', '').replaceAll('_', ' ') : '—'}>{printer.monitor_last_event_type ? printer.monitor_last_event_type.replace('notify_', '').replaceAll('_', ' ') : '—'}</p></div>
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">Last event at</p><p className="truncate font-semibold" title={formatDateTime(printer.monitor_last_event_at)}>{formatDateTime(printer.monitor_last_event_at)}</p></div>
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">Last seen</p><p className="truncate font-semibold" title={formatDateTime(printer.monitor_last_seen_at)}>{formatDateTime(printer.monitor_last_seen_at)}</p></div>
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">Last updated</p><p className="truncate font-semibold" title={formatDateTime(printer.monitor_last_updated_at)}>{formatDateTime(printer.monitor_last_updated_at)}</p></div>
-            <div className="min-w-0"><p className="text-xs text-muted-foreground">Live transport</p><p className="truncate font-semibold" title={printer.monitor_provider === 'moonraker' ? (printer.monitor_ws_connected ? 'WebSocket streaming' : 'HTTP polling fallback') : 'HTTP polling'}>{printer.monitor_provider === 'moonraker' ? (printer.monitor_ws_connected ? 'WebSocket streaming' : 'HTTP polling fallback') : 'HTTP polling'}</p></div>
-              </div>
-              <div className="space-y-2">
-                <div>
-                  <p className="text-xs text-muted-foreground">Current print thumbnail</p>
-                  <p className="truncate text-sm text-muted-foreground" title={printer.current_print_name || 'No active file'}>{printer.current_print_name || 'No active file'}</p>
+          {!printer.monitor_enabled ? (
+            <div className="rounded-[1.4rem] border border-dashed border-border bg-background/60 p-6 text-sm text-muted-foreground">
+              Monitoring is not configured for this printer yet. The machine is still available as a static tracked record.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <div className="rounded-[1.25rem] border border-border bg-background/60 p-4">
+                  <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Provider</p>
+                  <p className="mt-2 font-semibold capitalize text-foreground">{printer.monitor_provider || '—'}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">{printer.monitor_poll_interval_seconds}s poll interval</p>
                 </div>
-                <PrinterThumbnail
-                  src={printer.current_print_thumbnail_url}
-                  alt={printer.current_print_name ? `${printer.current_print_name} thumbnail` : `${printer.name} current print thumbnail`}
-                  className="aspect-square min-h-[220px]"
-                  fallbackLabel={printer.current_print_name ? 'No thumbnail in G-code metadata' : 'No active print'}
-                />
+                <div className="rounded-[1.25rem] border border-border bg-background/60 p-4">
+                  <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Last event</p>
+                  <p className="mt-2 font-semibold text-foreground">
+                    {printer.monitor_last_event_type ? printer.monitor_last_event_type.replace('notify_', '').replaceAll('_', ' ') : '—'}
+                  </p>
+                  <p className="mt-1 text-sm text-muted-foreground">{formatDateTime(printer.monitor_last_event_at)}</p>
+                </div>
+                <div className="rounded-[1.25rem] border border-border bg-background/60 p-4">
+                  <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Last seen</p>
+                  <p className="mt-2 font-semibold text-foreground">{formatDateTime(printer.monitor_last_seen_at)}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {printer.monitor_provider === 'moonraker'
+                      ? printer.monitor_ws_connected
+                        ? 'WebSocket receiving live events'
+                        : 'Socket stale, polling fallback'
+                      : 'Polled provider'}
+                  </p>
+                </div>
               </div>
-            </div>
-          </div>
-        )}
 
-        {printer.monitor_enabled ? (
-          <div className="mt-4 space-y-3">
-            <div className="rounded-lg border border-border bg-background/40 p-4">
-              <p className="text-xs text-muted-foreground mb-1">Provider message</p>
-              <p className="text-sm">{printer.monitor_last_message || '—'}</p>
+              <div className="rounded-[1.4rem] border border-border bg-background/60 p-4">
+                <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Provider message</p>
+                <p className="mt-2 text-sm text-foreground">{printer.monitor_last_message || '—'}</p>
+              </div>
+
+              {printer.monitor_last_error ? (
+                <div className="rounded-[1.4rem] border border-red-300/60 bg-red-50/80 p-4 dark:border-red-500/30 dark:bg-red-500/10">
+                  <div className="flex items-start gap-3">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 text-red-600 dark:text-red-300" />
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.16em] text-red-700 dark:text-red-200">Last monitor error</p>
+                      <p className="mt-2 text-sm text-red-700 dark:text-red-100">{printer.monitor_last_error}</p>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
             </div>
-            {printer.monitor_provider === 'moonraker' ? (
-              <div className="rounded-lg border border-border bg-background/40 p-4">
-                <p className="text-xs text-muted-foreground mb-1">Moonraker live channel</p>
-                <p className="text-sm break-words">{printer.monitor_ws_connected ? 'WebSocket connected and receiving live status events.' : 'WebSocket not fresh right now — using polling fallback.'}</p>
-                {printer.monitor_ws_last_error ? <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">Last socket issue: {printer.monitor_ws_last_error}</p> : null}
-              </div>
-            ) : null}
-            {printer.monitor_last_error ? (
-              <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-800 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-300">
-                <p className="text-xs uppercase tracking-wide">Last monitor error</p>
-                <p className="mt-1 text-sm">{printer.monitor_last_error}</p>
-              </div>
-            ) : null}
+          )}
+        </section>
+
+        <section className="rounded-[1.8rem] border border-border bg-card/85 p-5 shadow-[0_16px_40px_rgba(8,17,31,0.06)]">
+          <div className="mb-4">
+            <h2 className="text-xl font-semibold text-foreground">Visual console</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Current print thumbnail plus the most relevant assignment and machine details.
+            </p>
           </div>
-        ) : null}
+
+          <PrinterThumbnail
+            src={printer.current_print_thumbnail_url}
+            alt={printer.current_print_name ? `${printer.current_print_name} thumbnail` : `${printer.name} current print thumbnail`}
+            className="min-h-[280px] rounded-[1.4rem]"
+            fallbackLabel={printer.current_print_name ? 'No thumbnail in G-code metadata' : 'No active print'}
+          />
+
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <div className="rounded-[1.25rem] border border-border bg-background/60 p-4">
+              <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Machine identity</p>
+              <p className="mt-2 font-semibold text-foreground">{printer.manufacturer || '—'} {printer.model || ''}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{printer.serial_number || 'No serial number'}</p>
+            </div>
+            <div className="rounded-[1.25rem] border border-border bg-background/60 p-4">
+              <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Current assignment</p>
+              {activeJob ? (
+                <>
+                  <Link to={`/orders/jobs/${activeJob.id}`} className="mt-2 block font-semibold text-primary no-underline hover:underline">
+                    {activeJob.job_number}
+                  </Link>
+                  <p className="mt-1 text-sm text-muted-foreground">{activeJob.product_name}</p>
+                </>
+              ) : (
+                <p className="mt-2 text-sm text-muted-foreground">No draft or in-progress job assigned.</p>
+              )}
+            </div>
+          </div>
+
+          {printer.notes ? (
+            <div className="mt-4 rounded-[1.25rem] border border-border bg-background/60 p-4">
+              <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Notes</p>
+              <p className="mt-2 whitespace-pre-wrap text-sm text-foreground">{printer.notes}</p>
+            </div>
+          ) : null}
+        </section>
       </div>
 
-      <div className="mb-6 rounded-lg border border-border bg-card p-6">
+      <section className="rounded-[1.8rem] border border-border bg-card/85 p-5 shadow-[0_16px_40px_rgba(8,17,31,0.06)]">
         <div className="mb-4 flex items-start justify-between gap-3">
           <div>
-            <h2 className="text-xl font-bold">Recent Activity</h2>
-            <p className="text-sm text-muted-foreground">Status changes and printer assignment events for this machine.</p>
+            <h2 className="text-xl font-semibold text-foreground">Recent floor activity</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Status changes and assignment events for this machine.
+            </p>
           </div>
-          <span className="rounded-full bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground">{printer.history_events.length} events</span>
+          <span className="rounded-full bg-background/80 px-2.5 py-1 text-xs font-medium text-muted-foreground">
+            {printer.history_events.length} events
+          </span>
         </div>
 
         {!printer.history_events.length ? (
-          <div className="rounded-lg border border-border bg-background/40 p-6 text-sm text-muted-foreground">No printer activity has been recorded yet.</div>
+          <div className="rounded-[1.4rem] border border-dashed border-border bg-background/60 p-6 text-sm text-muted-foreground">
+            No printer activity has been recorded yet.
+          </div>
         ) : (
           <div className="space-y-3">
             {printer.history_events.map((event) => {
@@ -315,7 +468,7 @@ export default function PrinterDetailPage() {
               const fromPrinter = formatEventMetaValue(event.metadata?.from_printer_name);
               const toPrinter = formatEventMetaValue(event.metadata?.to_printer_name);
               return (
-                <div key={event.id} className="rounded-lg border border-border bg-background/40 p-4">
+                <div key={event.id} className="rounded-[1.35rem] border border-border bg-background/60 p-4">
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                     <div>
                       <p className="font-medium text-foreground">{event.title}</p>
@@ -336,23 +489,27 @@ export default function PrinterDetailPage() {
             })}
           </div>
         )}
-      </div>
+      </section>
 
-      <div>
-        <div className="flex items-center justify-between mb-4">
+      <section className="rounded-[1.8rem] border border-border bg-card/85 p-5 shadow-[0_16px_40px_rgba(8,17,31,0.06)]">
+        <div className="mb-4 flex items-center justify-between gap-3">
           <div>
-            <h2 className="text-xl font-bold">Assigned Jobs</h2>
-            <p className="text-sm text-muted-foreground">Current and recent jobs for this printer.</p>
+            <h2 className="text-xl font-semibold text-foreground">Assigned jobs</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Current and recent jobs routed through this printer.</p>
           </div>
-          <Link to="/jobs" className="text-sm text-primary no-underline hover:underline">View all jobs</Link>
+          <Link to="/orders" className="text-sm text-primary no-underline hover:underline">
+            View all jobs
+          </Link>
         </div>
 
         {jobsLoading ? (
           <SkeletonTable rows={5} cols={6} />
         ) : !recentJobs.length ? (
-          <div className="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">No jobs assigned to this printer yet.</div>
+          <div className="rounded-[1.4rem] border border-dashed border-border bg-background/60 p-8 text-center text-muted-foreground">
+            No jobs assigned to this printer yet.
+          </div>
         ) : (
-          <div className="overflow-x-auto rounded-lg border border-border bg-card">
+          <div className="overflow-x-auto rounded-[1.4rem] border border-border bg-background/60">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-border text-left text-muted-foreground">
@@ -366,14 +523,23 @@ export default function PrinterDetailPage() {
               </thead>
               <tbody>
                 {recentJobs.map((job: Job) => (
-                  <tr key={job.id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                    <td className="px-4 py-3"><Link to={`/jobs/${job.id}`} className="font-medium text-primary no-underline hover:underline">{job.job_number}</Link></td>
+                  <tr key={job.id} className="border-b border-border last:border-0 hover:bg-accent/40">
+                    <td className="px-4 py-3">
+                      <Link to={`/orders/jobs/${job.id}`} className="font-medium text-primary no-underline hover:underline">
+                        {job.job_number}
+                      </Link>
+                    </td>
                     <td className="px-4 py-3">{job.date}</td>
                     <td className="px-4 py-3">{job.product_name}</td>
                     <td className="px-4 py-3 text-right">{job.total_pieces}</td>
                     <td className="px-4 py-3 text-right">{formatCurrency(job.total_revenue)}</td>
                     <td className="px-4 py-3">
-                      <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', jobStatusClasses[job.status] || 'bg-primary/10 text-primary')}>
+                      <span
+                        className={cn(
+                          'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium capitalize',
+                          jobStatusClasses[job.status] || 'bg-primary/10 text-primary'
+                        )}
+                      >
                         {job.status.replace('_', ' ')}
                       </span>
                     </td>
@@ -383,7 +549,7 @@ export default function PrinterDetailPage() {
             </table>
           </div>
         )}
-      </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -1,17 +1,34 @@
-import { useMemo, useState, type ElementType } from 'react';
+import { useEffect, useMemo, useState, type ElementType } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Link } from 'react-router-dom';
-import { Plus, Search, Eye, Edit, Archive, ArchiveRestore, ArrowRight, Layers3, Activity, PauseCircle, WifiOff, AlertTriangle, Wrench } from 'lucide-react';
+import { Link, useSearchParams } from 'react-router-dom';
+import {
+  Activity,
+  AlertTriangle,
+  ArrowRight,
+  Archive,
+  ArchiveRestore,
+  Camera,
+  Edit,
+  Expand,
+  Layers3,
+  PauseCircle,
+  Plus,
+  Search,
+  Sparkles,
+  Shrink,
+  WifiOff,
+  Wrench,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
+import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import EmptyState from '@/components/ui/EmptyState';
-import { SkeletonTable } from '@/components/ui/Skeleton';
 import { cn } from '@/lib/utils';
 import type { Job, PaginatedJobs, PaginatedPrinters, Printer } from '@/types';
 
 const STATUS_OPTIONS = ['idle', 'printing', 'paused', 'maintenance', 'offline', 'error'] as const;
 const ACTIVE_ASSIGNMENT_STATUSES = new Set(['draft', 'in_progress']);
-const DEGRADED_STATUSES = new Set(['paused', 'maintenance', 'offline', 'error']);
+const ATTENTION_STATUSES = new Set(['paused', 'maintenance', 'offline', 'error']);
 
 const statusClasses: Record<string, string> = {
   idle: 'bg-slate-100 text-slate-800 dark:bg-slate-800/60 dark:text-slate-200',
@@ -29,14 +46,14 @@ const jobStatusClasses: Record<string, string> = {
   cancelled: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
 };
 
-const activeClasses: Record<string, string> = {
-  active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  inactive: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
-};
-
 function StatusBadge({ status }: { status: string }) {
   return (
-    <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize', statusClasses[status] || 'bg-primary/10 text-primary')}>
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium capitalize',
+        statusClasses[status] || 'bg-primary/10 text-primary'
+      )}
+    >
       {status.replace('_', ' ')}
     </span>
   );
@@ -44,16 +61,13 @@ function StatusBadge({ status }: { status: string }) {
 
 function JobStatusBadge({ status }: { status: string }) {
   return (
-    <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', jobStatusClasses[status] || 'bg-primary/10 text-primary')}>
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium capitalize',
+        jobStatusClasses[status] || 'bg-primary/10 text-primary'
+      )}
+    >
       {status.replace('_', ' ')}
-    </span>
-  );
-}
-
-function ActiveBadge({ isActive }: { isActive: boolean }) {
-  return (
-    <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', isActive ? activeClasses.active : activeClasses.inactive)}>
-      {isActive ? 'Active' : 'Inactive'}
     </span>
   );
 }
@@ -80,91 +94,226 @@ type PrinterGroup = {
   emptyText: string;
   icon: ElementType;
   accentClass: string;
+  panelTone?: string;
   printers: Printer[];
 };
 
-function PrinterAssignmentCard({ printer, currentJob }: { printer: Printer; currentJob?: Job }) {
+function SummaryCard({
+  label,
+  value,
+  subtext,
+  emphasis = 'default',
+}: {
+  label: string;
+  value: string;
+  subtext?: string;
+  emphasis?: 'default' | 'warning' | 'success';
+}) {
   return (
-    <div className="rounded-lg border border-border bg-card p-4">
+    <div className="rounded-[1.5rem] border border-border bg-card/80 p-4 shadow-[0_14px_40px_rgba(8,17,31,0.06)]">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">{label}</p>
+      <p
+        className={cn(
+          'mt-3 text-3xl font-semibold',
+          emphasis === 'warning' && 'text-amber-600 dark:text-amber-300',
+          emphasis === 'success' && 'text-emerald-600 dark:text-emerald-300'
+        )}
+      >
+        {value}
+      </p>
+      {subtext ? <p className="mt-1 text-sm text-muted-foreground">{subtext}</p> : null}
+    </div>
+  );
+}
+
+function PrinterWallCard({
+  printer,
+  currentJob,
+  onToggleActive,
+  wallMode = false,
+  reducedMotion = false,
+}: {
+  printer: Printer;
+  currentJob?: Job;
+  onToggleActive: (printer: Printer) => void;
+  wallMode?: boolean;
+  reducedMotion?: boolean;
+}) {
+  const liveStatus = printer.monitor_status || printer.status;
+  const needsAttention = ATTENTION_STATUSES.has(liveStatus);
+  const progress = printer.monitor_progress_percent ?? 0;
+
+  return (
+    <article
+      className={cn(
+        'rounded-[1.6rem] border p-4 shadow-[0_16px_40px_rgba(8,17,31,0.06)]',
+        !reducedMotion && 'transition-colors',
+        needsAttention
+          ? 'border-amber-300/70 bg-amber-50/80 dark:border-amber-500/30 dark:bg-amber-500/10'
+          : wallMode
+            ? 'border-slate-700/80 bg-slate-950/85 text-slate-50'
+            : 'border-border bg-card/85'
+      )}
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <Link to={`/printers/${printer.id}`} className="font-semibold text-foreground no-underline hover:text-primary">
+            <Link
+              to={`/print-floor/printers/${printer.id}`}
+              className="truncate font-semibold text-foreground no-underline hover:text-primary"
+            >
               {printer.name}
             </Link>
-            <StatusBadge status={printer.status} />
-            {!printer.is_active && <ActiveBadge isActive={false} />}
+            <StatusBadge status={liveStatus} />
+            {!printer.is_active ? <span className="rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">Inactive</span> : null}
           </div>
-          <p className="mt-1 text-xs text-muted-foreground">
-            {[printer.manufacturer, printer.model].filter(Boolean).join(' · ') || 'Printer details pending'}
-            {printer.location ? ` · ${printer.location}` : ''}
+          <p className="mt-1 text-xs uppercase tracking-[0.16em] text-muted-foreground">
+            {[printer.manufacturer, printer.model, printer.location].filter(Boolean).join(' • ') || 'Printer details pending'}
           </p>
-          {printer.monitor_enabled ? (
-            <div className="mt-1 space-y-1 text-xs text-muted-foreground">
-              <p className="truncate" title={[printer.monitor_status || printer.status, printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : null, printer.current_print_name].filter(Boolean).join(' · ')}>
-                Live: {printer.monitor_status || printer.status}
-                {printer.monitor_progress_percent != null ? ` · ${printer.monitor_progress_percent.toFixed(0)}%` : ''}
-                {printer.current_print_name ? ` · ${printer.current_print_name}` : ''}
-              </p>
-              <p className="truncate" title={[`Layer ${formatLayer(printer.monitor_current_layer, printer.monitor_total_layers)}`, printer.monitor_remaining_seconds != null ? `ETA ${formatDuration(printer.monitor_remaining_seconds)}` : null, printer.monitor_provider === 'moonraker' ? (printer.monitor_ws_connected ? 'socket live' : 'poll fallback') : null].filter(Boolean).join(' · ')}>
-                Layer {formatLayer(printer.monitor_current_layer, printer.monitor_total_layers)}
-                {printer.monitor_remaining_seconds != null ? ` · ETA ${formatDuration(printer.monitor_remaining_seconds)}` : ''}
-                {printer.monitor_provider === 'moonraker' ? ` · ${printer.monitor_ws_connected ? 'socket live' : 'poll fallback'}` : ''}
-              </p>
-            </div>
-          ) : (
-            <p className="mt-1 text-xs text-muted-foreground">Static record only</p>
-          )}
         </div>
-        <Link to={`/printers/${printer.id}`} className="rounded-md border border-border p-2 text-muted-foreground hover:bg-accent" title="View printer">
-          <Eye className="h-4 w-4" />
-        </Link>
+        <button
+          type="button"
+          onClick={() => onToggleActive(printer)}
+          className={cn(
+            'rounded-xl border p-2 transition-colors hover:text-foreground',
+            wallMode
+              ? 'border-slate-700 bg-slate-900/80 text-slate-300'
+              : 'border-border bg-background/70 text-muted-foreground'
+          )}
+          title={printer.is_active ? 'Deactivate printer' : 'Restore printer'}
+        >
+          {printer.is_active ? <Archive className="h-4 w-4" /> : <ArchiveRestore className="h-4 w-4" />}
+        </button>
       </div>
 
-      <div className="mt-4 rounded-lg border border-border bg-background/40 p-3">
+      <div className="mt-4 grid gap-4 lg:grid-cols-[104px_minmax(0,1fr)]">
+        <PrinterThumbnail
+          src={printer.current_print_thumbnail_url}
+          alt={printer.current_print_name ? `${printer.current_print_name} thumbnail` : `${printer.name} thumbnail`}
+          className="h-[104px] w-[104px] rounded-[1.25rem]"
+          imgClassName="object-cover"
+          fallbackLabel={printer.current_print_name ? 'No thumbnail' : 'No active print'}
+        />
+
+        <div className="min-w-0">
+          <div className="flex items-center justify-between gap-3">
+            <p className="truncate text-sm font-medium text-foreground">
+              {printer.current_print_name || 'No active print'}
+            </p>
+            <span className="text-sm font-semibold text-foreground">
+              {printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}
+            </span>
+          </div>
+
+          <div className={cn('mt-3 h-2 rounded-full', wallMode ? 'bg-slate-900/90' : 'bg-background/90')}>
+            <div
+              className={cn(
+                'h-2 rounded-full',
+                !reducedMotion && 'transition-[width]',
+                needsAttention ? 'bg-amber-500' : liveStatus === 'printing' ? 'bg-primary' : 'bg-sky-500'
+              )}
+              style={{ width: `${Math.max(6, progress)}%` }}
+            />
+          </div>
+
+          <dl className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+            <div>
+              <dt className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Layer</dt>
+              <dd className="font-medium text-foreground">{formatLayer(printer.monitor_current_layer, printer.monitor_total_layers)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-[0.16em] text-muted-foreground">ETA</dt>
+              <dd className="font-medium text-foreground">{formatDuration(printer.monitor_remaining_seconds)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Transport</dt>
+              <dd className="font-medium text-foreground">
+                {printer.monitor_provider === 'moonraker'
+                  ? printer.monitor_ws_connected
+                    ? 'Socket live'
+                    : 'Polling fallback'
+                  : printer.monitor_enabled
+                    ? 'Polling'
+                    : 'Static record'}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Assignment</dt>
+              <dd className="font-medium text-foreground">{currentJob ? currentJob.job_number : 'Unassigned'}</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-[1.25rem] border border-border bg-background/60 p-3">
         <div className="flex items-start justify-between gap-3">
-          <div>
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Current assignment</p>
+          <div className="min-w-0">
+            <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Current job</p>
             {currentJob ? (
               <>
-                <Link to={`/jobs/${currentJob.id}`} className="mt-1 block font-medium text-primary no-underline hover:underline">
+                <Link
+                  to={`/orders/jobs/${currentJob.id}`}
+                  className="mt-1 block truncate font-medium text-primary no-underline hover:underline"
+                >
                   {currentJob.job_number}
                 </Link>
-                <p className="truncate text-sm text-muted-foreground" title={currentJob.product_name}>{currentJob.product_name}</p>
-                <p className="mt-1 text-xs text-muted-foreground">{currentJob.total_pieces} pcs · {currentJob.date}</p>
+                <p className="truncate text-sm text-muted-foreground">{currentJob.product_name}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{currentJob.total_pieces} pcs • {currentJob.date}</p>
               </>
             ) : (
-              <p className="mt-1 text-sm text-muted-foreground">No active job assigned.</p>
+              <p className="mt-1 text-sm text-muted-foreground">No active or draft job is assigned.</p>
             )}
           </div>
           {currentJob ? <JobStatusBadge status={currentJob.status} /> : null}
         </div>
       </div>
 
-      <div className="mt-4 flex flex-wrap gap-2 text-sm">
-        <Link to={`/printers/${printer.id}`} className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 no-underline hover:bg-accent">
-          <Eye className="h-4 w-4" /> Printer
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Link
+          to={`/print-floor/printers/${printer.id}`}
+          className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline shadow-[0_12px_32px_rgba(34,197,94,0.22)]"
+        >
+          Open console
         </Link>
-        <Link to={`/printers/${printer.id}/edit`} className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 no-underline hover:bg-accent">
-          <Edit className="h-4 w-4" /> Edit
-        </Link>
+        {!wallMode ? (
+          <Link
+            to={`/print-floor/printers/${printer.id}/edit`}
+            className="inline-flex items-center gap-2 rounded-full border border-border bg-background/70 px-4 py-2 text-sm font-medium text-foreground no-underline transition-colors hover:border-primary/30"
+          >
+            <Edit className="h-4 w-4" /> Edit
+          </Link>
+        ) : null}
         {currentJob ? (
-          <Link to={`/jobs/${currentJob.id}`} className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 no-underline hover:bg-accent">
+          <Link
+            to={`/orders/jobs/${currentJob.id}`}
+            className="inline-flex items-center gap-2 rounded-full border border-border bg-background/70 px-4 py-2 text-sm font-medium text-foreground no-underline transition-colors hover:border-primary/30"
+          >
             <ArrowRight className="h-4 w-4" /> Job
           </Link>
         ) : null}
       </div>
-    </div>
+    </article>
   );
 }
 
 export default function PrintersPage() {
   const queryClient = useQueryClient();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [search, setSearch] = useState('');
   const [status, setStatus] = useState('');
   const [active, setActive] = useState('');
   const [page, setPage] = useState(0);
   const limit = 24;
+  const wallMode = searchParams.get('mode') === 'wall';
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const sync = () => setReducedMotion(media.matches);
+    sync();
+    media.addEventListener('change', sync);
+    return () => media.removeEventListener('change', sync);
+  }, []);
 
   const { data, isLoading } = useQuery<PaginatedPrinters>({
     queryKey: ['printers', { search, status, active, page }],
@@ -178,7 +327,7 @@ export default function PrintersPage() {
       const { data } = await api.get(`/printers?${params.toString()}`);
       return data;
     },
-    refetchInterval: 15000,
+    refetchInterval: wallMode ? 10000 : 15000,
   });
 
   const { data: activeJobsData, isLoading: jobsLoading } = useQuery<PaginatedJobs>({
@@ -219,49 +368,77 @@ export default function PrintersPage() {
 
   const summary = useMemo(() => {
     const activePrinters = printers.filter((printer) => printer.is_active);
+    const printing = activePrinters.filter((printer) => (printer.monitor_status || printer.status) === 'printing').length;
+    const attention = activePrinters.filter((printer) => ATTENTION_STATUSES.has(printer.monitor_status || printer.status)).length;
+    const ready = activePrinters.filter((printer) => (printer.monitor_status || printer.status) === 'idle').length;
+    const unassignedJobs = (activeJobsData?.items || []).filter((job) => !job.printer_id && ACTIVE_ASSIGNMENT_STATUSES.has(job.status)).length;
+    const queuePressure = ready === 0 ? activeJobsData?.items.length || 0 : Number(((activeJobsData?.items.length || 0) / ready).toFixed(1));
+    const utilization = activePrinters.length ? Math.round((printing / activePrinters.length) * 100) : 0;
 
     return {
-      total: printers.length,
-      idle: activePrinters.filter((printer) => printer.status === 'idle').length,
-      printing: activePrinters.filter((printer) => printer.status === 'printing').length,
-      attention: activePrinters.filter((printer) => DEGRADED_STATUSES.has(printer.status)).length,
+      total: activePrinters.length,
+      printing,
+      attention,
+      ready,
       assigned: activePrinters.filter((printer) => currentJobsByPrinter.has(printer.id)).length,
+      unassignedJobs,
+      queuePressure,
+      utilization,
     };
   }, [currentJobsByPrinter, printers]);
 
-  const dashboardGroups = useMemo<PrinterGroup[]>(() => {
+  const wallGroups = useMemo<PrinterGroup[]>(() => {
     const activePrinters = printers.filter((printer) => printer.is_active);
 
     return [
       {
-        key: 'idle',
-        title: 'Idle printers',
-        description: 'Ready for new work with no active print running.',
-        emptyText: 'No idle printers in this filtered view.',
-        icon: Layers3,
-        accentClass: 'text-slate-600 dark:text-slate-300',
-        printers: activePrinters.filter((printer) => printer.status === 'idle'),
+        key: 'attention',
+        title: 'Needs attention',
+        description: 'Paused, offline, maintenance, or error states that need operator awareness first.',
+        emptyText: 'No printers currently need operator attention.',
+        icon: AlertTriangle,
+        accentClass: 'text-amber-600 dark:text-amber-300',
+        panelTone: 'border-amber-300/70 bg-amber-50/70 dark:border-amber-500/30 dark:bg-amber-500/8',
+        printers: activePrinters.filter((printer) => ATTENTION_STATUSES.has(printer.monitor_status || printer.status)),
       },
       {
-        key: 'busy',
-        title: 'Busy / printing',
-        description: 'Machines currently running or marked as printing.',
+        key: 'printing',
+        title: 'Printing now',
+        description: 'Machines actively producing parts with live telemetry and current job context.',
         emptyText: 'Nothing is actively printing right now.',
         icon: Activity,
-        accentClass: 'text-blue-600 dark:text-blue-400',
-        printers: activePrinters.filter((printer) => printer.status === 'printing'),
+        accentClass: 'text-sky-600 dark:text-sky-300',
+        panelTone: 'border-sky-300/70 bg-sky-50/70 dark:border-sky-500/30 dark:bg-sky-500/8',
+        printers: activePrinters.filter((printer) => (printer.monitor_status || printer.status) === 'printing'),
       },
       {
-        key: 'attention',
-        title: 'Paused / offline / error / maintenance',
-        description: 'Printers that need attention before they can take reliable work.',
-        emptyText: 'No printers are paused, offline, in error, or under maintenance.',
-        icon: AlertTriangle,
-        accentClass: 'text-amber-600 dark:text-amber-400',
-        printers: activePrinters.filter((printer) => DEGRADED_STATUSES.has(printer.status)),
+        key: 'ready',
+        title: 'Ready for work',
+        description: 'Idle or unblocked printers that can take the next assignment quickly.',
+        emptyText: 'No idle printers in this filtered view.',
+        icon: Layers3,
+        accentClass: 'text-emerald-600 dark:text-emerald-300',
+        panelTone: 'border-emerald-300/70 bg-emerald-50/70 dark:border-emerald-500/30 dark:bg-emerald-500/8',
+        printers: activePrinters.filter((printer) => (printer.monitor_status || printer.status) === 'idle'),
       },
     ];
   }, [printers]);
+
+  const attentionPrinters = wallGroups[0]?.printers || [];
+  const analytics = useMemo(() => {
+    const activeJobs = activeJobsData?.items || [];
+    const printingWithoutTelemetry = printers.filter(
+      (printer) => (printer.monitor_status || printer.status) === 'printing' && !printer.monitor_enabled
+    ).length;
+
+    return {
+      activeJobs: activeJobs.length,
+      unassignedJobs: activeJobs.filter((job) => !job.printer_id && ACTIVE_ASSIGNMENT_STATUSES.has(job.status)).length,
+      printersAtAttention: attentionPrinters.length,
+      printingWithoutTelemetry,
+      cameraReadyPlaceholder: printers.filter((printer) => printer.monitor_enabled).length,
+    };
+  }, [activeJobsData, attentionPrinters.length, printers]);
 
   const toggleActive = async (printer: Printer) => {
     const confirmed = window.confirm(
@@ -287,300 +464,301 @@ export default function PrintersPage() {
     }
   };
 
+  const updateWallMode = (enabled: boolean) => {
+    const next = new URLSearchParams(searchParams);
+    if (enabled) {
+      next.set('mode', 'wall');
+    } else {
+      next.delete('mode');
+    }
+    setSearchParams(next, { replace: true });
+  };
+
   return (
-    <div>
-      <div className="mb-6 flex items-center justify-between gap-3">
-        <div>
-          <h1 className="text-3xl font-bold">Printers</h1>
-          <p className="mt-1 text-sm text-muted-foreground">Manage your print farm, machine status, and printer assignments.</p>
-        </div>
-        <Link to="/printers/new" className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground no-underline hover:opacity-90">
-          <Plus className="h-4 w-4" /> Add Printer
-        </Link>
-      </div>
-
-      <div className="mb-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
-        <div className="rounded-lg border border-border bg-card p-4"><p className="text-xs text-muted-foreground">Visible printers</p><p className="mt-1 text-2xl font-bold">{summary.total}</p></div>
-        <div className="rounded-lg border border-border bg-card p-4"><p className="text-xs text-muted-foreground">Idle</p><p className="mt-1 text-2xl font-bold">{summary.idle}</p></div>
-        <div className="rounded-lg border border-border bg-card p-4"><p className="text-xs text-muted-foreground">Printing</p><p className="mt-1 text-2xl font-bold">{summary.printing}</p></div>
-        <div className="rounded-lg border border-border bg-card p-4"><p className="text-xs text-muted-foreground">Need attention</p><p className="mt-1 text-2xl font-bold">{summary.attention}</p></div>
-        <div className="rounded-lg border border-border bg-card p-4"><p className="text-xs text-muted-foreground">Assigned jobs</p><p className="mt-1 text-2xl font-bold">{summary.assigned}</p></div>
-      </div>
-
-      <div className="mb-6 rounded-xl border border-border bg-card p-4 sm:p-5">
-        <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+    <div className={cn('space-y-6', wallMode && 'rounded-[2rem] bg-[linear-gradient(180deg,#020617_0%,#08111f_100%)] p-4 text-slate-50')}>
+      <section className={cn(
+        'overflow-hidden rounded-[2rem] border border-border bg-[linear-gradient(135deg,rgba(8,17,31,0.98),rgba(17,34,53,0.96))] px-6 py-6 text-white shadow-[0_24px_70px_rgba(8,17,31,0.18)]',
+        wallMode && 'border-slate-700/80 bg-[linear-gradient(135deg,rgba(2,6,23,0.98),rgba(8,17,31,0.96))] shadow-none'
+      )}>
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,0.65fr)]">
           <div>
-            <h2 className="text-lg font-semibold">Operations dashboard</h2>
-            <p className="text-sm text-muted-foreground">Fleet availability and current assignment state from the app-managed printer and job data.</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-cyan-200/75">
+              {wallMode ? 'Print-floor wall mode' : 'Print-floor workspace'}
+            </p>
+            <h1 className="mt-3 text-3xl font-semibold md:text-4xl">
+              Printer wall
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-200/82 md:text-base">
+              Scan the fleet by status, jump into a live printer console, and move from machine state to job context without leaving the floor board.
+            </p>
+            <div className="mt-5 flex flex-wrap gap-3">
+              {!wallMode ? (
+                <>
+                  <Link
+                    to="/print-floor/printers/new"
+                    className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline shadow-[0_16px_40px_rgba(34,197,94,0.28)]"
+                  >
+                    <Plus className="h-4 w-4" /> Add printer
+                  </Link>
+                  <Link
+                    to="/orders"
+                    className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-2 text-sm font-medium text-white no-underline transition-colors hover:bg-white/12"
+                  >
+                    <ArrowRight className="h-4 w-4" /> Open jobs queue
+                  </Link>
+                </>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => updateWallMode(!wallMode)}
+                className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/12"
+              >
+                {wallMode ? <Shrink className="h-4 w-4" /> : <Expand className="h-4 w-4" />}
+                {wallMode ? 'Exit wall mode' : 'Wall mode'}
+              </button>
+            </div>
           </div>
-          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-            <span className="inline-flex items-center gap-1 rounded-full bg-background px-3 py-1"><PauseCircle className="h-3.5 w-3.5" /> Paused</span>
-            <span className="inline-flex items-center gap-1 rounded-full bg-background px-3 py-1"><WifiOff className="h-3.5 w-3.5" /> Offline</span>
-            <span className="inline-flex items-center gap-1 rounded-full bg-background px-3 py-1"><Wrench className="h-3.5 w-3.5" /> Maintenance</span>
-            <span className="inline-flex items-center gap-1 rounded-full bg-background px-3 py-1"><AlertTriangle className="h-3.5 w-3.5" /> Error</span>
+
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+            <SummaryCard
+              label="Attention queue"
+              value={String(summary.attention)}
+              subtext={summary.attention ? `${summary.attention} printers need intervention` : 'No open printer exceptions'}
+              emphasis={summary.attention ? 'warning' : 'success'}
+            />
+            <SummaryCard
+              label="Utilization"
+              value={summary.total ? `${summary.utilization}%` : '—'}
+              subtext={`${summary.printing} printing • ${summary.ready} ready • ${summary.assigned} assigned`}
+            />
           </div>
         </div>
+      </section>
 
-        {isLoading || jobsLoading ? (
-          <div className="grid gap-4 xl:grid-cols-3">
-            {Array.from({ length: 3 }).map((_, index) => (
-              <div key={index} className="rounded-lg border border-border bg-background/40 p-4">
-                <div className="mb-4 h-6 w-40 animate-pulse rounded bg-muted" />
-                <div className="space-y-3">
-                  {Array.from({ length: 2 }).map((__, cardIndex) => (
-                    <div key={cardIndex} className="h-40 animate-pulse rounded-lg border border-border bg-card" />
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="grid gap-4 xl:grid-cols-3">
-            {dashboardGroups.map((group) => {
-              const Icon = group.icon;
-
-              return (
-                <section key={group.key} className="rounded-lg border border-border bg-background/40 p-4">
-                  <div className="mb-4 flex items-start justify-between gap-3">
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <Icon className={cn('h-4 w-4', group.accentClass)} />
-                        <h3 className="font-semibold">{group.title}</h3>
-                      </div>
-                      <p className="mt-1 text-sm text-muted-foreground">{group.description}</p>
-                    </div>
-                    <span className="rounded-full bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground">{group.printers.length}</span>
-                  </div>
-
-                  {group.printers.length ? (
-                    <div className="space-y-3">
-                      {group.printers.map((printer) => (
-                        <PrinterAssignmentCard key={printer.id} printer={printer} currentJob={currentJobsByPrinter.get(printer.id)} />
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="rounded-lg border border-dashed border-border bg-card/60 px-4 py-10 text-center text-sm text-muted-foreground">
-                      {group.emptyText}
-                    </div>
-                  )}
-                </section>
-              );
-            })}
-          </div>
-        )}
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+        <SummaryCard label="Visible active printers" value={String(summary.total)} />
+        <SummaryCard label="Printing now" value={String(summary.printing)} emphasis={summary.printing ? 'success' : 'default'} />
+        <SummaryCard label="Ready for work" value={String(summary.ready)} emphasis={summary.ready ? 'success' : 'default'} />
+        <SummaryCard label="Need attention" value={String(summary.attention)} emphasis={summary.attention ? 'warning' : 'default'} />
+        <SummaryCard
+          label="Queue pressure"
+          value={summary.ready ? `${summary.queuePressure}:1` : `${summary.unassignedJobs}`}
+          subtext={summary.ready ? 'Active queue to ready-printer ratio' : 'No ready printers available'}
+          emphasis={summary.unassignedJobs > summary.ready ? 'warning' : 'default'}
+        />
       </div>
 
-      <div className="mb-6 grid gap-3 md:grid-cols-[minmax(0,1fr)_180px_180px]">
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <input
-            value={search}
+      <div className={cn('grid gap-4', wallMode ? 'xl:grid-cols-3' : 'xl:grid-cols-4')}>
+        <SummaryCard
+          label="Assignment pressure"
+          value={String(analytics.unassignedJobs)}
+          subtext="Draft or in-progress jobs missing a printer assignment"
+          emphasis={analytics.unassignedJobs ? 'warning' : 'default'}
+        />
+        <SummaryCard
+          label="Telemetry blind spots"
+          value={String(analytics.printingWithoutTelemetry)}
+          subtext="Printing machines relying on static status or polling only"
+          emphasis={analytics.printingWithoutTelemetry ? 'warning' : 'default'}
+        />
+        <SummaryCard
+          label="Urgent floor load"
+          value={String(analytics.printersAtAttention + analytics.unassignedJobs)}
+          subtext="Attention printers plus queue items needing assignment"
+          emphasis={analytics.printersAtAttention + analytics.unassignedJobs ? 'warning' : 'default'}
+        />
+        {!wallMode ? (
+          <div className="rounded-[1.5rem] border border-border bg-card/80 p-4 shadow-[0_14px_40px_rgba(8,17,31,0.06)]">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Camera integration path</p>
+            <p className="mt-3 text-base font-semibold text-foreground">Ready for `#129`</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Wall mode uses print thumbnails now and reserves camera tile space for the dedicated live-camera issue.
+            </p>
+          </div>
+        ) : null}
+      </div>
+
+      {attentionPrinters.length > 0 ? (
+        <section className="rounded-[1.7rem] border border-amber-300/70 bg-amber-50/80 p-5 shadow-[0_16px_40px_rgba(8,17,31,0.06)] dark:border-amber-500/30 dark:bg-amber-500/10">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <div className="flex items-center gap-2">
+                <Sparkles className="h-4 w-4 text-amber-500" />
+                <h2 className="text-lg font-semibold text-foreground">Operator attention strip</h2>
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Start here when the floor gets noisy. These are the machines most likely to block work right now.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+              <span className="inline-flex items-center gap-1 rounded-full bg-background/80 px-3 py-1"><PauseCircle className="h-3.5 w-3.5" /> Paused</span>
+              <span className="inline-flex items-center gap-1 rounded-full bg-background/80 px-3 py-1"><WifiOff className="h-3.5 w-3.5" /> Offline</span>
+              <span className="inline-flex items-center gap-1 rounded-full bg-background/80 px-3 py-1"><Wrench className="h-3.5 w-3.5" /> Maintenance</span>
+              <span className="inline-flex items-center gap-1 rounded-full bg-background/80 px-3 py-1"><AlertTriangle className="h-3.5 w-3.5" /> Error</span>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {!wallMode ? (
+        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px_180px]">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <input
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(0);
+              }}
+              placeholder="Search printers by name, model, slug, or location..."
+              className="w-full rounded-[1rem] border border-input bg-card/80 py-3 pl-10 pr-3 focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <select
+            value={status}
             onChange={(e) => {
-              setSearch(e.target.value);
+              setStatus(e.target.value);
               setPage(0);
             }}
-            placeholder="Search printers by name, model, slug, or location..."
-            className="w-full rounded-md border border-input bg-background py-2 pr-3 pl-10 focus:outline-none focus:ring-2 focus:ring-ring"
-          />
+            className="rounded-[1rem] border border-input bg-card/80 px-3 py-3 focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            <option value="">All statuses</option>
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option.replace('_', ' ')}
+              </option>
+            ))}
+          </select>
+          <select
+            value={active}
+            onChange={(e) => {
+              setActive(e.target.value);
+              setPage(0);
+            }}
+            className="rounded-[1rem] border border-input bg-card/80 px-3 py-3 focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            <option value="">Active + inactive</option>
+            <option value="true">Active only</option>
+            <option value="false">Inactive only</option>
+          </select>
         </div>
-        <select
-          value={status}
-          onChange={(e) => {
-            setStatus(e.target.value);
-            setPage(0);
-          }}
-          className="rounded-md border border-input bg-background px-3 py-2 focus:outline-none focus:ring-2 focus:ring-ring"
-        >
-          <option value="">All statuses</option>
-          {STATUS_OPTIONS.map((option) => (
-            <option key={option} value={option}>{option.replace('_', ' ')}</option>
-          ))}
-        </select>
-        <select
-          value={active}
-          onChange={(e) => {
-            setActive(e.target.value);
-            setPage(0);
-          }}
-          className="rounded-md border border-input bg-background px-3 py-2 focus:outline-none focus:ring-2 focus:ring-ring"
-        >
-          <option value="">Active + inactive</option>
-          <option value="true">Active only</option>
-          <option value="false">Inactive only</option>
-        </select>
-      </div>
+      ) : (
+        <section className="rounded-[1.7rem] border border-slate-700/80 bg-slate-950/80 p-5 shadow-none">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-50">Wall-mode monitor behavior</h2>
+              <p className="mt-1 text-sm text-slate-300">
+                Reduced chrome, darker surfaces, larger fleet signals, and a 10s refresh interval for persistent shop-floor display.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs text-slate-300">
+              <span className="inline-flex items-center gap-1 rounded-full border border-slate-700 bg-slate-900/80 px-3 py-1">
+                <Camera className="h-3.5 w-3.5" /> Camera tiles plug in here after `#129`
+              </span>
+              <span className="inline-flex items-center gap-1 rounded-full border border-slate-700 bg-slate-900/80 px-3 py-1">
+                {reducedMotion ? 'Reduced motion respected' : 'Motion available'}
+              </span>
+            </div>
+          </div>
+        </section>
+      )}
 
-      {isLoading ? (
-        <SkeletonTable rows={6} cols={7} />
+      {isLoading || jobsLoading ? (
+        <div className={cn('grid gap-4', wallMode ? 'xl:grid-cols-3 2xl:grid-cols-3' : 'xl:grid-cols-3')}>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="rounded-[1.6rem] border border-border bg-card/85 p-4">
+              <div className="mb-4 h-6 w-44 animate-pulse rounded bg-muted" />
+              <div className="space-y-3">
+                {Array.from({ length: 2 }).map((__, cardIndex) => (
+                  <div key={cardIndex} className="h-72 animate-pulse rounded-[1.4rem] border border-border bg-background/70" />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
       ) : !printers.length ? (
         <EmptyState
           title="No printers found"
-          description="Add your first printer to start tracking status, locations, and job assignments."
-          action={<Link to="/printers/new" className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground no-underline hover:opacity-90"><Plus className="h-4 w-4" /> Add Printer</Link>}
+          description="Add your first printer to start tracking the print floor, machine status, and assignment context."
+          action={
+            <Link
+              to="/print-floor/printers/new"
+              className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground no-underline hover:opacity-90"
+            >
+              <Plus className="h-4 w-4" /> Add printer
+            </Link>
+          }
         />
       ) : (
-        <>
-          <div className="hidden overflow-x-auto rounded-lg border border-border bg-card lg:block">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border text-left text-muted-foreground">
-                  <th className="px-4 py-3 font-medium">Name</th>
-                  <th className="px-4 py-3 font-medium">Manufacturer / Model</th>
-                  <th className="px-4 py-3 font-medium">Location</th>
-                  <th className="px-4 py-3 font-medium">Status</th>
-                  <th className="px-4 py-3 font-medium">Live monitor</th>
-                  <th className="px-4 py-3 font-medium">Assignment</th>
-                  <th className="px-4 py-3 font-medium">State</th>
-                  <th className="px-4 py-3 font-medium">Notes</th>
-                  <th className="px-4 py-3 font-medium text-right">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {printers.map((printer) => {
-                  const currentJob = currentJobsByPrinter.get(printer.id);
+        <div className={cn('grid gap-4', wallMode ? 'xl:grid-cols-2 2xl:grid-cols-3' : 'xl:grid-cols-3')}>
+          {wallGroups.map((group) => {
+            const Icon = group.icon;
 
-                  return (
-                    <tr key={printer.id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                      <td className="px-4 py-3">
-                        <div className="font-medium">{printer.name}</div>
-                        <div className="font-mono text-xs text-muted-foreground">{printer.slug}</div>
-                      </td>
-                      <td className="px-4 py-3">
-                        <div>{printer.manufacturer || '—'}</div>
-                        <div className="text-xs text-muted-foreground">{printer.model || '—'}</div>
-                      </td>
-                      <td className="px-4 py-3">{printer.location || '—'}</td>
-                      <td className="px-4 py-3"><StatusBadge status={printer.status} /></td>
-                      <td className="px-4 py-3 text-xs text-muted-foreground">
-                        {printer.monitor_enabled ? (
-                          <div>
-                            <div>{printer.monitor_status || printer.status}{printer.monitor_online === false ? ' · offline' : ''}</div>
-                            <div>{printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}{printer.current_print_name ? ` · ${printer.current_print_name}` : ''}</div>
-                            <div>Layer {formatLayer(printer.monitor_current_layer, printer.monitor_total_layers)} · Remaining {formatDuration(printer.monitor_remaining_seconds)}{printer.monitor_provider === 'moonraker' ? ` · ${printer.monitor_ws_connected ? 'WS' : 'poll'}` : ''}</div>
-                          </div>
-                        ) : (
-                          'Not configured'
-                        )}
-                      </td>
-                      <td className="px-4 py-3">
-                        {currentJob ? (
-                          <div>
-                            <Link to={`/jobs/${currentJob.id}`} className="font-medium text-primary no-underline hover:underline">{currentJob.job_number}</Link>
-                            <div className="mt-1 text-xs text-muted-foreground">{currentJob.product_name}</div>
-                          </div>
-                        ) : (
-                          <span className="text-muted-foreground">Unassigned</span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3"><ActiveBadge isActive={printer.is_active} /></td>
-                      <td className="max-w-xs truncate px-4 py-3 text-muted-foreground">{printer.notes || '—'}</td>
-                      <td className="px-4 py-3">
-                        <div className="flex justify-end gap-1">
-                          <Link to={`/printers/${printer.id}`} className="rounded-md p-1.5 text-muted-foreground hover:bg-accent" title="View"><Eye className="h-4 w-4" /></Link>
-                          {currentJob ? <Link to={`/jobs/${currentJob.id}`} className="rounded-md p-1.5 text-muted-foreground hover:bg-accent" title="View assigned job"><ArrowRight className="h-4 w-4" /></Link> : null}
-                          <Link to={`/printers/${printer.id}/edit`} className="rounded-md p-1.5 text-muted-foreground hover:bg-accent" title="Edit"><Edit className="h-4 w-4" /></Link>
-                          <button onClick={() => toggleActive(printer)} className="cursor-pointer rounded-md p-1.5 text-muted-foreground hover:bg-accent" title={printer.is_active ? 'Deactivate printer' : 'Restore printer'}>
-                            {printer.is_active ? <Archive className="h-4 w-4" /> : <ArchiveRestore className="h-4 w-4" />}
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-
-          <div className="grid gap-3 lg:hidden">
-            {printers.map((printer) => {
-              const currentJob = currentJobsByPrinter.get(printer.id);
-
-              return (
-                <div key={printer.id} className="rounded-lg border border-border bg-card p-4">
-                  <div className="mb-3 flex items-start justify-between gap-3">
-                    <div>
-                      <Link to={`/printers/${printer.id}`} className="font-semibold text-foreground no-underline hover:text-primary">{printer.name}</Link>
-                      <p className="mt-0.5 font-mono text-xs text-muted-foreground">{printer.slug}</p>
+            return (
+              <section
+                key={group.key}
+                className={cn('rounded-[1.8rem] border p-4 shadow-[0_16px_40px_rgba(8,17,31,0.06)]', group.panelTone || 'border-border bg-card/85')}
+              >
+                <div className="mb-4 flex items-start justify-between gap-3">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <Icon className={cn('h-4 w-4', group.accentClass)} />
+                      <h2 className="text-lg font-semibold text-foreground">{group.title}</h2>
                     </div>
-                    <div className="flex flex-col items-end gap-2">
-                      <StatusBadge status={printer.status} />
-                      <ActiveBadge isActive={printer.is_active} />
-                    </div>
+                    <p className="mt-1 text-sm text-muted-foreground">{group.description}</p>
                   </div>
-                  <div className="grid grid-cols-2 gap-3 text-sm">
-                    <div>
-                      <p className="text-xs text-muted-foreground">Manufacturer</p>
-                      <p>{printer.manufacturer || '—'}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground">Model</p>
-                      <p>{printer.model || '—'}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground">Location</p>
-                      <p>{printer.location || '—'}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground">Assignment</p>
-                      {currentJob ? (
-                        <Link to={`/jobs/${currentJob.id}`} className="text-primary no-underline hover:underline">{currentJob.job_number}</Link>
-                      ) : (
-                        <p>Unassigned</p>
-                      )}
-                    </div>
-                  </div>
-                  <div className="mt-3 rounded-lg border border-border bg-background/40 p-3 text-sm">
-                    <p className="text-xs text-muted-foreground">Current job</p>
-                    {currentJob ? (
-                      <>
-                        <p className="font-medium">{currentJob.product_name}</p>
-                        <p className="mt-1 text-xs text-muted-foreground">{currentJob.total_pieces} pcs · {currentJob.date}</p>
-                      </>
-                    ) : (
-                      <p className="text-muted-foreground">No active job assigned.</p>
-                    )}
-                  </div>
-                  {printer.monitor_enabled ? (
-                    <div className="mt-3 rounded-lg border border-border bg-background/40 p-3 text-sm">
-                      <p className="text-xs text-muted-foreground">Live telemetry</p>
-                      <p className="font-medium">{printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'} {printer.current_print_name ? `· ${printer.current_print_name}` : ''}</p>
-                      <p className="mt-1 text-xs text-muted-foreground">Layer {formatLayer(printer.monitor_current_layer, printer.monitor_total_layers)} · Remaining {formatDuration(printer.monitor_remaining_seconds)}</p>
-                    </div>
-                  ) : null}
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    <Link to={`/printers/${printer.id}`} className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm no-underline hover:bg-accent">
-                      <Eye className="h-4 w-4" /> View
-                    </Link>
-                    {currentJob ? (
-                      <Link to={`/jobs/${currentJob.id}`} className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm no-underline hover:bg-accent">
-                        <ArrowRight className="h-4 w-4" /> Job
-                      </Link>
-                    ) : null}
-                    <Link to={`/printers/${printer.id}/edit`} className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm no-underline hover:bg-accent">
-                      <Edit className="h-4 w-4" /> Edit
-                    </Link>
-                    <button onClick={() => toggleActive(printer)} className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm hover:bg-accent">
-                      {printer.is_active ? <Archive className="h-4 w-4" /> : <ArchiveRestore className="h-4 w-4" />}
-                      {printer.is_active ? 'Deactivate' : 'Restore'}
-                    </button>
-                  </div>
+                  <span className="rounded-full bg-background/80 px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                    {group.printers.length}
+                  </span>
                 </div>
-              );
-            })}
-          </div>
 
-          {totalPages > 1 && (
-            <div className="mt-4 flex items-center justify-between">
-              <p className="text-sm text-muted-foreground">Showing {page * limit + 1}–{Math.min((page + 1) * limit, total)} of {total}</p>
-              <div className="flex gap-2">
-                <button disabled={page === 0} onClick={() => setPage((current) => current - 1)} className="cursor-pointer rounded-md border border-border px-3 py-1 text-sm hover:bg-accent disabled:opacity-50">Prev</button>
-                <span className="px-3 py-1 text-sm">{page + 1} / {totalPages}</span>
-                <button disabled={page >= totalPages - 1} onClick={() => setPage((current) => current + 1)} className="cursor-pointer rounded-md border border-border px-3 py-1 text-sm hover:bg-accent disabled:opacity-50">Next</button>
-              </div>
-            </div>
-          )}
-        </>
+                {group.printers.length ? (
+                  <div className="space-y-3">
+                    {group.printers.map((printer) => (
+                      <PrinterWallCard
+                        key={printer.id}
+                        printer={printer}
+                        currentJob={currentJobsByPrinter.get(printer.id)}
+                        onToggleActive={toggleActive}
+                        wallMode={wallMode}
+                        reducedMotion={reducedMotion}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="rounded-[1.4rem] border border-dashed border-border bg-background/60 px-4 py-12 text-center text-sm text-muted-foreground">
+                    {group.emptyText}
+                  </div>
+                )}
+              </section>
+            );
+          })}
+        </div>
       )}
+
+      {totalPages > 1 && !wallMode ? (
+        <div className="flex items-center justify-between text-sm">
+          <p className="text-muted-foreground">
+            Showing {page * limit + 1}–{Math.min((page + 1) * limit, total)} of {total}
+          </p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setPage((current) => Math.max(0, current - 1))}
+              disabled={page === 0}
+              className="rounded-full border border-border px-4 py-2 disabled:opacity-50"
+            >
+              Previous
+            </button>
+            <button
+              onClick={() => setPage((current) => (current + 1 < totalPages ? current + 1 : current))}
+              disabled={page + 1 >= totalPages}
+              className="rounded-full border border-border px-4 py-2 disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Plus, X, Archive, ArchiveRestore, RotateCcw } from 'lucide-react';
+import { ArrowLeft, Pencil, Plus, X, Archive, ArchiveRestore, RotateCcw } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
@@ -135,7 +135,7 @@ export default function ProductDetailPage() {
 
   return (
     <div className="max-w-4xl mx-auto">
-      <Link to="/products" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-4">
+      <Link to="/product-studio" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-4">
         <ArrowLeft className="w-4 h-4" /> Back to Products
       </Link>
 
@@ -152,6 +152,13 @@ export default function ProductDetailPage() {
             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${currentProduct.is_active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400'}`}>
               {currentProduct.is_active ? 'Active' : 'Archived'}
             </span>
+            <Link
+              to={`/product-studio/products/${currentProduct.id}/edit`}
+              className="inline-flex items-center gap-2 px-3 py-2 border border-border rounded-md hover:bg-accent no-underline text-foreground"
+            >
+              <Pencil className="w-4 h-4" />
+              Open Editor
+            </Link>
             <button
               onClick={toggleActive}
               disabled={saving}

--- a/frontend/src/pages/ProductEditorPage.tsx
+++ b/frontend/src/pages/ProductEditorPage.tsx
@@ -1,0 +1,457 @@
+import { useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  BadgeDollarSign,
+  Boxes,
+  Package,
+  ReceiptText,
+  Save,
+  ScanBarcode,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import EmptyState from '@/components/ui/EmptyState';
+import { SkeletonTable } from '@/components/ui/Skeleton';
+import { cn, formatCurrency } from '@/lib/utils';
+import type { InventoryTransaction, Material, PaginatedTransactions, Product } from '@/types';
+
+const emptyForm = {
+  name: '',
+  description: '',
+  material_id: '',
+  upc: '',
+  unit_price: 0,
+  reorder_point: 5,
+};
+
+function readinessTone(value: 'ready' | 'warning' | 'draft') {
+  if (value === 'ready') return 'bg-emerald-50 text-emerald-900 border-emerald-300/60';
+  if (value === 'warning') return 'bg-amber-50 text-amber-900 border-amber-300/60';
+  return 'bg-slate-100 text-slate-800 border-slate-300/60';
+}
+
+export default function ProductEditorPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const isCreate = !id;
+  const [saving, setSaving] = useState(false);
+  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+  const [form, setForm] = useState(emptyForm);
+  const [initialized, setInitialized] = useState(false);
+
+  const { data: materials = [], isLoading: materialsLoading } = useQuery<Material[]>({
+    queryKey: ['materials', 'active'],
+    queryFn: () => api.get('/materials?active=true').then((r) => r.data),
+  });
+
+  const { data: product, isLoading: productLoading } = useQuery<Product>({
+    queryKey: ['product', id],
+    enabled: Boolean(id),
+    queryFn: () => api.get(`/products/${id}`).then((r) => r.data),
+  });
+
+  const { data: transactionsData, isLoading: transactionsLoading } = useQuery<PaginatedTransactions>({
+    queryKey: ['transactions', id, 'editor'],
+    enabled: Boolean(id),
+    queryFn: () =>
+      api.get('/inventory/transactions', { params: { product_id: id, limit: 6 } }).then((r) => r.data),
+  });
+
+  if (product && !initialized) {
+    setForm({
+      name: product.name,
+      description: product.description || '',
+      material_id: product.material_id,
+      upc: product.upc || '',
+      unit_price: Number(product.unit_price),
+      reorder_point: product.reorder_point,
+    });
+    setInitialized(true);
+  }
+
+  const selectedMaterial = materials.find((material) => material.id === form.material_id) || null;
+  const unitCost = product?.unit_cost ?? 0;
+  const stockQty = product?.stock_qty ?? 0;
+  const marginDollars = Number(form.unit_price || 0) - Number(unitCost || 0);
+  const marginPct = Number(form.unit_price || 0) > 0 ? (marginDollars / Number(form.unit_price || 1)) * 100 : 0;
+  const inventoryValue = stockQty * Number(unitCost || 0);
+  const recentTransactions = transactionsData?.items || [];
+
+  const identityReadiness = useMemo(() => {
+    if (form.name.trim() && form.material_id && Number(form.unit_price) > 0) return 'ready';
+    if (form.name.trim() || form.material_id || Number(form.unit_price) > 0) return 'warning';
+    return 'draft';
+  }, [form.material_id, form.name, form.unit_price]);
+
+  const barcodeReadiness = form.upc.trim() ? 'ready' : 'warning';
+  const stockReadiness =
+    isCreate || stockQty > form.reorder_point ? 'ready' : stockQty > 0 ? 'warning' : 'draft';
+
+  const validate = () => {
+    const nextErrors: Record<string, string> = {};
+    if (!form.name.trim()) nextErrors.name = 'Name is required';
+    if (!form.material_id) nextErrors.material_id = 'Select a material';
+    if (Number(form.unit_price) < 0) nextErrors.unit_price = 'Price cannot be negative';
+    if (Number(form.reorder_point) < 0) nextErrors.reorder_point = 'Reorder point cannot be negative';
+    setFormErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const save = async () => {
+    if (!validate()) return;
+
+    setSaving(true);
+    try {
+      const payload = {
+        ...form,
+        description: form.description.trim() || null,
+        upc: form.upc.trim() || null,
+        unit_price: Number(form.unit_price) || 0,
+        reorder_point: Number(form.reorder_point) || 0,
+      };
+
+      if (isCreate) {
+        const response = await api.post<Product>('/products', payload);
+        toast.success('Product created');
+        queryClient.invalidateQueries({ queryKey: ['products'] });
+        navigate(`/product-studio/products/${response.data.id}/edit`);
+      } else {
+        await api.put(`/products/${id}`, payload);
+        toast.success('Product updated');
+        queryClient.invalidateQueries({ queryKey: ['products'] });
+        queryClient.invalidateQueries({ queryKey: ['product', id] });
+      }
+    } catch (err: any) {
+      toast.error(err.response?.data?.detail || 'Failed to save product');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if ((productLoading && !isCreate) || materialsLoading) {
+    return <SkeletonTable rows={6} cols={5} />;
+  }
+
+  if (!isCreate && !product) {
+    return <p className="py-16 text-center text-muted-foreground">Product not found</p>;
+  }
+
+  const inputClass = (field: string) =>
+    `w-full rounded-2xl border px-4 py-3 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring ${
+      formErrors[field] ? 'border-destructive' : 'border-input'
+    }`;
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-[2rem] border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.12),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(24,24,27,0.96)_100%)] p-6 text-white shadow-sm">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-sm uppercase tracking-[0.3em] text-white/65">Product Studio</p>
+            <h1 className="mt-3 flex items-center gap-3 text-3xl font-bold">
+              <Package className="h-8 w-8" />
+              {isCreate ? 'New product editor' : 'Product editor'}
+            </h1>
+            <p className="mt-3 text-sm text-white/80">
+              Build a sellable product with identity, pricing, material, stock policy, and readiness context visible in one workflow instead of a cramped modal.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <Link
+              to="/product-studio"
+              className="inline-flex min-h-12 items-center gap-2 rounded-2xl border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white no-underline transition-colors hover:bg-white/15"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back to catalog
+            </Link>
+            {!isCreate ? (
+              <Link
+                to={`/product-studio/products/${id}`}
+                className="inline-flex min-h-12 items-center gap-2 rounded-2xl border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white no-underline transition-colors hover:bg-white/15"
+              >
+                View record
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.95fr)]">
+        <section className="space-y-6">
+          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="flex items-center gap-2">
+              <ReceiptText className="h-5 w-5 text-muted-foreground" />
+              <h2 className="text-xl font-semibold">Identity and sellable details</h2>
+            </div>
+
+            <div className="mt-5 grid gap-4 lg:grid-cols-2">
+              <div className="lg:col-span-2">
+                <label className="mb-2 block text-sm font-medium">Product name</label>
+                <input
+                  value={form.name}
+                  onChange={(event) => {
+                    setForm((current) => ({ ...current, name: event.target.value }));
+                    setFormErrors((current) => ({ ...current, name: '' }));
+                  }}
+                  className={inputClass('name')}
+                  placeholder="Desk Dragon, Tool Holder, Display Plaque..."
+                />
+                {formErrors.name ? <p className="mt-1 text-xs text-destructive">{formErrors.name}</p> : null}
+              </div>
+
+              <div className="lg:col-span-2">
+                <label className="mb-2 block text-sm font-medium">Description</label>
+                <textarea
+                  value={form.description}
+                  onChange={(event) => setForm((current) => ({ ...current, description: event.target.value }))}
+                  rows={4}
+                  className={inputClass('description')}
+                  placeholder="Short operator-facing or storefront-facing summary."
+                />
+              </div>
+
+              <div>
+                <label className="mb-2 block text-sm font-medium">SKU</label>
+                <div className="rounded-2xl border border-border bg-background px-4 py-3 text-sm">
+                  {product?.sku || 'Generated after first save'}
+                </div>
+              </div>
+
+              <div>
+                <label className="mb-2 block text-sm font-medium">UPC / barcode</label>
+                <div className="relative">
+                  <ScanBarcode className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <input
+                    value={form.upc}
+                    onChange={(event) => setForm((current) => ({ ...current, upc: event.target.value }))}
+                    className={`${inputClass('upc')} pl-10`}
+                    placeholder="012345678901"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="mb-2 block text-sm font-medium">Material</label>
+                <select
+                  value={form.material_id}
+                  onChange={(event) => {
+                    setForm((current) => ({ ...current, material_id: event.target.value }));
+                    setFormErrors((current) => ({ ...current, material_id: '' }));
+                  }}
+                  className={inputClass('material_id')}
+                >
+                  <option value="">Select material...</option>
+                  {materials.map((material) => (
+                    <option key={material.id} value={material.id}>
+                      {material.name} ({material.brand})
+                    </option>
+                  ))}
+                </select>
+                {formErrors.material_id ? <p className="mt-1 text-xs text-destructive">{formErrors.material_id}</p> : null}
+              </div>
+
+              <div>
+                <label className="mb-2 block text-sm font-medium">Unit price</label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={form.unit_price}
+                  onChange={(event) => setForm((current) => ({ ...current, unit_price: Number(event.target.value) }))}
+                  className={inputClass('unit_price')}
+                />
+                {formErrors.unit_price ? <p className="mt-1 text-xs text-destructive">{formErrors.unit_price}</p> : null}
+              </div>
+
+              <div>
+                <label className="mb-2 block text-sm font-medium">Reorder point</label>
+                <input
+                  type="number"
+                  min="0"
+                  value={form.reorder_point}
+                  onChange={(event) => setForm((current) => ({ ...current, reorder_point: Number(event.target.value) }))}
+                  className={inputClass('reorder_point')}
+                />
+                {formErrors.reorder_point ? <p className="mt-1 text-xs text-destructive">{formErrors.reorder_point}</p> : null}
+              </div>
+            </div>
+
+            <div className="mt-6 flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={save}
+                disabled={saving}
+                className="inline-flex min-h-12 items-center gap-2 rounded-2xl bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+              >
+                <Save className="h-4 w-4" />
+                {saving ? 'Saving...' : isCreate ? 'Create product' : 'Save changes'}
+              </button>
+              {!isCreate ? (
+                <Link
+                  to={`/product-studio/products/${id}`}
+                  className="inline-flex min-h-12 items-center gap-2 rounded-2xl border border-border px-5 py-3 font-semibold text-foreground no-underline transition-colors hover:bg-accent"
+                >
+                  Open detail record
+                </Link>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="flex items-center gap-2">
+              <Boxes className="h-5 w-5 text-muted-foreground" />
+              <h2 className="text-xl font-semibold">Stock and activity context</h2>
+            </div>
+            {isCreate ? (
+              <EmptyState
+                icon="products"
+                title="Stock activity starts after creation"
+                description="Save the product first to start tracking stock movement, adjustments, and production receipts."
+                className="py-10"
+              />
+            ) : transactionsLoading ? (
+              <SkeletonTable rows={3} cols={4} />
+            ) : !recentTransactions.length ? (
+              <p className="mt-4 text-sm text-muted-foreground">No stock activity recorded yet for this product.</p>
+            ) : (
+              <div className="mt-4 space-y-3">
+                {recentTransactions.map((transaction: InventoryTransaction) => (
+                  <div key={transaction.id} className="rounded-2xl border border-border bg-background/80 px-4 py-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-medium capitalize">{transaction.type}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {transaction.created_at ? new Date(transaction.created_at).toLocaleString() : '-'}
+                        </p>
+                      </div>
+                      <p
+                        className={cn(
+                          'font-semibold',
+                          transaction.quantity > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                        )}
+                      >
+                        {transaction.quantity > 0 ? '+' : ''}
+                        {transaction.quantity}
+                      </p>
+                    </div>
+                    <p className="mt-3 text-sm text-muted-foreground">{transaction.notes || 'No notes recorded'}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+
+        <aside className="space-y-4 xl:sticky xl:top-6 xl:self-start">
+          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="flex items-center gap-2">
+              <BadgeDollarSign className="h-5 w-5 text-muted-foreground" />
+              <h2 className="text-xl font-semibold">Readiness and margin</h2>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              <div className={cn('rounded-2xl border px-4 py-3', readinessTone(identityReadiness))}>
+                <p className="font-semibold">Identity</p>
+                <p className="mt-1 text-sm">
+                  {identityReadiness === 'ready'
+                    ? 'Name, material, and price are present.'
+                    : identityReadiness === 'warning'
+                      ? 'The product has partial setup but still needs key sellable fields.'
+                      : 'Start with the basic product identity and pricing fields.'}
+                </p>
+              </div>
+
+              <div className={cn('rounded-2xl border px-4 py-3', readinessTone(barcodeReadiness))}>
+                <p className="font-semibold">POS readiness</p>
+                <p className="mt-1 text-sm">
+                  {barcodeReadiness === 'ready'
+                    ? 'UPC present. This product can participate in barcode-driven POS flow.'
+                    : 'No UPC yet. Product is still sellable, but manual lookup will be required at the register.'}
+                </p>
+              </div>
+
+              <div className={cn('rounded-2xl border px-4 py-3', readinessTone(stockReadiness))}>
+                <p className="font-semibold">Stock policy</p>
+                <p className="mt-1 text-sm">
+                  {isCreate
+                    ? 'Stock starts after creation. Reorder policy will apply once transactions begin.'
+                    : stockReadiness === 'ready'
+                      ? 'Current stock is above the reorder threshold.'
+                      : stockReadiness === 'warning'
+                        ? 'Current stock is near the reorder point.'
+                        : 'Current stock is at or below zero and needs attention.'}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-5 space-y-3 rounded-3xl bg-background p-4">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Unit price</span>
+                <span>{formatCurrency(Number(form.unit_price || 0))}</span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Current unit cost</span>
+                <span>{formatCurrency(Number(unitCost || 0))}</span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Margin dollars</span>
+                <span className={cn(marginDollars >= 0 ? 'text-emerald-700' : 'text-red-600')}>
+                  {formatCurrency(marginDollars)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Margin percent</span>
+                <span className={cn(marginPct >= 0 ? 'text-emerald-700' : 'text-red-600')}>
+                  {Number.isFinite(marginPct) ? `${marginPct.toFixed(1)}%` : '0.0%'}
+                </span>
+              </div>
+              <div className="flex items-center justify-between border-t border-border pt-3 text-sm">
+                <span className="text-muted-foreground">Inventory value</span>
+                <span>{formatCurrency(inventoryValue)}</span>
+              </div>
+            </div>
+
+            {marginDollars < 0 ? (
+              <div className="mt-4 rounded-2xl border border-destructive/35 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <p>This price is below the current unit cost.</p>
+                </div>
+              </div>
+            ) : null}
+          </section>
+
+          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <h2 className="text-xl font-semibold">Material context</h2>
+            {selectedMaterial ? (
+              <div className="mt-4 space-y-3 text-sm">
+                <div className="rounded-2xl bg-background px-4 py-3">
+                  <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Material</p>
+                  <p className="mt-2 font-semibold">{selectedMaterial.name}</p>
+                  <p className="mt-1 text-muted-foreground">{selectedMaterial.brand}</p>
+                </div>
+                <div className="rounded-2xl bg-background px-4 py-3">
+                  <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Cost per gram</p>
+                  <p className="mt-2 font-semibold">${Number(selectedMaterial.cost_per_g).toFixed(4)}</p>
+                </div>
+                <div className="rounded-2xl bg-background px-4 py-3">
+                  <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Material stock</p>
+                  <p className="mt-2 font-semibold">{selectedMaterial.spools_in_stock} spools</p>
+                  <p className="mt-1 text-muted-foreground">Reorder at {selectedMaterial.reorder_point}</p>
+                </div>
+              </div>
+            ) : (
+              <p className="mt-4 text-sm text-muted-foreground">Select a material to see cost and stock context.</p>
+            )}
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -1,216 +1,136 @@
 import { useState } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
-import { Plus, Edit, X, Eye, AlertTriangle, ArchiveRestore, Archive } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { AlertTriangle, ArrowRight, Archive, ArchiveRestore, Eye, Pencil, Plus, ScanBarcode } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
-import { formatCurrency } from '@/lib/utils';
-import { SkeletonTable } from '@/components/ui/Skeleton';
 import EmptyState from '@/components/ui/EmptyState';
-import type { Product, PaginatedProducts, Material } from '@/types';
-
-const emptyForm = {
-  name: '',
-  description: '',
-  material_id: '',
-  upc: '',
-  unit_price: 0,
-  reorder_point: 5,
-};
+import { SkeletonTable } from '@/components/ui/Skeleton';
+import { formatCurrency } from '@/lib/utils';
+import type { PaginatedProducts, Product } from '@/types';
 
 export default function ProductsPage() {
-  const queryClient = useQueryClient();
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(0);
   const limit = 25;
 
-  const { data, isLoading } = useQuery<PaginatedProducts>({
+  const { data, isLoading, refetch } = useQuery<PaginatedProducts>({
     queryKey: ['products', search, page],
     queryFn: () =>
       api.get('/products', { params: { search: search || undefined, skip: page * limit, limit } }).then((r) => r.data),
   });
 
-  const { data: materials } = useQuery<Material[]>({
-    queryKey: ['materials', 'active'],
-    queryFn: () => api.get('/materials?active=true').then((r) => r.data),
-  });
+  const products = data?.items || [];
+  const total = data?.total || 0;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const lowStockCount = products.filter((product) => product.stock_qty <= product.reorder_point).length;
+  const barcodeReadyCount = products.filter((product) => product.upc).length;
 
-  const [editing, setEditing] = useState<string | 'new' | null>(null);
-  const [form, setForm] = useState(emptyForm);
-  const [saving, setSaving] = useState(false);
-  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
-
-  const openNew = () => { setForm(emptyForm); setFormErrors({}); setEditing('new'); };
-  const openEdit = (p: Product) => {
-    setForm({
-      name: p.name,
-      description: p.description || '',
-      material_id: p.material_id,
-      upc: p.upc || '',
-      unit_price: Number(p.unit_price),
-      reorder_point: p.reorder_point,
-    });
-    setFormErrors({});
-    setEditing(p.id);
-  };
-  const close = () => setEditing(null);
-
-  const validate = () => {
-    const errs: Record<string, string> = {};
-    if (!form.name.trim()) errs.name = 'Name is required';
-    if (!form.material_id) errs.material_id = 'Select a material';
-    setFormErrors(errs);
-    return Object.keys(errs).length === 0;
-  };
-
-  const save = async () => {
-    if (!validate()) return;
-    setSaving(true);
-    try {
-      const payload = {
-        ...form,
-        description: form.description || null,
-        upc: form.upc || null,
-      };
-      if (editing === 'new') {
-        await api.post('/products', payload);
-        toast.success('Product created');
-      } else {
-        await api.put(`/products/${editing}`, payload);
-        toast.success('Product updated');
-      }
-      queryClient.invalidateQueries({ queryKey: ['products'] });
-      close();
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to save');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const toggleActive = async (p: Product) => {
-    const action = p.is_active ? 'archive' : 'restore';
+  const toggleActive = async (product: Product) => {
+    const action = product.is_active ? 'archive' : 'restore';
     const confirmed = window.confirm(
-      p.is_active
-        ? `Archive ${p.name}?\n\nThis will remove it from active use but keep historical records and inventory history.`
-        : `Restore ${p.name} to active products?`
+      product.is_active
+        ? `Archive ${product.name}?\n\nThis removes it from active selling while preserving history.`
+        : `Restore ${product.name} to active products?`
     );
 
     if (!confirmed) return;
 
     try {
-      if (p.is_active) {
-        await api.delete(`/products/${p.id}`);
-        toast.success(`${p.name} archived`);
+      if (product.is_active) {
+        await api.delete(`/products/${product.id}`);
+        toast.success(`${product.name} archived`);
       } else {
-        await api.put(`/products/${p.id}`, { is_active: true });
-        toast.success(`${p.name} restored`);
+        await api.put(`/products/${product.id}`, { is_active: true });
+        toast.success(`${product.name} restored`);
       }
-      queryClient.invalidateQueries({ queryKey: ['products'] });
-      queryClient.invalidateQueries({ queryKey: ['product', p.id] });
+      await refetch();
     } catch {
       toast.error(`Failed to ${action} product`);
     }
   };
 
-  const products = data?.items || [];
-  const total = data?.total || 0;
-  const totalPages = Math.ceil(total / limit);
-
-  const inputCls = (field: string) =>
-    `w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring ${formErrors[field] ? 'border-destructive' : 'border-input'}`;
-
   return (
-    <div>
-      <div className="flex items-center justify-between mb-8">
-        <h1 className="text-3xl font-bold">Products</h1>
-        <button onClick={openNew} className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 transition-opacity cursor-pointer">
-          <Plus className="w-4 h-4" /> Add Product
-        </button>
-      </div>
+    <div className="space-y-6">
+      <section className="rounded-[2rem] border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.12),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(24,24,27,0.96)_100%)] p-6 text-white shadow-sm">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-sm uppercase tracking-[0.3em] text-white/65">Product Studio</p>
+            <h1 className="mt-3 text-3xl font-bold">Catalog and authoring workflow</h1>
+            <p className="mt-3 text-sm text-white/80">
+              Browse the catalog, watch sellability signals, and move straight into the full-page editor when a product needs real setup work.
+            </p>
+          </div>
 
-      {/* Search */}
-      <div className="mb-4">
-        <input
-          placeholder="Search products by name or SKU..."
-          value={search}
-          onChange={(e) => { setSearch(e.target.value); setPage(0); }}
-          className="w-full max-w-md px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
-        />
-      </div>
+          <Link
+            to="/product-studio/products/new"
+            className="inline-flex min-h-12 items-center gap-2 rounded-2xl bg-primary px-5 py-3 font-semibold text-primary-foreground no-underline transition-opacity hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" />
+            New product
+          </Link>
+        </div>
 
-      {/* Modal */}
-      {editing !== null && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={(e) => e.target === e.currentTarget && close()}>
-          <div className="bg-card border border-border rounded-lg p-6 w-full max-w-md">
-            <div className="flex justify-between items-center mb-4">
-              <h3 className="text-lg font-semibold">{editing === 'new' ? 'Add Product' : 'Edit Product'}</h3>
-              <button onClick={close} className="p-1 hover:bg-accent rounded-md"><X className="w-5 h-5" /></button>
-            </div>
-            <div className="space-y-3">
-              <div>
-                <label className="block text-sm font-medium mb-1">Name *</label>
-                <input value={form.name} onChange={(e) => { setForm({ ...form, name: e.target.value }); setFormErrors({ ...formErrors, name: '' }); }} className={inputCls('name')} />
-                {formErrors.name && <p className="text-destructive text-xs mt-1">{formErrors.name}</p>}
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Description</label>
-                <input value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Material *</label>
-                <select
-                  value={form.material_id}
-                  onChange={(e) => { setForm({ ...form, material_id: e.target.value }); setFormErrors({ ...formErrors, material_id: '' }); }}
-                  className={inputCls('material_id')}
-                >
-                  <option value="">Select material...</option>
-                  {materials?.map((m) => (
-                    <option key={m.id} value={m.id}>{m.name} ({m.brand})</option>
-                  ))}
-                </select>
-                {formErrors.material_id && <p className="text-destructive text-xs mt-1">{formErrors.material_id}</p>}
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-sm font-medium mb-1">Unit Price ($)</label>
-                  <input type="number" step="0.01" min="0" value={form.unit_price} onChange={(e) => setForm({ ...form, unit_price: Number(e.target.value) })} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-1">Reorder Point</label>
-                  <input type="number" min="0" value={form.reorder_point} onChange={(e) => setForm({ ...form, reorder_point: Number(e.target.value) })} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
-                </div>
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">UPC/EAN (optional)</label>
-                <input value={form.upc} onChange={(e) => setForm({ ...form, upc: e.target.value })} placeholder="012345678901" className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
-              </div>
-            </div>
-            <div className="flex gap-3 mt-6">
-              <button onClick={save} disabled={saving} className="flex-1 bg-primary text-primary-foreground py-2 rounded-md font-medium hover:opacity-90 disabled:opacity-50 cursor-pointer">{saving ? 'Saving...' : 'Save'}</button>
-              <button onClick={close} className="px-4 py-2 border border-border rounded-md hover:bg-accent cursor-pointer">Cancel</button>
-            </div>
+        <div className="mt-6 grid gap-3 lg:grid-cols-4">
+          <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.24em] text-white/55">Visible products</p>
+            <p className="mt-3 text-2xl font-semibold">{total}</p>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.24em] text-white/55">Low stock</p>
+            <p className="mt-3 text-2xl font-semibold">{lowStockCount}</p>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.24em] text-white/55">Barcode ready</p>
+            <p className="mt-3 text-2xl font-semibold">{barcodeReadyCount}</p>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.24em] text-white/55">Authoring route</p>
+            <p className="mt-3 text-lg font-semibold">/product-studio/products/new</p>
           </div>
         </div>
-      )}
+      </section>
+
+      <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">Catalog</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Search products and jump to either the full-page editor or the existing detail record.
+            </p>
+          </div>
+          <input
+            placeholder="Search products by name or SKU..."
+            value={search}
+            onChange={(event) => {
+              setSearch(event.target.value);
+              setPage(0);
+            }}
+            className="w-full rounded-2xl border border-input bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring lg:max-w-sm"
+          />
+        </div>
+      </section>
 
       {isLoading ? (
         <SkeletonTable rows={5} cols={8} />
       ) : !products.length ? (
         <EmptyState
-          icon="default"
+          icon="products"
           title="No products yet"
-          description="Add your first product to start tracking inventory."
+          description="Start the catalog in the new full-page product editor."
           action={
-            <button onClick={openNew} className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 cursor-pointer">
-              <Plus className="w-4 h-4" /> Add Product
-            </button>
+            <Link
+              to="/product-studio/products/new"
+              className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground no-underline hover:opacity-90"
+            >
+              <Plus className="h-4 w-4" />
+              New product
+            </Link>
           }
         />
       ) : (
         <>
-          {/* Desktop table */}
-          <div className="hidden md:block overflow-x-auto bg-card border border-border rounded-lg">
+          <div className="hidden overflow-x-auto rounded-3xl border border-border bg-card shadow-sm md:block">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-border text-left text-muted-foreground">
@@ -219,93 +139,151 @@ export default function ProductsPage() {
                   <th className="px-4 py-3 font-medium text-right">Price</th>
                   <th className="px-4 py-3 font-medium text-right">Cost</th>
                   <th className="px-4 py-3 font-medium text-right">Stock</th>
-                  <th className="px-4 py-3 font-medium">Status</th>
+                  <th className="px-4 py-3 font-medium">Readiness</th>
                   <th className="px-4 py-3 font-medium">Actions</th>
                 </tr>
               </thead>
               <tbody>
-                {products.map((p) => (
-                  <tr key={p.id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                    <td className="px-4 py-3 font-mono text-xs">{p.sku}</td>
-                    <td className="px-4 py-3">
-                      <div className="font-medium">{p.name}</div>
-                      {!p.is_active && <div className="text-xs text-muted-foreground mt-0.5">Archived product</div>}
-                    </td>
-                    <td className="px-4 py-3 text-right">{formatCurrency(p.unit_price)}</td>
-                    <td className="px-4 py-3 text-right">{formatCurrency(p.unit_cost)}</td>
-                    <td className="px-4 py-3 text-right">
-                      <span className={`inline-flex items-center gap-1 ${p.stock_qty <= p.reorder_point ? 'text-amber-600 dark:text-amber-400' : ''}`}>
-                        {p.stock_qty <= p.reorder_point && <AlertTriangle className="w-3 h-3" />}
-                        {p.stock_qty}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${p.is_active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400'}`}>
-                        {p.is_active ? 'Active' : 'Archived'}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex gap-1">
-                        <Link to={`/products/${p.id}`} className="p-1.5 hover:bg-accent rounded-md text-muted-foreground" title="View">
-                          <Eye className="w-4 h-4" />
-                        </Link>
-                        <button onClick={() => openEdit(p)} className="p-1.5 hover:bg-accent rounded-md text-muted-foreground cursor-pointer" title="Edit">
-                          <Edit className="w-4 h-4" />
-                        </button>
-                        <button
-                          onClick={() => toggleActive(p)}
-                          className="p-1.5 hover:bg-accent rounded-md text-muted-foreground cursor-pointer"
-                          title={p.is_active ? 'Archive product' : 'Restore product'}
-                        >
-                          {p.is_active ? <Archive className="w-4 h-4" /> : <ArchiveRestore className="w-4 h-4" />}
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
+                {products.map((product) => {
+                  const lowStock = product.stock_qty <= product.reorder_point;
+                  return (
+                    <tr key={product.id} className="border-b border-border last:border-0 hover:bg-accent/50">
+                      <td className="px-4 py-3 font-mono text-xs">{product.sku}</td>
+                      <td className="px-4 py-3">
+                        <div className="font-medium">{product.name}</div>
+                        <div className="mt-0.5 text-xs text-muted-foreground">
+                          {product.upc ? `UPC ${product.upc}` : 'No UPC yet'}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-right">{formatCurrency(product.unit_price)}</td>
+                      <td className="px-4 py-3 text-right">{formatCurrency(product.unit_cost)}</td>
+                      <td className="px-4 py-3 text-right">
+                        <span className={lowStock ? 'text-amber-600 dark:text-amber-400' : ''}>
+                          {lowStock ? <AlertTriangle className="mr-1 inline h-3 w-3" /> : null}
+                          {product.stock_qty}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex flex-wrap gap-2">
+                          <span className="inline-flex items-center rounded-full bg-accent px-2.5 py-0.5 text-xs font-medium text-accent-foreground">
+                            {product.is_active ? 'Active' : 'Archived'}
+                          </span>
+                          <span className="inline-flex items-center rounded-full bg-accent px-2.5 py-0.5 text-xs font-medium text-accent-foreground">
+                            {product.upc ? (
+                              <>
+                                <ScanBarcode className="mr-1 h-3 w-3" />
+                                POS ready
+                              </>
+                            ) : (
+                              'Manual lookup'
+                            )}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex gap-1">
+                          <Link
+                            to={`/product-studio/products/${product.id}/edit`}
+                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent"
+                            title="Edit in Product Studio"
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Link>
+                          <Link
+                            to={`/product-studio/products/${product.id}`}
+                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent"
+                            title="View detail"
+                          >
+                            <Eye className="h-4 w-4" />
+                          </Link>
+                          <button
+                            type="button"
+                            onClick={() => toggleActive(product)}
+                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent"
+                            title={product.is_active ? 'Archive product' : 'Restore product'}
+                          >
+                            {product.is_active ? <Archive className="h-4 w-4" /> : <ArchiveRestore className="h-4 w-4" />}
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
 
-          {/* Mobile cards */}
-          <div className="md:hidden space-y-3">
-            {products.map((p) => (
-              <Link key={p.id} to={`/products/${p.id}`} className="block bg-card border border-border rounded-lg p-4">
-                <div className="flex items-start justify-between mb-2">
+          <div className="space-y-3 md:hidden">
+            {products.map((product) => (
+              <div key={product.id} className="rounded-3xl border border-border bg-card p-4 shadow-sm">
+                <div className="flex items-start justify-between gap-3">
                   <div>
-                    <p className="font-semibold">{p.name}</p>
-                    <p className="text-xs text-muted-foreground font-mono">{p.sku}</p>
-                    {!p.is_active && <p className="text-xs text-muted-foreground mt-1">Archived product</p>}
+                    <p className="font-semibold">{product.name}</p>
+                    <p className="font-mono text-xs text-muted-foreground">{product.sku}</p>
                   </div>
-                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${p.is_active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400'}`}>
-                    {p.is_active ? 'Active' : 'Archived'}
+                  <span className="rounded-full bg-accent px-2.5 py-0.5 text-xs font-medium text-accent-foreground">
+                    {product.is_active ? 'Active' : 'Archived'}
                   </span>
                 </div>
-                <div className="grid grid-cols-3 gap-2 text-sm">
-                  <div><p className="text-xs text-muted-foreground">Price</p><p>{formatCurrency(p.unit_price)}</p></div>
-                  <div><p className="text-xs text-muted-foreground">Cost</p><p>{formatCurrency(p.unit_cost)}</p></div>
+                <div className="mt-4 grid grid-cols-3 gap-2 text-sm">
+                  <div>
+                    <p className="text-xs text-muted-foreground">Price</p>
+                    <p>{formatCurrency(product.unit_price)}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground">Cost</p>
+                    <p>{formatCurrency(product.unit_cost)}</p>
+                  </div>
                   <div>
                     <p className="text-xs text-muted-foreground">Stock</p>
-                    <p className={p.stock_qty <= p.reorder_point ? 'text-amber-600 dark:text-amber-400' : ''}>
-                      {p.stock_qty <= p.reorder_point && '⚠ '}{p.stock_qty}
+                    <p className={product.stock_qty <= product.reorder_point ? 'text-amber-600 dark:text-amber-400' : ''}>
+                      {product.stock_qty}
                     </p>
                   </div>
                 </div>
-              </Link>
+                <div className="mt-4 flex gap-2">
+                  <Link
+                    to={`/product-studio/products/${product.id}/edit`}
+                    className="inline-flex flex-1 items-center justify-center gap-2 rounded-2xl bg-primary px-4 py-3 font-semibold text-primary-foreground no-underline"
+                  >
+                    <Pencil className="h-4 w-4" />
+                    Edit
+                  </Link>
+                  <Link
+                    to={`/product-studio/products/${product.id}`}
+                    className="inline-flex items-center justify-center rounded-2xl border border-border px-4 py-3 text-foreground no-underline"
+                  >
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                </div>
+              </div>
             ))}
           </div>
 
-          {/* Pagination */}
-          {totalPages > 1 && (
-            <div className="flex items-center justify-between mt-4">
-              <p className="text-sm text-muted-foreground">{total} products</p>
+          {totalPages > 1 ? (
+            <div className="flex items-center justify-between text-sm">
+              <p className="text-muted-foreground">{total} products</p>
               <div className="flex gap-2">
-                <button disabled={page === 0} onClick={() => setPage(page - 1)} className="px-3 py-1 border border-border rounded-md text-sm hover:bg-accent disabled:opacity-50 cursor-pointer">Prev</button>
-                <span className="px-3 py-1 text-sm">{page + 1} / {totalPages}</span>
-                <button disabled={page >= totalPages - 1} onClick={() => setPage(page + 1)} className="px-3 py-1 border border-border rounded-md text-sm hover:bg-accent disabled:opacity-50 cursor-pointer">Next</button>
+                <button
+                  disabled={page === 0}
+                  onClick={() => setPage(page - 1)}
+                  className="rounded-md border border-border px-3 py-1 transition-colors hover:bg-accent disabled:opacity-50"
+                >
+                  Prev
+                </button>
+                <span className="px-3 py-1">
+                  {page + 1} / {totalPages}
+                </span>
+                <button
+                  disabled={page >= totalPages - 1}
+                  onClick={() => setPage(page + 1)}
+                  className="rounded-md border border-border px-3 py-1 transition-colors hover:bg-accent disabled:opacity-50"
+                >
+                  Next
+                </button>
               </div>
             </div>
-          )}
+          ) : null}
         </>
       )}
     </div>

--- a/frontend/src/pages/SalesPage.tsx
+++ b/frontend/src/pages/SalesPage.tsx
@@ -58,11 +58,27 @@ export default function SalesPage() {
   ) as string[];
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-8">
-        <h1 className="text-3xl font-bold">Sales</h1>
+    <div className="space-y-6">
+      <section className="rounded-[2rem] border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.14),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(22,44,64,0.96)_100%)] p-6 text-white shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-sm uppercase tracking-[0.3em] text-white/65">Sell Workspace</p>
+            <h1 className="mt-3 text-3xl font-bold">Sales inbox</h1>
+            <p className="mt-3 text-sm text-white/80">
+              Review recent sales, refunds, and follow-up work without dropping back into the general dashboard.
+            </p>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-white/8 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.22em] text-white/60">Visible sales</p>
+            <p className="mt-2 text-2xl font-semibold">{total}</p>
+            <p className="mt-1 text-sm text-white/65">Filtered transactions in the current inbox view</p>
+          </div>
+        </div>
+      </section>
+
+      <div className="flex items-center justify-between">
         <Link
-          to="/sales/new"
+          to="/sell/sales/new"
           className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 transition-opacity no-underline"
         >
           <Plus className="w-4 h-4" /> New Sale
@@ -136,7 +152,7 @@ export default function SalesPage() {
           description="Record your first sale to start tracking revenue."
           action={
             <Link
-              to="/sales/new"
+              to="/sell/sales/new"
               className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 no-underline"
             >
               <Plus className="w-4 h-4" /> New Sale
@@ -183,7 +199,7 @@ export default function SalesPage() {
                       </span>
                     </td>
                     <td className="px-4 py-3">
-                      <Link to={`/sales/${s.id}`} className="p-1.5 hover:bg-accent rounded-md text-muted-foreground inline-block" title="View">
+                      <Link to={`/sell/sales/${s.id}`} className="p-1.5 hover:bg-accent rounded-md text-muted-foreground inline-block" title="View">
                         <Eye className="w-4 h-4" />
                       </Link>
                     </td>
@@ -196,7 +212,7 @@ export default function SalesPage() {
           {/* Mobile cards */}
           <div className="md:hidden space-y-3">
             {sales.map((s) => (
-              <Link key={s.id} to={`/sales/${s.id}`} className="block bg-card border border-border rounded-lg p-4 no-underline">
+              <Link key={s.id} to={`/sell/sales/${s.id}`} className="block bg-card border border-border rounded-lg p-4 no-underline">
                 <div className="flex items-start justify-between mb-2">
                   <div>
                     <p className="font-semibold">{s.sale_number}</p>


### PR DESCRIPTION
## Summary

- Replace flat navigation with 8 workspace-oriented shells: Control Center, Print Floor, Sell, Stock, Product Studio, Orders, Insights, Admin
- Add role-based navigation filtering (`admin`, `floor`, `cashier`, `inventory`, `catalog`, `analyst`, `general`)
- Implement operations-first dark palette with Rubik/Nunito Sans typography
- Redesign POS register with split-pane cashier layout, larger touch targets, scanner lane
- Redesign inventory page as exceptions-first with triage cards above ledger
- Redesign printer wall with status grouping, telemetry cards, wall mode
- Add full-page Product Editor replacing modal CRUD
- Add Control Center with role-specific dashboard modules and priority stats
- Add Orders page unifying production jobs, fulfillment sales, and assignment pressure
- Add workspace local nav component and centralized workspace definitions
- Update README tech stack (React 19, Tailwind 4, Zustand)

## Validation

- `npm run build` passes (437ms, all chunks split correctly)
- `npm test` passes (5/5 POS tests)
- All acceptance criteria from #140 Phase 1 and Phase 2 met

## Linked Issue

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)