### PR TITLE
feat: add live camera feeds with go2rtc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ All endpoints are under `/api/v1`. Rate limited at 120 requests/minute per IP.
 | **Customers** | Full CRUD at `/customers` | `?search` (name/email), pagination |
 | **Jobs** | Full CRUD at `/jobs`, `POST /jobs/calculate` | `?status`, `?material_id`, `?customer_id`, `?date_from`, `?date_to`, `?search`, `?sort_by`, `?sort_dir`, pagination |
 | **Products** | Full CRUD at `/products` | `?is_active`, `?material_id`, `?low_stock`, `?search`, pagination |
+| **Cameras** | Full CRUD at `/cameras`, `POST /cameras/{id}/assign`, `GET /cameras/{id}/snapshot` | `?is_active`, `?assigned`, `?search`, pagination |
 | **Inventory** | `GET/POST /inventory/transactions`, `GET /inventory/alerts` | `?product_id`, `?type`, pagination |
 | **Sales Channels** | Full CRUD at `/sales/channels` | `?is_active` |
 | **Sales** | Full CRUD at `/sales`, `GET /sales/metrics`, `POST /sales/{id}/refund`, `POST /pos/checkout`, `POST /pos/scan/resolve` | `?status`, `?channel_id`, `?payment_method`, `?customer_id`, `?date_from`, `?date_to`, `?search`, pagination |
@@ -97,7 +98,7 @@ All endpoints are under `/api/v1`. Rate limited at 120 requests/minute per IP.
 
 ## Database
 
-Eleven tables (6 seeded from the original spreadsheet + 2 for inventory + 3 for sales):
+Twelve tables (6 seeded from the original spreadsheet + 2 for inventory + 3 for sales + 1 for cameras):
 
 - **settings** — Business configuration (currency, margins, fees, electricity rates)
 - **materials** — Filament inventory (PLA, PETG, TPU, ABS, PLA+) with cost-per-gram, spool stock tracking
@@ -110,6 +111,7 @@ Eleven tables (6 seeded from the original spreadsheet + 2 for inventory + 3 for 
 - **sales_channels** — Sales platforms (Etsy, Amazon, Direct) with platform fee % and fixed fee per order
 - **sales** — Order tracking with auto-generated sale number (S-YYYY-NNNN), status flow, computed totals and contribution margin
 - **sale_items** — Line items per sale linking to products/jobs with quantity, pricing, and cost
+- **cameras** — Camera devices (Wyze/go2rtc) with stream config, optional 1:1 printer assignment, snapshot proxy
 
 ## Cost Calculation Engine
 
@@ -148,6 +150,7 @@ Net Profit          = not yet exposed for sales reporting until overhead allocat
 ### Pages
 
 - **Control Center** — Role-aware landing workspace with urgent printer, stock, sales, finance, and draft-job priorities plus quick actions into the main operational areas
+- **Live Camera Feeds** — go2rtc-powered live video on printer wall cards and detail pages, MSE/WebSocket primary with MJPEG snapshot fallback, dedicated kiosk monitor page at `/print-floor/monitor/:id`
 - **Print Floor** — Dedicated printer wall with grouped machine states, queue-pressure and utilization signals, reduced-chrome wall mode via `/print-floor?mode=wall`, console-style printer detail pages for live monitoring, and a defined camera-tile integration path for issue `#129`
 - **Stock** — Exceptions-first inventory workspace at `/stock` with product-impacting low-stock triage, quick reconcile/adjust actions, material signals separated from finished-goods alerts, and the full ledger preserved as a secondary surface
 - **Orders** — Unified queue workspace at `/orders` that stitches production jobs, fulfillment-relevant sales, printer readiness, and customer load into one operational surface while preserving the existing jobs and sales detail flows
@@ -175,6 +178,7 @@ Net Profit          = not yet exposed for sales reporting until overhead allocat
 
 ## Design Briefs
 
+- [Camera Setup Guide](docs/camera-setup.md) — go2rtc configuration, Wyze camera setup, stream formats, kiosk mode, troubleshooting
 - [Role-Based Frontend Redesign User Story](docs/frontend_role_based_redesign_user_story.md) — issue-ready redesign brief for print monitoring, live views, POS, inventory, product studio, and role-based workspaces.
 
 ## Testing

--- a/backend/alembic/versions/20260412_01_add_cameras.py
+++ b/backend/alembic/versions/20260412_01_add_cameras.py
@@ -1,0 +1,44 @@
+"""add cameras table
+
+Revision ID: 20260412_01
+Revises: 20260329_03
+Create Date: 2026-04-12 16:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260412_01"
+down_revision = "20260329_03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cameras",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("slug", sa.String(length=120), nullable=False),
+        sa.Column("go2rtc_base_url", sa.String(length=500), nullable=False),
+        sa.Column("stream_name", sa.String(length=120), nullable=False),
+        sa.Column("printer_id", sa.UUID(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["printer_id"], ["printers.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("printer_id", name="uq_cameras_printer_id"),
+    )
+    op.create_index(op.f("ix_cameras_name"), "cameras", ["name"], unique=True)
+    op.create_index(op.f("ix_cameras_slug"), "cameras", ["slug"], unique=True)
+    op.create_index(op.f("ix_cameras_is_active"), "cameras", ["is_active"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_cameras_is_active"), table_name="cameras")
+    op.drop_index(op.f("ix_cameras_slug"), table_name="cameras")
+    op.drop_index(op.f("ix_cameras_name"), table_name="cameras")
+    op.drop_table("cameras")

--- a/backend/app/api/v1/endpoints/cameras.py
+++ b/backend/app/api/v1/endpoints/cameras.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import uuid
+from urllib.parse import quote
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query, Response
+from sqlalchemy import func, select
+
+from app.api.deps import DB, CurrentUser
+from app.models.camera import Camera
+from app.models.printer import Printer
+from app.schemas.camera import (
+    CameraCreate,
+    CameraResponse,
+    CameraUpdate,
+    PaginatedCameras,
+)
+
+router = APIRouter(prefix="/cameras", tags=["Cameras"])
+
+_SNAPSHOT_TIMEOUT = 5.0
+
+
+def _prepare_camera_response(camera: Camera, printer_name: str | None = None) -> Camera:
+    """Attach computed display fields onto the ORM instance."""
+    setattr(camera, "printer_name", printer_name)
+    setattr(camera, "snapshot_url", f"/api/v1/cameras/{camera.id}/snapshot")
+    base = camera.go2rtc_base_url
+    stream = quote(camera.stream_name, safe="")
+    # Replace http(s) with ws(s) for the MSE WebSocket URL
+    ws_base = base.replace("https://", "wss://").replace("http://", "ws://")
+    setattr(camera, "mse_ws_url", f"{ws_base}/api/ws?src={stream}")
+    return camera
+
+
+async def _get_camera_or_404(db: DB, camera_id: uuid.UUID) -> Camera:
+    result = await db.execute(select(Camera).where(Camera.id == camera_id))
+    camera = result.scalar_one_or_none()
+    if not camera:
+        raise HTTPException(status_code=404, detail="Camera not found")
+    return camera
+
+
+async def _get_printer_name(db: DB, printer_id: uuid.UUID | None) -> str | None:
+    if printer_id is None:
+        return None
+    result = await db.execute(select(Printer.name).where(Printer.id == printer_id))
+    return result.scalar_one_or_none()
+
+
+async def _validate_printer_assignment(
+    db: DB, printer_id: uuid.UUID, exclude_camera_id: uuid.UUID | None = None
+) -> None:
+    """Ensure the target printer exists and is not already assigned to another camera."""
+    printer = await db.execute(select(Printer.id).where(Printer.id == printer_id))
+    if printer.scalar_one_or_none() is None:
+        raise HTTPException(status_code=404, detail="Printer not found")
+
+    stmt = select(Camera.id).where(Camera.printer_id == printer_id, Camera.is_active.is_(True))
+    if exclude_camera_id:
+        stmt = stmt.where(Camera.id != exclude_camera_id)
+    existing = await db.execute(stmt)
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail="This printer already has a camera assigned")
+
+
+@router.get(
+    "",
+    response_model=PaginatedCameras,
+    summary="List cameras",
+    description="Returns paginated cameras with optional filtering.",
+)
+async def list_cameras(
+    db: DB,
+    is_active: bool | None = Query(None, description="Filter by active status"),
+    assigned: bool | None = Query(None, description="Filter by printer assignment"),
+    search: str | None = Query(None, description="Search by name, slug, or stream name"),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+):
+    base = select(Camera)
+    if is_active is not None:
+        base = base.where(Camera.is_active == is_active)
+    if assigned is True:
+        base = base.where(Camera.printer_id.isnot(None))
+    elif assigned is False:
+        base = base.where(Camera.printer_id.is_(None))
+    if search:
+        pattern = f"%{search}%"
+        base = base.where(
+            Camera.name.ilike(pattern) | Camera.slug.ilike(pattern) | Camera.stream_name.ilike(pattern)
+        )
+
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total = (await db.execute(count_stmt)).scalar() or 0
+
+    result = await db.execute(base.order_by(Camera.name).offset(skip).limit(limit))
+    items = result.scalars().all()
+
+    # Bulk-fetch printer names
+    printer_ids = [c.printer_id for c in items if c.printer_id]
+    printer_names: dict[uuid.UUID, str] = {}
+    if printer_ids:
+        rows = await db.execute(select(Printer.id, Printer.name).where(Printer.id.in_(printer_ids)))
+        printer_names = {row.id: row.name for row in rows}
+
+    for camera in items:
+        _prepare_camera_response(camera, printer_names.get(camera.printer_id))
+
+    return PaginatedCameras(items=items, total=total, skip=skip, limit=limit)
+
+
+@router.get(
+    "/{camera_id}",
+    response_model=CameraResponse,
+    summary="Get camera by ID",
+)
+async def get_camera(camera_id: uuid.UUID, db: DB):
+    camera = await _get_camera_or_404(db, camera_id)
+    printer_name = await _get_printer_name(db, camera.printer_id)
+    return _prepare_camera_response(camera, printer_name)
+
+
+@router.post(
+    "",
+    response_model=CameraResponse,
+    status_code=201,
+    summary="Create a camera",
+)
+async def create_camera(body: CameraCreate, user: CurrentUser, db: DB):
+    existing = await db.execute(
+        select(Camera.id).where((Camera.name == body.name) | (Camera.slug == body.slug))
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail="Camera name or slug already exists")
+
+    if body.printer_id:
+        await _validate_printer_assignment(db, body.printer_id)
+
+    camera = Camera(**body.model_dump())
+    db.add(camera)
+    await db.commit()
+    await db.refresh(camera)
+    printer_name = await _get_printer_name(db, camera.printer_id)
+    return _prepare_camera_response(camera, printer_name)
+
+
+@router.put(
+    "/{camera_id}",
+    response_model=CameraResponse,
+    summary="Update a camera",
+)
+async def update_camera(camera_id: uuid.UUID, body: CameraUpdate, user: CurrentUser, db: DB):
+    camera = await _get_camera_or_404(db, camera_id)
+    update_data = body.model_dump(exclude_unset=True)
+    clear_printer_id = update_data.pop("clear_printer_id", False)
+
+    if "name" in update_data or "slug" in update_data:
+        existing = await db.execute(
+            select(Camera.id).where(
+                Camera.id != camera_id,
+                (Camera.name == update_data.get("name", camera.name))
+                | (Camera.slug == update_data.get("slug", camera.slug)),
+            )
+        )
+        if existing.scalar_one_or_none():
+            raise HTTPException(status_code=409, detail="Camera name or slug already exists")
+
+    if "printer_id" in update_data and update_data["printer_id"] is not None:
+        await _validate_printer_assignment(db, update_data["printer_id"], exclude_camera_id=camera_id)
+
+    for field, value in update_data.items():
+        setattr(camera, field, value)
+
+    if clear_printer_id:
+        camera.printer_id = None
+
+    await db.commit()
+    await db.refresh(camera)
+    printer_name = await _get_printer_name(db, camera.printer_id)
+    return _prepare_camera_response(camera, printer_name)
+
+
+@router.delete(
+    "/{camera_id}",
+    status_code=204,
+    summary="Deactivate a camera",
+    description="Soft-deletes a camera by setting is_active=false and clearing printer assignment.",
+)
+async def delete_camera(camera_id: uuid.UUID, user: CurrentUser, db: DB):
+    camera = await _get_camera_or_404(db, camera_id)
+    camera.is_active = False
+    camera.printer_id = None
+    await db.commit()
+
+
+@router.post(
+    "/{camera_id}/assign",
+    response_model=CameraResponse,
+    summary="Assign or unassign a camera to a printer",
+)
+async def assign_camera(camera_id: uuid.UUID, body: dict, user: CurrentUser, db: DB):
+    camera = await _get_camera_or_404(db, camera_id)
+    printer_id = body.get("printer_id")
+
+    if printer_id is not None:
+        printer_uuid = uuid.UUID(printer_id) if isinstance(printer_id, str) else printer_id
+        await _validate_printer_assignment(db, printer_uuid, exclude_camera_id=camera_id)
+        camera.printer_id = printer_uuid
+    else:
+        camera.printer_id = None
+
+    await db.commit()
+    await db.refresh(camera)
+    printer_name = await _get_printer_name(db, camera.printer_id)
+    return _prepare_camera_response(camera, printer_name)
+
+
+@router.get(
+    "/{camera_id}/snapshot",
+    summary="Get camera snapshot",
+    description="Proxies a single MJPEG frame from go2rtc for health checking and CORS-free fallback.",
+)
+async def get_camera_snapshot(camera_id: uuid.UUID, db: DB):
+    camera = await _get_camera_or_404(db, camera_id)
+    if not camera.is_active:
+        raise HTTPException(status_code=404, detail="Camera is inactive")
+
+    stream = quote(camera.stream_name, safe="")
+    snapshot_url = f"{camera.go2rtc_base_url}/api/frame.jpeg?src={stream}"
+
+    try:
+        async with httpx.AsyncClient(timeout=_SNAPSHOT_TIMEOUT) as client:
+            resp = await client.get(snapshot_url)
+            resp.raise_for_status()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=f"Camera snapshot unavailable: {exc}") from exc
+
+    return Response(content=resp.content, media_type="image/jpeg")

--- a/backend/app/api/v1/endpoints/printers.py
+++ b/backend/app/api/v1/endpoints/printers.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, HTTPException, Query, Response
 from sqlalchemy import func, select
 
 from app.api.deps import DB, CurrentUser
+from app.models.camera import Camera
 from app.models.printer import Printer
 from app.schemas.printer import (
     PaginatedPrinters,
@@ -42,8 +43,27 @@ def _apply_thumbnail_urls(printer: Printer) -> Printer:
     return printer
 
 
-def _prepare_printer_response(printer: Printer) -> Printer:
+def _attach_camera_fields(printer: Printer, camera_map: dict | None = None) -> Printer:
+    """Attach camera display fields from a pre-built lookup or leave defaults."""
+    cam = (camera_map or {}).get(printer.id)
+    if cam:
+        setattr(printer, "camera_id", cam["id"])
+        setattr(printer, "camera_name", cam["name"])
+        setattr(printer, "camera_snapshot_url", f"/api/v1/cameras/{cam['id']}/snapshot")
+        from urllib.parse import quote
+        ws_base = cam["go2rtc_base_url"].replace("https://", "wss://").replace("http://", "ws://")
+        setattr(printer, "camera_mse_ws_url", f"{ws_base}/api/ws?src={quote(cam['stream_name'], safe='')}")
+    else:
+        setattr(printer, "camera_id", None)
+        setattr(printer, "camera_name", None)
+        setattr(printer, "camera_snapshot_url", None)
+        setattr(printer, "camera_mse_ws_url", None)
+    return printer
+
+
+def _prepare_printer_response(printer: Printer, camera_map: dict | None = None) -> Printer:
     setattr(printer, "monitor_api_key_configured", bool(getattr(printer, "monitor_api_key", None)))
+    _attach_camera_fields(printer, camera_map)
     return _apply_thumbnail_urls(printer)
 
 
@@ -88,10 +108,26 @@ async def list_printers(
 
     result = await db.execute(base.order_by(Printer.name).offset(skip).limit(limit))
     items = result.scalars().all()
+
+    # Bulk-fetch camera assignments to avoid N+1
+    printer_ids = [p.id for p in items]
+    camera_map: dict = {}
+    if printer_ids:
+        cam_rows = await db.execute(
+            select(Camera.id, Camera.name, Camera.printer_id, Camera.go2rtc_base_url, Camera.stream_name).where(
+                Camera.printer_id.in_(printer_ids), Camera.is_active.is_(True)
+            )
+        )
+        for row in cam_rows:
+            camera_map[row.printer_id] = {
+                "id": row.id, "name": row.name,
+                "go2rtc_base_url": row.go2rtc_base_url, "stream_name": row.stream_name,
+            }
+
     for printer in items:
         mark_printer_stale_if_needed(printer)
         await refresh_printer_monitoring(db, printer)
-        _prepare_printer_response(printer)
+        _prepare_printer_response(printer, camera_map)
     return PaginatedPrinters(items=items, total=total, skip=skip, limit=limit)
 
 
@@ -109,7 +145,21 @@ async def get_printer(printer_id: uuid.UUID, db: DB):
     for event in history_events:
         setattr(event, "actor_name", event.actor.full_name if getattr(event, "actor", None) else None)
     setattr(printer, "history_events", history_events)
-    return _prepare_printer_response(printer)
+
+    # Single camera lookup
+    cam_row = await db.execute(
+        select(Camera.id, Camera.name, Camera.go2rtc_base_url, Camera.stream_name).where(
+            Camera.printer_id == printer.id, Camera.is_active.is_(True)
+        )
+    )
+    cam = cam_row.one_or_none()
+    camera_map = {}
+    if cam:
+        camera_map[printer.id] = {
+            "id": cam.id, "name": cam.name,
+            "go2rtc_base_url": cam.go2rtc_base_url, "stream_name": cam.stream_name,
+        }
+    return _prepare_printer_response(printer, camera_map)
 
 
 @router.post(

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, audit, auth, customers, dashboard, inventory, invoices, jobs, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, tax
+from app.api.v1.endpoints import accounting, approvals, audit, auth, cameras, customers, dashboard, inventory, invoices, jobs, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
 api_router.include_router(accounting.router)
+api_router.include_router(cameras.router)
 api_router.include_router(approvals.router)
 api_router.include_router(audit.router)
 api_router.include_router(settings.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,1 @@
+from app.models.camera import Camera  # noqa: F401

--- a/backend/app/models/camera.py
+++ b/backend/app/models/camera.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class Camera(Base):
+    __tablename__ = "cameras"
+    __table_args__ = (UniqueConstraint("printer_id", name="uq_cameras_printer_id"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(120), unique=True, index=True)
+    slug: Mapped[str] = mapped_column(String(120), unique=True, index=True)
+    go2rtc_base_url: Mapped[str] = mapped_column(String(500))
+    stream_name: Mapped[str] = mapped_column(String(120))
+    printer_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("printers.id"), nullable=True, unique=True
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/backend/app/schemas/camera.py
+++ b/backend/app/schemas/camera.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class CameraCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    slug: str = Field(..., min_length=1, max_length=120)
+    go2rtc_base_url: str = Field(..., min_length=1, max_length=500)
+    stream_name: str = Field(..., min_length=1, max_length=120)
+    printer_id: uuid.UUID | None = None
+    is_active: bool = True
+    notes: str | None = Field(None, max_length=1000)
+
+    @field_validator("go2rtc_base_url")
+    @classmethod
+    def normalize_base_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = value.strip()
+        return value.rstrip("/") or None
+
+
+class CameraUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=120)
+    slug: str | None = Field(None, min_length=1, max_length=120)
+    go2rtc_base_url: str | None = Field(None, min_length=1, max_length=500)
+    stream_name: str | None = Field(None, min_length=1, max_length=120)
+    printer_id: uuid.UUID | None = None
+    clear_printer_id: bool = False
+    is_active: bool | None = None
+    notes: str | None = Field(None, max_length=1000)
+
+    @field_validator("go2rtc_base_url")
+    @classmethod
+    def normalize_base_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = value.strip()
+        return value.rstrip("/") or None
+
+
+class CameraResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    slug: str
+    go2rtc_base_url: str
+    stream_name: str
+    printer_id: uuid.UUID | None = None
+    printer_name: str | None = None
+    is_active: bool
+    notes: str | None = None
+    snapshot_url: str | None = None
+    mse_ws_url: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class PaginatedCameras(BaseModel):
+    items: list[CameraResponse]
+    total: int
+    skip: int
+    limit: int

--- a/backend/app/schemas/printer.py
+++ b/backend/app/schemas/printer.py
@@ -135,6 +135,10 @@ class PrinterResponse(BaseModel):
     monitor_ws_last_error: str | None = None
     monitor_last_seen_at: datetime | None = None
     monitor_last_updated_at: datetime | None = None
+    camera_id: uuid.UUID | None = None
+    camera_name: str | None = None
+    camera_snapshot_url: str | None = None
+    camera_mse_ws_url: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -24,6 +24,7 @@ from app.models.material_receipt import MaterialReceipt
 from app.models.rate import Rate
 from app.models.setting import Setting
 from app.models.user import User
+from app.models.camera import Camera  # noqa: F401
 from app.models.printer_history_event import PrinterHistoryEvent  # noqa: F401
 from app.services.accounting_service import seed_chart_of_accounts
 

--- a/backend/tests/test_api_cameras.py
+++ b/backend/tests/test_api_cameras.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+
+async def _create_printer(client: AsyncClient, auth_headers: dict, name: str, slug: str) -> dict:
+    resp = await client.post(
+        "/api/v1/printers",
+        headers=auth_headers,
+        json={"name": name, "slug": slug, "status": "idle"},
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+async def _create_camera(
+    client: AsyncClient,
+    auth_headers: dict,
+    name: str = "Wyze Cam 1",
+    slug: str = "wyze-cam-1",
+    printer_id: str | None = None,
+) -> dict:
+    payload = {
+        "name": name,
+        "slug": slug,
+        "go2rtc_base_url": "http://192.168.1.50:1984",
+        "stream_name": "wyze_printer_1",
+    }
+    if printer_id:
+        payload["printer_id"] = printer_id
+    resp = await client.post("/api/v1/cameras", headers=auth_headers, json=payload)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+@pytest.mark.asyncio
+async def test_create_camera(client: AsyncClient, auth_headers: dict):
+    data = await _create_camera(client, auth_headers)
+    assert data["name"] == "Wyze Cam 1"
+    assert data["slug"] == "wyze-cam-1"
+    assert data["go2rtc_base_url"] == "http://192.168.1.50:1984"
+    assert data["stream_name"] == "wyze_printer_1"
+    assert data["printer_id"] is None
+    assert data["is_active"] is True
+    assert data["snapshot_url"].startswith("/api/v1/cameras/")
+    assert "ws://" in data["mse_ws_url"]
+
+
+@pytest.mark.asyncio
+async def test_create_camera_rejects_duplicate_name_or_slug(client: AsyncClient, auth_headers: dict):
+    await _create_camera(client, auth_headers)
+
+    dup_name = await client.post(
+        "/api/v1/cameras",
+        headers=auth_headers,
+        json={
+            "name": "Wyze Cam 1",
+            "slug": "wyze-cam-1-other",
+            "go2rtc_base_url": "http://192.168.1.50:1984",
+            "stream_name": "other",
+        },
+    )
+    assert dup_name.status_code == 409
+
+    dup_slug = await client.post(
+        "/api/v1/cameras",
+        headers=auth_headers,
+        json={
+            "name": "Other Cam",
+            "slug": "wyze-cam-1",
+            "go2rtc_base_url": "http://192.168.1.50:1984",
+            "stream_name": "other",
+        },
+    )
+    assert dup_slug.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_create_camera_with_printer_assignment(client: AsyncClient, auth_headers: dict):
+    printer = await _create_printer(client, auth_headers, "Bambu X1C", "bambu-x1c")
+    camera = await _create_camera(client, auth_headers, printer_id=printer["id"])
+    assert camera["printer_id"] == printer["id"]
+    assert camera["printer_name"] == "Bambu X1C"
+
+
+@pytest.mark.asyncio
+async def test_create_camera_rejects_duplicate_printer_assignment(client: AsyncClient, auth_headers: dict):
+    printer = await _create_printer(client, auth_headers, "Prusa MK4", "prusa-mk4")
+    await _create_camera(client, auth_headers, printer_id=printer["id"])
+
+    dup = await client.post(
+        "/api/v1/cameras",
+        headers=auth_headers,
+        json={
+            "name": "Cam 2",
+            "slug": "cam-2",
+            "go2rtc_base_url": "http://192.168.1.50:1984",
+            "stream_name": "cam2",
+            "printer_id": printer["id"],
+        },
+    )
+    assert dup.status_code == 409
+    assert "already has a camera" in dup.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_update_camera(client: AsyncClient, auth_headers: dict):
+    camera = await _create_camera(client, auth_headers)
+    resp = await client.put(
+        f"/api/v1/cameras/{camera['id']}",
+        headers=auth_headers,
+        json={"name": "Wyze Cam Updated", "stream_name": "wyze_updated"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Wyze Cam Updated"
+    assert data["stream_name"] == "wyze_updated"
+
+
+@pytest.mark.asyncio
+async def test_assign_and_unassign_camera(client: AsyncClient, auth_headers: dict):
+    printer = await _create_printer(client, auth_headers, "Voron 2.4", "voron-24")
+    camera = await _create_camera(client, auth_headers)
+
+    # Assign
+    assign = await client.post(
+        f"/api/v1/cameras/{camera['id']}/assign",
+        headers=auth_headers,
+        json={"printer_id": printer["id"]},
+    )
+    assert assign.status_code == 200
+    assert assign.json()["printer_id"] == printer["id"]
+
+    # Unassign
+    unassign = await client.post(
+        f"/api/v1/cameras/{camera['id']}/assign",
+        headers=auth_headers,
+        json={"printer_id": None},
+    )
+    assert unassign.status_code == 200
+    assert unassign.json()["printer_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_reassign_camera_between_printers(client: AsyncClient, auth_headers: dict):
+    p1 = await _create_printer(client, auth_headers, "Printer A", "printer-a")
+    p2 = await _create_printer(client, auth_headers, "Printer B", "printer-b")
+    camera = await _create_camera(client, auth_headers, printer_id=p1["id"])
+
+    # Reassign to printer B
+    resp = await client.post(
+        f"/api/v1/cameras/{camera['id']}/assign",
+        headers=auth_headers,
+        json={"printer_id": p2["id"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["printer_id"] == p2["id"]
+    assert resp.json()["printer_name"] == "Printer B"
+
+
+@pytest.mark.asyncio
+async def test_delete_camera_soft_deactivates_and_unassigns(client: AsyncClient, auth_headers: dict):
+    printer = await _create_printer(client, auth_headers, "Ender 3", "ender-3")
+    camera = await _create_camera(client, auth_headers, printer_id=printer["id"])
+
+    delete_resp = await client.delete(f"/api/v1/cameras/{camera['id']}", headers=auth_headers)
+    assert delete_resp.status_code == 204
+
+    get_resp = await client.get(f"/api/v1/cameras/{camera['id']}")
+    assert get_resp.status_code == 200
+    data = get_resp.json()
+    assert data["is_active"] is False
+    assert data["printer_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_cameras_with_filters(client: AsyncClient, auth_headers: dict):
+    printer = await _create_printer(client, auth_headers, "P1S", "p1s")
+    await _create_camera(client, auth_headers, name="Assigned Cam", slug="assigned-cam", printer_id=printer["id"])
+    await _create_camera(client, auth_headers, name="Free Cam", slug="free-cam")
+
+    # All cameras
+    all_resp = await client.get("/api/v1/cameras")
+    assert all_resp.status_code == 200
+    assert all_resp.json()["total"] == 2
+
+    # Assigned only
+    assigned_resp = await client.get("/api/v1/cameras", params={"assigned": True})
+    assert assigned_resp.json()["total"] == 1
+    assert assigned_resp.json()["items"][0]["name"] == "Assigned Cam"
+
+    # Unassigned only
+    free_resp = await client.get("/api/v1/cameras", params={"assigned": False})
+    assert free_resp.json()["total"] == 1
+    assert free_resp.json()["items"][0]["name"] == "Free Cam"
+
+    # Search
+    search_resp = await client.get("/api/v1/cameras", params={"search": "Free"})
+    assert search_resp.json()["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_snapshot_returns_404_for_missing_camera(client: AsyncClient, auth_headers: dict):
+    fake_id = str(uuid.uuid4())
+    resp = await client.get(f"/api/v1/cameras/{fake_id}/snapshot")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_printer_response_includes_camera_data(client: AsyncClient, auth_headers: dict):
+    printer = await _create_printer(client, auth_headers, "Cam Printer", "cam-printer")
+    camera = await _create_camera(client, auth_headers, printer_id=printer["id"])
+
+    # Get printer should include camera fields
+    get_resp = await client.get(f"/api/v1/printers/{printer['id']}")
+    assert get_resp.status_code == 200
+    data = get_resp.json()
+    assert data["camera_id"] == camera["id"]
+    assert data["camera_name"] == "Wyze Cam 1"
+    assert data["camera_snapshot_url"].startswith("/api/v1/cameras/")
+    assert "ws://" in data["camera_mse_ws_url"]
+
+
+@pytest.mark.asyncio
+async def test_printer_response_without_camera_has_null_fields(client: AsyncClient, auth_headers: dict):
+    printer = await _create_printer(client, auth_headers, "No Cam", "no-cam")
+    get_resp = await client.get(f"/api/v1/printers/{printer['id']}")
+    assert get_resp.status_code == 200
+    data = get_resp.json()
+    assert data["camera_id"] is None
+    assert data["camera_name"] is None
+    assert data["camera_snapshot_url"] is None
+    assert data["camera_mse_ws_url"] is None

--- a/docs/camera-setup.md
+++ b/docs/camera-setup.md
@@ -1,0 +1,119 @@
+# Camera Setup Guide
+
+Live camera feeds for printer monitoring, powered by go2rtc.
+
+## Overview
+
+Cameras are standalone devices (e.g., Wyze Cam v4) that watch printers. Each camera is configured as its own entity in the app and can be assigned to exactly one printer. The browser connects directly to go2rtc for low-latency MSE/WebSocket streaming with an MJPEG snapshot fallback proxied through the backend.
+
+## Prerequisites
+
+- **go2rtc** running on your network, accessible from both the app server and client browsers
+- Camera sources configured in go2rtc (e.g., Wyze cameras via native P2P, RTSP, or other supported protocols)
+- The 3D Print Sales app deployed and running
+
+## go2rtc Configuration
+
+Example `go2rtc.yaml` for three Wyze cameras:
+
+```yaml
+streams:
+  wyze_printer_1:
+    - wyze://user@example.com:password#DeviceName1
+  wyze_printer_2:
+    - wyze://user@example.com:password#DeviceName2
+  wyze_printer_3:
+    - wyze://user@example.com:password#DeviceName3
+```
+
+Once go2rtc is running, verify streams are available at `http://<go2rtc-host>:1984/api/streams`.
+
+## Adding Cameras in the App
+
+1. Navigate to **Admin > Cameras** in the app
+2. Click **Add Camera**
+3. Fill in:
+   - **Name**: A human-readable label (e.g., "Wyze Cam - Bay 1")
+   - **Slug**: Auto-generated from name, or customized
+   - **go2rtc Base URL**: The base URL of your go2rtc instance (e.g., `http://192.168.1.50:1984`)
+   - **Stream Name**: The stream name from your go2rtc config (e.g., `wyze_printer_1`)
+4. Optionally assign to a printer using the dropdown
+5. Click **Add Camera**
+
+A live snapshot preview appears in the form when the URL and stream name are filled in correctly.
+
+## Assigning Cameras to Printers
+
+Each camera can be assigned to exactly one printer. Assignment can be done:
+
+- During camera creation (printer dropdown in the form)
+- By editing an existing camera
+- Via the API: `POST /api/v1/cameras/{id}/assign` with `{ "printer_id": "<uuid>" }`
+
+Once assigned, the camera feed appears:
+
+- On the **printer wall card** (replaces the print thumbnail)
+- In the **printer detail page** (Visual Console section)
+- On the **dedicated monitor page** (`/print-floor/monitor/{printer-id}`)
+
+## Stream Formats
+
+The app supports two streaming methods:
+
+| Method | URL Pattern | Latency | Browser Support |
+|--------|-------------|---------|-----------------|
+| **MSE** (primary) | `ws://{host}/api/ws?src={stream}` | Sub-second | Chrome, Edge, Firefox |
+| **MJPEG** (fallback) | `{host}/api/frame.jpeg?src={stream}` | ~2 seconds | All browsers |
+
+MSE streaming is used by default. If the WebSocket connection fails or MediaSource is unavailable (e.g., Safari), the app automatically falls back to MJPEG snapshot polling through the backend proxy.
+
+## Monitor / Kiosk Mode
+
+For wall-mounted displays or dedicated monitoring stations, use the kiosk URL:
+
+```
+https://your-app.local/print-floor/monitor/{printer-id}
+```
+
+This provides:
+- Full-screen camera feed with no navigation chrome
+- Translucent telemetry overlay (printer name, status, progress, temps)
+- Auto-refresh of printer data every 30 seconds
+- "Exit Monitor" button to return to printer detail
+
+## Troubleshooting
+
+### Camera shows "Connecting..." but never goes live
+
+- Verify go2rtc is accessible from the browser (not just the server)
+- Check that the stream name matches exactly what's in `go2rtc.yaml`
+- Open the go2rtc web UI at `http://<host>:1984` to verify the stream is active
+
+### Snapshot proxy returns 502
+
+- The backend cannot reach the go2rtc instance
+- Check network connectivity between the app server and go2rtc host
+- Verify the go2rtc base URL is correct (no trailing slash)
+
+### CORS errors in browser console
+
+- go2rtc serves CORS headers by default
+- If go2rtc is behind a reverse proxy, ensure the proxy forwards WebSocket upgrade headers and CORS headers
+
+### Camera feed freezes after a while
+
+- The app cleans up video buffers every 10 seconds (keeps last 30 seconds)
+- If still freezing, check go2rtc memory usage and stream health
+- The tab visibility API pauses streams when the tab is hidden and reconnects when visible
+
+## API Reference
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/v1/cameras` | GET | List cameras (filters: `is_active`, `assigned`, `search`) |
+| `/api/v1/cameras` | POST | Create camera |
+| `/api/v1/cameras/{id}` | GET | Get camera |
+| `/api/v1/cameras/{id}` | PUT | Update camera |
+| `/api/v1/cameras/{id}` | DELETE | Soft-delete camera |
+| `/api/v1/cameras/{id}/assign` | POST | Assign/unassign printer |
+| `/api/v1/cameras/{id}/snapshot` | GET | Proxy MJPEG snapshot from go2rtc |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,8 @@ const LoginPage = lazy(() => import('@/pages/LoginPage'));
 const SettingsPage = lazy(() => import('@/pages/admin/SettingsPage'));
 const UsersPage = lazy(() => import('@/pages/admin/UsersPage'));
 const DataPage = lazy(() => import('@/pages/admin/DataPage'));
+const CamerasPage = lazy(() => import('@/pages/admin/CamerasPage'));
+const PrinterMonitorPage = lazy(() => import('@/pages/PrinterMonitorPage'));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -69,6 +71,14 @@ export default function App() {
           <Suspense fallback={<RouteFallback />}>
             <Routes>
               <Route path="/login" element={<LoginPage />} />
+              <Route
+                path="/print-floor/monitor/:id"
+                element={
+                  <ProtectedRoute>
+                    <PrinterMonitorPage />
+                  </ProtectedRoute>
+                }
+              />
               <Route
                 element={
                   <ProtectedRoute>
@@ -149,6 +159,7 @@ export default function App() {
                   <Route index element={<Navigate to="/admin/settings" replace />} />
                   <Route path="settings" element={<SettingsPage />} />
                   <Route path="users" element={<UsersPage />} />
+                  <Route path="cameras" element={<CamerasPage />} />
                   <Route path="data" element={<DataPage />} />
                 </Route>
               </Route>

--- a/frontend/src/components/cameras/CameraFeed.tsx
+++ b/frontend/src/components/cameras/CameraFeed.tsx
@@ -1,0 +1,327 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { VideoOff, RefreshCw } from 'lucide-react';
+
+type FeedStatus = 'connecting' | 'live' | 'error' | 'offline';
+
+interface CameraFeedProps {
+  mseWsUrl: string | null;
+  snapshotUrl: string | null;
+  alt?: string;
+  className?: string;
+  showLiveBadge?: boolean;
+  onStatusChange?: (status: FeedStatus) => void;
+}
+
+const MAX_RETRIES = 4;
+const RETRY_BASE_MS = 3000;
+const MJPEG_POLL_MS = 2000;
+const BUFFER_CLEANUP_INTERVAL_MS = 10000;
+const BUFFER_MAX_SECONDS = 30;
+
+export default function CameraFeed({
+  mseWsUrl,
+  snapshotUrl,
+  alt = 'Camera feed',
+  className = '',
+  showLiveBadge = true,
+  onStatusChange,
+}: CameraFeedProps) {
+  const [status, setStatus] = useState<FeedStatus>('connecting');
+  const [useMjpeg, setUseMjpeg] = useState(false);
+  const [mjpegSrc, setMjpegSrc] = useState<string | null>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const mediaSourceRef = useRef<MediaSource | null>(null);
+  const sourceBufferRef = useRef<SourceBuffer | null>(null);
+  const retryCountRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mjpegTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const cleanupTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const mountedRef = useRef(true);
+
+  const updateStatus = useCallback(
+    (s: FeedStatus) => {
+      setStatus(s);
+      onStatusChange?.(s);
+    },
+    [onStatusChange],
+  );
+
+  // ── Cleanup all resources ──
+  const cleanup = useCallback(() => {
+    if (wsRef.current) {
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+    if (mjpegTimerRef.current) {
+      clearInterval(mjpegTimerRef.current);
+      mjpegTimerRef.current = null;
+    }
+    if (cleanupTimerRef.current) {
+      clearInterval(cleanupTimerRef.current);
+      cleanupTimerRef.current = null;
+    }
+    if (mediaSourceRef.current && videoRef.current) {
+      try {
+        if (videoRef.current.src) {
+          URL.revokeObjectURL(videoRef.current.src);
+        }
+      } catch {
+        // ignore
+      }
+    }
+    mediaSourceRef.current = null;
+    sourceBufferRef.current = null;
+  }, []);
+
+  // ── MJPEG fallback polling ──
+  const startMjpeg = useCallback(() => {
+    if (!snapshotUrl) {
+      updateStatus('offline');
+      return;
+    }
+    setUseMjpeg(true);
+    const refresh = () => {
+      if (!mountedRef.current) return;
+      setMjpegSrc(`${snapshotUrl}?t=${Date.now()}`);
+      updateStatus('live');
+    };
+    refresh();
+    mjpegTimerRef.current = setInterval(refresh, MJPEG_POLL_MS);
+  }, [snapshotUrl, updateStatus]);
+
+  // ── MSE WebSocket connection ──
+  const connectMse = useCallback(() => {
+    if (!mseWsUrl || !mountedRef.current) {
+      startMjpeg();
+      return;
+    }
+    if (!('MediaSource' in window)) {
+      startMjpeg();
+      return;
+    }
+
+    updateStatus('connecting');
+
+    const ms = new MediaSource();
+    mediaSourceRef.current = ms;
+    const video = videoRef.current;
+    if (!video) return;
+
+    video.src = URL.createObjectURL(ms);
+
+    let codec = '';
+    let initDone = false;
+
+    ms.addEventListener('sourceopen', () => {
+      // sourceopen fires after we set video.src
+    });
+
+    const ws = new WebSocket(mseWsUrl);
+    ws.binaryType = 'arraybuffer';
+    wsRef.current = ws;
+
+    const connectionTimeout = setTimeout(() => {
+      if (!initDone && mountedRef.current) {
+        ws.close();
+      }
+    }, 8000);
+
+    ws.onmessage = (event) => {
+      if (!mountedRef.current) return;
+
+      if (typeof event.data === 'string') {
+        // First message is JSON with codec info
+        try {
+          const msg = JSON.parse(event.data);
+          if (msg.type === 'mse' && msg.value) {
+            codec = msg.value;
+          }
+        } catch {
+          // ignore parse errors
+        }
+        return;
+      }
+
+      // Binary frame data
+      if (!initDone && ms.readyState === 'open') {
+        clearTimeout(connectionTimeout);
+        try {
+          const sb = ms.addSourceBuffer(codec || 'video/avc; codecs="avc1.640029"');
+          sourceBufferRef.current = sb;
+          initDone = true;
+          retryCountRef.current = 0;
+          updateStatus('live');
+
+          // Periodic buffer cleanup to prevent memory growth
+          cleanupTimerRef.current = setInterval(() => {
+            if (sb.updating || ms.readyState !== 'open') return;
+            try {
+              const buffered = sb.buffered;
+              if (buffered.length > 0) {
+                const end = buffered.end(buffered.length - 1);
+                const start = buffered.start(0);
+                if (end - start > BUFFER_MAX_SECONDS) {
+                  sb.remove(start, end - BUFFER_MAX_SECONDS);
+                }
+              }
+            } catch {
+              // ignore
+            }
+          }, BUFFER_CLEANUP_INTERVAL_MS);
+        } catch {
+          // Codec not supported, fall back to MJPEG
+          cleanup();
+          startMjpeg();
+          return;
+        }
+      }
+
+      const sb = sourceBufferRef.current;
+      if (sb && !sb.updating && ms.readyState === 'open') {
+        try {
+          sb.appendBuffer(event.data);
+        } catch {
+          // Buffer full or closed — ignore
+        }
+      }
+    };
+
+    ws.onerror = () => {
+      clearTimeout(connectionTimeout);
+    };
+
+    ws.onclose = () => {
+      clearTimeout(connectionTimeout);
+      if (!mountedRef.current) return;
+
+      if (retryCountRef.current < MAX_RETRIES) {
+        const delay = RETRY_BASE_MS * Math.pow(2, retryCountRef.current);
+        retryCountRef.current++;
+        updateStatus('connecting');
+        cleanup();
+        retryTimerRef.current = setTimeout(() => {
+          if (mountedRef.current) connectMse();
+        }, delay);
+      } else {
+        cleanup();
+        startMjpeg();
+      }
+    };
+  }, [mseWsUrl, cleanup, startMjpeg, updateStatus]);
+
+  // ── Visibility API: pause when hidden, reconnect when visible ──
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.hidden) {
+        cleanup();
+      } else if (mountedRef.current) {
+        retryCountRef.current = 0;
+        setUseMjpeg(false);
+        connectMse();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [cleanup, connectMse]);
+
+  // ── Main effect: connect on mount ──
+  useEffect(() => {
+    mountedRef.current = true;
+    connectMse();
+    return () => {
+      mountedRef.current = false;
+      cleanup();
+    };
+  }, [connectMse, cleanup]);
+
+  const handleRetry = () => {
+    cleanup();
+    retryCountRef.current = 0;
+    setUseMjpeg(false);
+    setMjpegSrc(null);
+    connectMse();
+  };
+
+  // ── No URLs at all ──
+  if (!mseWsUrl && !snapshotUrl) {
+    return (
+      <div className={`flex items-center justify-center bg-black/60 text-muted-foreground ${className}`}>
+        <div className="flex flex-col items-center gap-2">
+          <VideoOff className="h-8 w-8 opacity-50" />
+          <span className="text-xs">No camera configured</span>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Error / Offline state ──
+  if (status === 'error' || status === 'offline') {
+    return (
+      <div className={`flex items-center justify-center bg-black/60 text-muted-foreground ${className}`}>
+        <div className="flex flex-col items-center gap-2">
+          <VideoOff className="h-8 w-8 text-danger opacity-70" />
+          <span className="text-xs">Camera offline</span>
+          <button
+            type="button"
+            onClick={handleRetry}
+            className="flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors"
+          >
+            <RefreshCw className="h-3 w-3" />
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`relative bg-black overflow-hidden ${className}`}>
+      {/* MSE video */}
+      {!useMjpeg && (
+        <video
+          ref={videoRef}
+          autoPlay
+          muted
+          playsInline
+          className="w-full h-full object-contain"
+        />
+      )}
+
+      {/* MJPEG fallback */}
+      {useMjpeg && mjpegSrc && (
+        <img
+          src={mjpegSrc}
+          alt={alt}
+          className="w-full h-full object-contain"
+          onError={() => updateStatus('error')}
+        />
+      )}
+
+      {/* Connecting overlay */}
+      {status === 'connecting' && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/80">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <span className="h-2 w-2 rounded-full bg-warning animate-pulse" />
+            <span className="text-xs">Connecting...</span>
+          </div>
+        </div>
+      )}
+
+      {/* Live badge */}
+      {status === 'live' && showLiveBadge && (
+        <div className="absolute top-2 right-2 flex items-center gap-1 px-1.5 py-0.5 rounded bg-danger/90 text-white text-[10px] font-semibold uppercase tracking-wider">
+          <span className="h-1.5 w-1.5 rounded-full bg-white animate-pulse" />
+          Live
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/AdminLayout.tsx
+++ b/frontend/src/components/layout/AdminLayout.tsx
@@ -1,11 +1,12 @@
 import { NavLink, Outlet, Navigate } from 'react-router-dom';
-import { Settings, Users, Download } from 'lucide-react';
+import { Settings, Users, Download, Camera } from 'lucide-react';
 import { useAuthStore } from '@/store/auth';
 import { cn } from '@/lib/utils';
 
 const adminLinks = [
   { to: '/admin/settings', label: 'Settings', icon: Settings },
   { to: '/admin/users', label: 'Users', icon: Users },
+  { to: '/admin/cameras', label: 'Cameras', icon: Camera },
   { to: '/admin/data', label: 'Data Export', icon: Download },
 ];
 

--- a/frontend/src/components/layout/workspaces.ts
+++ b/frontend/src/components/layout/workspaces.ts
@@ -141,6 +141,7 @@ export const workspaces: WorkspaceDefinition[] = [
     localLinks: [
       { to: '/admin/settings', label: 'Settings', matchPrefixes: ['/admin/settings'] },
       { to: '/admin/users', label: 'Users', matchPrefixes: ['/admin/users'] },
+      { to: '/admin/cameras', label: 'Cameras', matchPrefixes: ['/admin/cameras'] },
       { to: '/admin/data', label: 'Data Export', matchPrefixes: ['/admin/data'] },
     ],
   },

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -6,6 +6,7 @@ import {
   Archive,
   ArchiveRestore,
   Edit,
+  Expand,
   Gauge,
   Layers3,
   PlugZap,
@@ -16,6 +17,7 @@ import {
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { cn, formatCurrency } from '@/lib/utils';
+import CameraFeed from '@/components/cameras/CameraFeed';
 import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import type { Job, PaginatedJobs, Printer, PrinterConnectionTestResult } from '@/types';
@@ -398,19 +400,39 @@ export default function PrinterDetailPage() {
         </section>
 
         <section className="rounded-[1.8rem] border border-border bg-card/85 p-5 shadow-[0_16px_40px_rgba(8,17,31,0.06)]">
-          <div className="mb-4">
-            <h2 className="text-xl font-semibold text-foreground">Visual console</h2>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Current print thumbnail plus the most relevant assignment and machine details.
-            </p>
+          <div className="mb-4 flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-foreground">Visual console</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {printer.camera_id ? `Live feed from ${printer.camera_name}` : 'Current print thumbnail plus the most relevant assignment and machine details.'}
+              </p>
+            </div>
+            {printer.camera_id && (
+              <Link
+                to={`/print-floor/monitor/${printer.id}`}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-sm font-medium hover:bg-muted transition-colors"
+              >
+                <Expand className="h-3.5 w-3.5" />
+                Monitor
+              </Link>
+            )}
           </div>
 
-          <PrinterThumbnail
-            src={printer.current_print_thumbnail_url}
-            alt={printer.current_print_name ? `${printer.current_print_name} thumbnail` : `${printer.name} current print thumbnail`}
-            className="min-h-[280px] rounded-[1.4rem]"
-            fallbackLabel={printer.current_print_name ? 'No thumbnail in G-code metadata' : 'No active print'}
-          />
+          {printer.camera_mse_ws_url || printer.camera_snapshot_url ? (
+            <CameraFeed
+              mseWsUrl={printer.camera_mse_ws_url}
+              snapshotUrl={printer.camera_snapshot_url}
+              alt={`${printer.name} camera feed`}
+              className="min-h-[280px] rounded-[1.4rem]"
+            />
+          ) : (
+            <PrinterThumbnail
+              src={printer.current_print_thumbnail_url}
+              alt={printer.current_print_name ? `${printer.current_print_name} thumbnail` : `${printer.name} current print thumbnail`}
+              className="min-h-[280px] rounded-[1.4rem]"
+              fallbackLabel={printer.current_print_name ? 'No thumbnail in G-code metadata' : 'No active print'}
+            />
+          )}
 
           <div className="mt-4 grid gap-3 sm:grid-cols-2">
             <div className="rounded-[1.25rem] border border-border bg-background/60 p-4">

--- a/frontend/src/pages/PrinterMonitorPage.tsx
+++ b/frontend/src/pages/PrinterMonitorPage.tsx
@@ -1,0 +1,171 @@
+import { useParams, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { ArrowLeft, Thermometer, Clock, Layers, Wifi, WifiOff } from 'lucide-react';
+import api from '@/api/client';
+import type { Printer } from '@/types';
+import CameraFeed from '@/components/cameras/CameraFeed';
+
+function formatDuration(seconds: number | null | undefined): string {
+  if (!seconds || seconds <= 0) return '--';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+function formatTemp(c: number | null | undefined): string {
+  if (c == null) return '--';
+  return `${c.toFixed(0)}°C`;
+}
+
+export default function PrinterMonitorPage() {
+  const { id } = useParams<{ id: string }>();
+
+  const { data: printer, isLoading } = useQuery<Printer>({
+    queryKey: ['printer-monitor', id],
+    queryFn: () => api.get(`/printers/${id}`).then((r) => r.data),
+    refetchInterval: 30_000,
+    enabled: !!id,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="h-screen w-screen bg-slate-950 flex items-center justify-center">
+        <div className="animate-pulse text-muted-foreground text-sm">Loading printer...</div>
+      </div>
+    );
+  }
+
+  if (!printer) {
+    return (
+      <div className="h-screen w-screen bg-slate-950 flex items-center justify-center">
+        <div className="text-center text-muted-foreground">
+          <p className="text-lg font-medium">Printer not found</p>
+          <Link to="/print-floor" className="text-primary text-sm mt-2 inline-block hover:underline">
+            Back to Print Floor
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const status = printer.monitor_status || printer.status;
+  const progress = printer.monitor_progress_percent;
+  const hasCamera = !!printer.camera_mse_ws_url || !!printer.camera_snapshot_url;
+
+  const statusColor =
+    status === 'printing'
+      ? 'text-primary'
+      : status === 'error'
+        ? 'text-danger'
+        : status === 'paused'
+          ? 'text-warning'
+          : 'text-muted-foreground';
+
+  return (
+    <div className="h-screen w-screen bg-slate-950 flex flex-col overflow-hidden">
+      {/* Camera feed area — fills most of the screen */}
+      <div className="flex-1 min-h-0 relative">
+        {hasCamera ? (
+          <CameraFeed
+            mseWsUrl={printer.camera_mse_ws_url}
+            snapshotUrl={printer.camera_snapshot_url}
+            alt={`${printer.name} camera feed`}
+            className="w-full h-full"
+            showLiveBadge
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-muted-foreground">
+            <div className="text-center">
+              <p className="text-lg">No camera assigned</p>
+              <p className="text-sm mt-1 opacity-60">
+                Assign a camera to this printer in Admin &gt; Cameras
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Back button (top-left, translucent) */}
+        <Link
+          to={`/print-floor/printers/${printer.id}`}
+          className="absolute top-4 left-4 flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-black/60 text-white/80 hover:text-white text-xs font-medium backdrop-blur-sm transition-colors"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Exit Monitor
+        </Link>
+      </div>
+
+      {/* Bottom telemetry strip */}
+      <div className="shrink-0 bg-gradient-to-t from-black/95 to-black/80 backdrop-blur-sm border-t border-white/5 px-6 py-4">
+        <div className="flex items-center justify-between gap-6 max-w-7xl mx-auto">
+          {/* Printer identity */}
+          <div className="min-w-0">
+            <h1 className="text-white text-lg font-display font-bold truncate">{printer.name}</h1>
+            <div className="flex items-center gap-2 mt-0.5">
+              <span className={`text-sm font-medium capitalize ${statusColor}`}>{status}</span>
+              {printer.current_print_name && (
+                <span className="text-xs text-white/50 truncate max-w-[200px]">
+                  {printer.current_print_name}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Progress bar (center) */}
+          {status === 'printing' && progress != null && (
+            <div className="flex-1 max-w-md">
+              <div className="flex items-center justify-between text-xs text-white/60 mb-1">
+                <span>Progress</span>
+                <span className="font-medium text-white">{progress.toFixed(1)}%</span>
+              </div>
+              <div className="h-2 bg-white/10 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-primary rounded-full transition-all duration-1000"
+                  style={{ width: `${Math.min(progress, 100)}%` }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Telemetry stats */}
+          <div className="flex items-center gap-5 shrink-0">
+            {/* ETA */}
+            <div className="flex items-center gap-1.5 text-white/70">
+              <Clock className="h-4 w-4" />
+              <span className="text-sm">{formatDuration(printer.monitor_remaining_seconds)}</span>
+            </div>
+
+            {/* Layers */}
+            <div className="flex items-center gap-1.5 text-white/70">
+              <Layers className="h-4 w-4" />
+              <span className="text-sm">
+                {printer.monitor_current_layer ?? '--'}/{printer.monitor_total_layers ?? '--'}
+              </span>
+            </div>
+
+            {/* Nozzle temp */}
+            <div className="flex items-center gap-1.5 text-white/70" title="Nozzle">
+              <Thermometer className="h-4 w-4 text-danger/70" />
+              <span className="text-sm">{formatTemp(printer.monitor_tool_temp_c)}</span>
+            </div>
+
+            {/* Bed temp */}
+            <div className="flex items-center gap-1.5 text-white/70" title="Bed">
+              <Thermometer className="h-4 w-4 text-info/70" />
+              <span className="text-sm">{formatTemp(printer.monitor_bed_temp_c)}</span>
+            </div>
+
+            {/* Connection */}
+            <div className="flex items-center gap-1.5">
+              {printer.monitor_ws_connected ? (
+                <Wifi className="h-4 w-4 text-primary/70" />
+              ) : (
+                <WifiOff className="h-4 w-4 text-muted-foreground/50" />
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
+import CameraFeed from '@/components/cameras/CameraFeed';
 import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import EmptyState from '@/components/ui/EmptyState';
 import { cn } from '@/lib/utils';
@@ -187,6 +188,15 @@ function PrinterWallCard({
       </div>
 
       <div className="mt-4 grid gap-4 lg:grid-cols-[104px_minmax(0,1fr)]">
+        {printer.camera_mse_ws_url || printer.camera_snapshot_url ? (
+          <CameraFeed
+            mseWsUrl={printer.camera_mse_ws_url}
+            snapshotUrl={printer.camera_snapshot_url}
+            alt={`${printer.name} camera`}
+            className="h-[104px] w-[104px] rounded-[1.25rem]"
+            showLiveBadge={false}
+          />
+        ) : (
         <PrinterThumbnail
           src={printer.current_print_thumbnail_url}
           alt={printer.current_print_name ? `${printer.current_print_name} thumbnail` : `${printer.name} thumbnail`}
@@ -194,6 +204,7 @@ function PrinterWallCard({
           imgClassName="object-cover"
           fallbackLabel={printer.current_print_name ? 'No thumbnail' : 'No active print'}
         />
+        )}
 
         <div className="min-w-0">
           <div className="flex items-center justify-between gap-3">
@@ -567,15 +578,11 @@ export default function PrintersPage() {
           subtext="Attention printers plus queue items needing assignment"
           emphasis={analytics.printersAtAttention + analytics.unassignedJobs ? 'warning' : 'default'}
         />
-        {!wallMode ? (
-          <div className="rounded-[1.5rem] border border-border bg-card/80 p-4 shadow-[0_14px_40px_rgba(8,17,31,0.06)]">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Camera integration path</p>
-            <p className="mt-3 text-base font-semibold text-foreground">Ready for `#129`</p>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Wall mode uses print thumbnails now and reserves camera tile space for the dedicated live-camera issue.
-            </p>
-          </div>
-        ) : null}
+        <SummaryCard
+          label="Live cameras"
+          value={String(printers.filter((p) => p.camera_id).length)}
+          subtext={`${printers.filter((p) => p.camera_id).length} printers with camera feeds`}
+        />
       </div>
 
       {attentionPrinters.length > 0 ? (
@@ -653,7 +660,7 @@ export default function PrintersPage() {
             </div>
             <div className="flex flex-wrap gap-2 text-xs text-slate-300">
               <span className="inline-flex items-center gap-1 rounded-full border border-slate-700 bg-slate-900/80 px-3 py-1">
-                <Camera className="h-3.5 w-3.5" /> Camera tiles plug in here after `#129`
+                <Camera className="h-3.5 w-3.5" /> {printers.filter((p) => p.camera_id).length} live camera{printers.filter((p) => p.camera_id).length !== 1 ? 's' : ''}
               </span>
               <span className="inline-flex items-center gap-1 rounded-full border border-slate-700 bg-slate-900/80 px-3 py-1">
                 {reducedMotion ? 'Reduced motion respected' : 'Motion available'}

--- a/frontend/src/pages/admin/CamerasPage.tsx
+++ b/frontend/src/pages/admin/CamerasPage.tsx
@@ -1,0 +1,391 @@
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Camera as CameraIcon, Plus, Pencil, Trash2, Link2, Link2Off, Video } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import type { Camera, PaginatedCameras, PaginatedPrinters } from '@/types';
+
+type ModalMode = 'create' | 'edit' | null;
+
+const emptyForm = {
+  name: '',
+  slug: '',
+  go2rtc_base_url: '',
+  stream_name: '',
+  printer_id: '',
+  notes: '',
+};
+
+export default function CamerasPage() {
+  const qc = useQueryClient();
+  const [modal, setModal] = useState<ModalMode>(null);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [form, setForm] = useState(emptyForm);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [snapshotPreview, setSnapshotPreview] = useState<string | null>(null);
+
+  const { data: camerasData, isLoading } = useQuery<PaginatedCameras>({
+    queryKey: ['cameras'],
+    queryFn: () => api.get('/cameras?limit=100').then((r) => r.data),
+  });
+
+  const { data: printersData } = useQuery<PaginatedPrinters>({
+    queryKey: ['printers-for-cameras'],
+    queryFn: () => api.get('/printers?is_active=true&limit=100').then((r) => r.data),
+  });
+
+  const cameras = camerasData?.items ?? [];
+  const printers = printersData?.items ?? [];
+
+  // Filter out printers already assigned to OTHER cameras
+  const availablePrinters = printers.filter((p) => {
+    if (form.printer_id && form.printer_id === p.id) return true; // Current assignment is OK
+    return !cameras.some((c) => c.printer_id === p.id && c.id !== editId && c.is_active);
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const payload: Record<string, unknown> = {
+        name: form.name.trim(),
+        slug: form.slug.trim(),
+        go2rtc_base_url: form.go2rtc_base_url.trim().replace(/\/+$/, ''),
+        stream_name: form.stream_name.trim(),
+        notes: form.notes.trim() || null,
+      };
+      if (form.printer_id) {
+        payload.printer_id = form.printer_id;
+      } else if (modal === 'edit') {
+        payload.clear_printer_id = true;
+      }
+
+      if (modal === 'create') {
+        return api.post('/cameras', payload);
+      }
+      return api.put(`/cameras/${editId}`, payload);
+    },
+    onSuccess: () => {
+      toast.success(modal === 'create' ? 'Camera created' : 'Camera updated');
+      qc.invalidateQueries({ queryKey: ['cameras'] });
+      qc.invalidateQueries({ queryKey: ['printers'] });
+      closeModal();
+    },
+    onError: (err: any) => {
+      toast.error(err?.response?.data?.detail || 'Failed to save camera');
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/cameras/${id}`),
+    onSuccess: () => {
+      toast.success('Camera deactivated');
+      qc.invalidateQueries({ queryKey: ['cameras'] });
+      qc.invalidateQueries({ queryKey: ['printers'] });
+    },
+  });
+
+  const closeModal = () => {
+    setModal(null);
+    setEditId(null);
+    setForm(emptyForm);
+    setErrors({});
+    setSnapshotPreview(null);
+  };
+
+  const openCreate = () => {
+    setForm(emptyForm);
+    setModal('create');
+  };
+
+  const openEdit = (cam: Camera) => {
+    setForm({
+      name: cam.name,
+      slug: cam.slug,
+      go2rtc_base_url: cam.go2rtc_base_url,
+      stream_name: cam.stream_name,
+      printer_id: cam.printer_id ?? '',
+      notes: cam.notes ?? '',
+    });
+    setEditId(cam.id);
+    setModal('edit');
+  };
+
+  const validate = () => {
+    const e: Record<string, string> = {};
+    if (!form.name.trim()) e.name = 'Name is required';
+    if (!form.slug.trim()) e.slug = 'Slug is required';
+    if (!form.go2rtc_base_url.trim()) e.go2rtc_base_url = 'go2rtc URL is required';
+    if (!form.stream_name.trim()) e.stream_name = 'Stream name is required';
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  };
+
+  const handleSave = () => {
+    if (!validate()) return;
+    saveMutation.mutate();
+  };
+
+  // Auto-generate slug from name
+  const handleNameChange = (name: string) => {
+    const slug = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+    setForm((f) => ({ ...f, name, slug }));
+  };
+
+  // Preview snapshot when URL + stream name are filled
+  useEffect(() => {
+    if (form.go2rtc_base_url.trim() && form.stream_name.trim()) {
+      const url = `${form.go2rtc_base_url.trim().replace(/\/+$/, '')}/api/frame.jpeg?src=${encodeURIComponent(form.stream_name.trim())}`;
+      setSnapshotPreview(url);
+    } else {
+      setSnapshotPreview(null);
+    }
+  }, [form.go2rtc_base_url, form.stream_name]);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-display font-bold">Cameras</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Manage camera feeds and assign them to printers for live monitoring.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={openCreate}
+          className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90 transition-colors"
+        >
+          <Plus className="h-4 w-4" />
+          Add Camera
+        </button>
+      </div>
+
+      {/* Table */}
+      {isLoading ? (
+        <div className="animate-pulse space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-14 bg-muted/50 rounded-lg" />
+          ))}
+        </div>
+      ) : cameras.length === 0 ? (
+        <div className="text-center py-16 text-muted-foreground">
+          <CameraIcon className="h-12 w-12 mx-auto mb-3 opacity-40" />
+          <p className="text-lg font-medium">No cameras yet</p>
+          <p className="text-sm mt-1">Add your first camera to start monitoring printers with live video.</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-muted/30">
+                <th className="text-left px-4 py-3 font-medium">Name</th>
+                <th className="text-left px-4 py-3 font-medium hidden md:table-cell">Stream</th>
+                <th className="text-left px-4 py-3 font-medium">Printer</th>
+                <th className="text-left px-4 py-3 font-medium hidden sm:table-cell">Status</th>
+                <th className="text-right px-4 py-3 font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {cameras.map((cam) => (
+                <tr key={cam.id} className="border-b border-border/50 hover:bg-muted/20 transition-colors">
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <Video className="h-4 w-4 text-info shrink-0" />
+                      <span className="font-medium">{cam.name}</span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 hidden md:table-cell">
+                    <code className="text-xs bg-muted/50 px-1.5 py-0.5 rounded">{cam.stream_name}</code>
+                  </td>
+                  <td className="px-4 py-3">
+                    {cam.printer_name ? (
+                      <span className="flex items-center gap-1 text-primary">
+                        <Link2 className="h-3 w-3" />
+                        {cam.printer_name}
+                      </span>
+                    ) : (
+                      <span className="flex items-center gap-1 text-muted-foreground">
+                        <Link2Off className="h-3 w-3" />
+                        Unassigned
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 hidden sm:table-cell">
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                        cam.is_active
+                          ? 'bg-primary/10 text-primary'
+                          : 'bg-muted text-muted-foreground'
+                      }`}
+                    >
+                      {cam.is_active ? 'Active' : 'Inactive'}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <div className="flex items-center justify-end gap-1">
+                      <button
+                        type="button"
+                        onClick={() => openEdit(cam)}
+                        className="p-1.5 rounded hover:bg-muted transition-colors"
+                        title="Edit"
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => deleteMutation.mutate(cam.id)}
+                        className="p-1.5 rounded hover:bg-danger/10 text-danger transition-colors"
+                        title="Deactivate"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Modal */}
+      {modal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
+          <div className="bg-card border border-border rounded-2xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+            <div className="p-6 space-y-5">
+              <h2 className="text-lg font-display font-bold">
+                {modal === 'create' ? 'Add Camera' : 'Edit Camera'}
+              </h2>
+
+              {/* Name */}
+              <div>
+                <label className="block text-sm font-medium mb-1">Name</label>
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => handleNameChange(e.target.value)}
+                  placeholder="Wyze Cam - Bay 1"
+                  className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+                />
+                {errors.name && <p className="text-xs text-danger mt-1">{errors.name}</p>}
+              </div>
+
+              {/* Slug */}
+              <div>
+                <label className="block text-sm font-medium mb-1">Slug</label>
+                <input
+                  type="text"
+                  value={form.slug}
+                  onChange={(e) => setForm((f) => ({ ...f, slug: e.target.value }))}
+                  placeholder="wyze-cam-bay-1"
+                  className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+                />
+                {errors.slug && <p className="text-xs text-danger mt-1">{errors.slug}</p>}
+              </div>
+
+              {/* go2rtc Base URL */}
+              <div>
+                <label className="block text-sm font-medium mb-1">go2rtc Base URL</label>
+                <input
+                  type="text"
+                  value={form.go2rtc_base_url}
+                  onChange={(e) => setForm((f) => ({ ...f, go2rtc_base_url: e.target.value }))}
+                  placeholder="http://192.168.1.50:1984"
+                  className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/30"
+                />
+                {errors.go2rtc_base_url && (
+                  <p className="text-xs text-danger mt-1">{errors.go2rtc_base_url}</p>
+                )}
+              </div>
+
+              {/* Stream Name */}
+              <div>
+                <label className="block text-sm font-medium mb-1">Stream Name</label>
+                <input
+                  type="text"
+                  value={form.stream_name}
+                  onChange={(e) => setForm((f) => ({ ...f, stream_name: e.target.value }))}
+                  placeholder="wyze_printer_1"
+                  className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/30"
+                />
+                {errors.stream_name && (
+                  <p className="text-xs text-danger mt-1">{errors.stream_name}</p>
+                )}
+              </div>
+
+              {/* Snapshot Preview */}
+              {snapshotPreview && (
+                <div>
+                  <label className="block text-sm font-medium mb-1">Preview</label>
+                  <div className="rounded-lg overflow-hidden border border-border bg-black aspect-video">
+                    <img
+                      src={snapshotPreview}
+                      alt="Camera preview"
+                      className="w-full h-full object-contain"
+                      onError={(e) => {
+                        (e.target as HTMLImageElement).style.display = 'none';
+                      }}
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Live snapshot from go2rtc. If blank, verify the URL and stream name.
+                  </p>
+                </div>
+              )}
+
+              {/* Assigned Printer */}
+              <div>
+                <label className="block text-sm font-medium mb-1">Assigned Printer</label>
+                <select
+                  value={form.printer_id}
+                  onChange={(e) => setForm((f) => ({ ...f, printer_id: e.target.value }))}
+                  className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+                >
+                  <option value="">None (unassigned)</option>
+                  {availablePrinters.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name} {p.location ? `(${p.location})` : ''}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Notes */}
+              <div>
+                <label className="block text-sm font-medium mb-1">Notes</label>
+                <textarea
+                  value={form.notes}
+                  onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))}
+                  rows={2}
+                  className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 resize-none"
+                />
+              </div>
+
+              {/* Actions */}
+              <div className="flex items-center justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className="px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={saveMutation.isPending}
+                  className="px-5 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+                >
+                  {saveMutation.isPending ? 'Saving...' : modal === 'create' ? 'Add Camera' : 'Save Changes'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -97,8 +97,35 @@ export interface Printer {
   monitor_ws_last_error: string | null;
   monitor_last_seen_at: string | null;
   monitor_last_updated_at: string | null;
+  camera_id: string | null;
+  camera_name: string | null;
+  camera_snapshot_url: string | null;
+  camera_mse_ws_url: string | null;
   created_at: string | null;
   updated_at: string | null;
+}
+
+export interface Camera {
+  id: string;
+  name: string;
+  slug: string;
+  go2rtc_base_url: string;
+  stream_name: string;
+  printer_id: string | null;
+  printer_name: string | null;
+  is_active: boolean;
+  notes: string | null;
+  snapshot_url: string | null;
+  mse_ws_url: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface PaginatedCameras {
+  items: Camera[];
+  total: number;
+  skip: number;
+  limit: number;
 }
 
 export interface PrinterConnectionTestResult {


### PR DESCRIPTION
## Summary

- Add `cameras` table as a first-class entity with 1:1 optional printer assignment (unique FK constraint)
- Full CRUD + assign/unassign + MJPEG snapshot proxy API at `/api/v1/cameras`
- Printer responses now include `camera_id`, `camera_name`, `camera_snapshot_url`, `camera_mse_ws_url`
- CameraFeed component: MSE/WebSocket primary with MJPEG polling fallback, reconnect logic, visibility API
- Admin CamerasPage under `/admin/cameras` with live snapshot preview and printer dropdown
- PrinterMonitorPage kiosk view at `/print-floor/monitor/:id` — full-screen, zero chrome
- Printer wall cards and detail page conditionally render live camera feed when assigned
- Camera setup guide at `docs/camera-setup.md`

## Validation

- 249 backend tests pass (12 new camera tests)
- 5 frontend tests pass
- `npm run build` succeeds (3.83s)
- All existing printer tests unaffected

## Linked Issue

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)