### PR TITLE
feat: add configurable AI insights workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ All endpoints are under `/api/v1`. Rate limited at 120 requests/minute per IP.
 | Resource | Endpoints | Filters |
 |----------|-----------|---------|
 | **Auth** | `POST /auth/login`, `GET /auth/me`, `PUT /auth/me/password`, `POST /auth/register` (admin), `GET/PUT/DELETE /auth/users` (admin) | `?is_active` |
-| **Settings** | `GET/PUT /settings`, `GET/PUT /settings/{key}`, `PUT /settings/bulk` | — |
+| **Settings** | `GET/PUT /settings`, `GET/PUT /settings/{key}`, `PUT /settings/bulk` | Admin-only |
+| **Insights** | `GET /insights/status`, `POST /insights/summary` | Auth required |
 | **Materials** | Full CRUD at `/materials` | `?active`, `?search`, pagination |
 | **Rates** | Full CRUD at `/rates` | `?active`, pagination |
 | **Customers** | Full CRUD at `/customers` | `?search` (name/email), pagination |
@@ -137,6 +138,7 @@ Net Profit          = not yet exposed for sales reporting until overhead allocat
 - **Protected Routes** — Auto-redirect to login, preserves original URL
 - **Dark/Light Theme** — Persisted to localStorage, respects system preference
 - **Workspace Shell** — Role-aware workspace navigation for Control Center, Print Floor, Sell, Stock, Product Studio, Orders, Insights, and Admin while preserving legacy deep links
+- **AI Insights** — Dedicated `/insights` workspace for read-only business summaries with admin-configurable `ChatGPT`, `Claude`, or `Grok` provider selection
 - **Active Navigation** — Current route highlighted, admin-only items
 - **Error Boundary** — Global error catch with reload action
 - **Empty States** — Contextual illustrations and CTA buttons on empty lists
@@ -155,6 +157,7 @@ Net Profit          = not yet exposed for sales reporting until overhead allocat
 - **Stock** — Exceptions-first inventory workspace at `/stock` with product-impacting low-stock triage, quick reconcile/adjust actions, material signals separated from finished-goods alerts, and the full ledger preserved as a secondary surface
 - **Orders** — Unified queue workspace at `/orders` that stitches production jobs, fulfillment-relevant sales, printer readiness, and customer load into one operational surface while preserving the existing jobs and sales detail flows
 - **Dashboard** — Classic metrics view with summary cards + 3 charts (revenue line, material pie, profit bar) + low-stock alerts + sales metrics (orders, gross sales, item COGS, gross profit, contribution margin) + revenue by channel chart
+- **Insights** — Separate AI analysis workspace with focused questions, provider status, recommendations, risks, follow-up prompts, and source-of-truth evidence metrics
 - **Jobs** — List with search, status filter, pagination; detail with cost breakdown; create/edit with live cost preview, now reachable inside the Orders workspace at `/orders/jobs`
 - **Materials** — Full CRUD with modal, cost-per-gram preview, active/inactive toggle, mobile card layout
 - **Rates** — Full CRUD with modal, unit dropdown, active/inactive toggle, mobile card layout
@@ -172,7 +175,7 @@ Net Profit          = not yet exposed for sales reporting until overhead allocat
   - **Sales Report** — Gross sales/gross profit trend chart, top products ranking, channel breakdown with fees and contribution margin
   - **Profit & Loss** — Sales-realized revenue P&L with production estimates shown separately for operational context, cost breakdown by category, stacked bar trend chart, period detail table
 - **Calculator** — Standalone cost calculator with live preview and "Save as Job"
-- **Admin Settings** — Editable business settings with bulk save, grouped by category
+- **Admin Settings** — Editable business settings with bulk save, grouped by category, plus AI provider, model, and API-key configuration for Insights
 - **Admin Users** — User management with create, edit, role assignment, deactivate/reactivate
 - **Admin Data** — CSV export for jobs, materials, rates, customers, settings
 - **Login** — JWT authentication with Zod validation
@@ -181,6 +184,7 @@ Net Profit          = not yet exposed for sales reporting until overhead allocat
 
 - [Camera Setup Guide](docs/camera-setup.md) — go2rtc configuration, Wyze camera setup, stream formats, kiosk mode, troubleshooting
 - [Shipping Label Printing](docs/shipping_label_printing.md) — remote-compatible 4x6 shipping-label workflow, backend contract, workstation print path, and operator rules for print/cancel/reprint
+- [AI Insights Guide](docs/ai_insights.md) — provider configuration, safety boundaries, endpoints, and UX rationale for issue `#112`
 - [Role-Based Frontend Redesign User Story](docs/frontend_role_based_redesign_user_story.md) — issue-ready redesign brief for print monitoring, live views, POS, inventory, product studio, and role-based workspaces.
 
 ## Testing
@@ -202,7 +206,8 @@ python -m pytest backend/tests/ -v
 # Test categories:
 #   test_cost_calculator.py   - Cost calculation engine (6 tests)
 #   test_api_auth.py          - Auth, RBAC, user management (18 tests)
-#   test_api_settings.py      - Settings CRUD + admin guard (7 tests)
+#   test_api_settings.py      - Settings CRUD + admin guard (8 tests)
+#   test_api_insights.py      - AI provider status + read-only insight flow (3 tests)
 #   test_api_materials.py     - Materials CRUD + auth guard (9 tests)
 #   test_api_rates.py         - Rates CRUD + auth guard (6 tests)
 #   test_api_customers.py     - Customers CRUD + auth guard (8 tests)

--- a/backend/alembic/versions/20260413_02_add_ai_settings.py
+++ b/backend/alembic/versions/20260413_02_add_ai_settings.py
@@ -1,0 +1,49 @@
+"""add ai insight settings
+
+Revision ID: 20260413_02
+Revises: 20260413_01
+Create Date: 2026-04-13 06:25:00
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+from app.services.settings_defaults import AI_SETTINGS_DATA
+
+
+revision = "20260413_02"
+down_revision = "20260413_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    for key, value, notes in AI_SETTINGS_DATA:
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO settings (id, key, value, notes, updated_at)
+                VALUES (:id, :key, :value, :notes, NOW())
+                ON CONFLICT (key) DO NOTHING
+                """
+            ).bindparams(
+                id=uuid.uuid4(),
+                key=key,
+                value=value,
+                notes=notes,
+            )
+        )
+
+
+def downgrade() -> None:
+    keys = [key for key, _, _ in AI_SETTINGS_DATA]
+    op.execute(
+        sa.text("DELETE FROM settings WHERE key IN :keys").bindparams(
+            sa.bindparam("keys", expanding=True)
+        ),
+        {"keys": keys},
+    )

--- a/backend/app/api/v1/endpoints/insights.py
+++ b/backend/app/api/v1/endpoints/insights.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from app.api.deps import CurrentUser, DB
+from app.schemas.insight import InsightRequest, InsightStatusResponse, InsightSummaryResponse
+from app.services.ai_insights_service import (
+    AIInsightConfigurationError,
+    AIInsightProviderError,
+    generate_insight_summary,
+    get_ai_status,
+)
+
+router = APIRouter(prefix="/insights", tags=["Insights"])
+
+
+@router.get(
+    "/status",
+    response_model=InsightStatusResponse,
+    summary="Get AI insights provider status",
+    description="Returns the selected LLM provider, active model, and whether the provider is configured for read-only insights.",
+)
+async def get_insights_status(user: CurrentUser, db: DB):
+    return await get_ai_status(db)
+
+
+@router.post(
+    "/summary",
+    response_model=InsightSummaryResponse,
+    summary="Generate AI business insights",
+    description="Uses the configured LLM provider to generate a read-only operational summary grounded in app data.",
+)
+async def create_insight_summary(body: InsightRequest, user: CurrentUser, db: DB):
+    try:
+        return await generate_insight_summary(db, question=body.question)
+    except AIInsightConfigurationError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except AIInsightProviderError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/backend/app/api/v1/endpoints/settings.py
+++ b/backend/app/api/v1/endpoints/settings.py
@@ -14,9 +14,9 @@ router = APIRouter(prefix="/settings", tags=["Settings"])
     "",
     response_model=list[SettingResponse],
     summary="List all settings",
-    description="Returns every business configuration setting (currency, margins, fees, etc.).",
+    description="Admin-only. Returns every business and AI configuration setting, including provider configuration records.",
 )
-async def list_settings(db: DB):
+async def list_settings(admin: CurrentAdmin, db: DB):
     from app.models.setting import Setting
 
     result = await db.execute(select(Setting).order_by(Setting.key))
@@ -27,9 +27,9 @@ async def list_settings(db: DB):
     "/{key}",
     response_model=SettingResponse,
     summary="Get a setting by key",
-    description="Retrieve a single configuration setting by its unique key.",
+    description="Admin-only. Retrieve a single configuration setting by its unique key.",
 )
-async def get_setting(key: str, db: DB):
+async def get_setting(key: str, admin: CurrentAdmin, db: DB):
     from app.models.setting import Setting
 
     result = await db.execute(select(Setting).where(Setting.key == key))
@@ -43,7 +43,7 @@ async def get_setting(key: str, db: DB):
     "/{key}",
     response_model=SettingResponse,
     summary="Update a setting",
-    description="Update the value of an existing configuration setting.",
+    description="Admin-only. Update the value of an existing configuration setting.",
 )
 async def update_setting(key: str, body: SettingUpdate, admin: CurrentAdmin, db: DB):
     from app.models.setting import Setting
@@ -64,7 +64,7 @@ async def update_setting(key: str, body: SettingUpdate, admin: CurrentAdmin, db:
     "/bulk",
     response_model=list[SettingResponse],
     summary="Bulk update settings",
-    description="Update multiple settings in a single request. Keys that don't exist are silently skipped.",
+    description="Admin-only. Update multiple settings in a single request. Keys that don't exist are silently skipped.",
 )
 async def bulk_update_settings(body: BulkSettingUpdate, admin: CurrentAdmin, db: DB):
     from app.models.setting import Setting

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, audit, auth, cameras, customers, dashboard, inventory, invoices, jobs, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, tax
+from app.api.v1.endpoints import accounting, approvals, audit, auth, cameras, customers, dashboard, insights, inventory, invoices, jobs, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -24,4 +24,5 @@ api_router.include_router(pos.router)
 api_router.include_router(settlements.router)
 api_router.include_router(reports.router)
 api_router.include_router(dashboard.router)
+api_router.include_router(insights.router)
 api_router.include_router(tax.router)

--- a/backend/app/schemas/insight.py
+++ b/backend/app/schemas/insight.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+AIProvider = Literal["chatgpt", "claude", "grok"]
+InsightPriority = Literal["high", "medium", "low"]
+
+
+class InsightRequest(BaseModel):
+    question: str | None = Field(
+        None,
+        max_length=500,
+        description="Optional operator question to steer the insight summary.",
+    )
+
+
+class InsightEvidenceMetric(BaseModel):
+    key: str
+    label: str
+    value: str
+
+
+class InsightItem(BaseModel):
+    title: str
+    detail: str
+    priority: InsightPriority = "medium"
+    evidence: list[str] = Field(default_factory=list)
+    recommended_action: str | None = None
+
+
+class InsightStatusResponse(BaseModel):
+    provider: AIProvider
+    model: str
+    configured: bool
+    available_providers: list[AIProvider]
+    note: str
+
+
+class InsightSummaryResponse(BaseModel):
+    provider: AIProvider
+    model: str
+    generated_at: datetime.datetime
+    title: str
+    summary: str
+    question: str | None = None
+    recommendations: list[InsightItem]
+    risks: list[InsightItem]
+    suggested_questions: list[str]
+    evidence_metrics: list[InsightEvidenceMetric]
+    read_only: bool = True

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -12,19 +12,7 @@ from app.models.sales_channel import SalesChannel
 from app.models.setting import Setting
 from app.models.user import User
 from app.services.accounting_service import seed_chart_of_accounts
-
-SETTINGS_DATA = [
-    ("currency", "USD", "Currency code"),
-    ("default_profit_margin_pct", "40", "Target markup on total cost"),
-    ("platform_fee_pct", "9.5", "Etsy/Amazon/etc."),
-    ("fixed_fee_per_order", "0.45", "Per-transaction fee"),
-    ("sales_tax_pct", "0", "Set if you collect tax"),
-    ("electricity_cost_per_kwh", "0.18", "Check your utility bill"),
-    ("printer_power_draw_watts", "120", "Average draw while printing"),
-    ("failure_rate_pct", "5", "Buffer for failed prints"),
-    ("packaging_cost_per_order", "1.25", "Boxes, tape, padding"),
-    ("shipping_charged_to_customer", "0", "0 = free shipping model"),
-]
+from app.services.settings_defaults import SETTINGS_DATA
 
 MATERIALS_DATA = [
     ("PLA", "Generic", 1000, 20, 950, "Standard PLA spool", True),

--- a/backend/app/services/ai_insights_service.py
+++ b/backend/app/services/ai_insights_service.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import datetime
+import json
+import re
+from dataclasses import dataclass
+from decimal import Decimal
+
+import httpx
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.job import Job
+from app.models.material import Material
+from app.models.printer import Printer
+from app.models.product import Product
+from app.models.sale import Sale
+from app.models.sale_item import SaleItem
+from app.models.setting import Setting
+from app.schemas.insight import (
+    AIProvider,
+    InsightEvidenceMetric,
+    InsightItem,
+    InsightStatusResponse,
+    InsightSummaryResponse,
+)
+
+SUPPORTED_AI_PROVIDERS: list[AIProvider] = ["chatgpt", "claude", "grok"]
+ATTENTION_PRINTER_STATUSES = {"paused", "maintenance", "offline", "error"}
+
+
+class AIInsightConfigurationError(ValueError):
+    """Raised when the configured provider is incomplete."""
+
+
+class AIInsightProviderError(RuntimeError):
+    """Raised when the upstream provider request fails."""
+
+
+@dataclass
+class ProviderConfig:
+    provider: AIProvider
+    model: str
+    api_key: str
+
+
+def _stringify(value: Decimal | float | int | str | None) -> str:
+    if value is None:
+        return "0"
+    if isinstance(value, Decimal):
+        normalized = value.quantize(Decimal("0.01"))
+        return f"{normalized}"
+    if isinstance(value, float):
+        return f"{value:.2f}"
+    return str(value)
+
+
+def _extract_json_object(text: str) -> dict:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if not match:
+            raise AIInsightProviderError("Provider returned a non-JSON response.")
+        try:
+            return json.loads(match.group(0))
+        except json.JSONDecodeError as exc:
+            raise AIInsightProviderError("Provider returned malformed JSON.") from exc
+
+
+def _build_metrics(snapshot: dict) -> list[InsightEvidenceMetric]:
+    return [
+        InsightEvidenceMetric(key="total_jobs", label="Total jobs", value=str(snapshot["job_summary"]["total_jobs"])),
+        InsightEvidenceMetric(key="total_revenue", label="Job revenue", value=f"${snapshot['job_summary']['total_revenue']:.2f}"),
+        InsightEvidenceMetric(key="total_net_profit", label="Job net profit", value=f"${snapshot['job_summary']['total_net_profit']:.2f}"),
+        InsightEvidenceMetric(key="sales_orders", label="Completed sales orders", value=str(snapshot["sales_summary"]["total_sales"])),
+        InsightEvidenceMetric(key="sales_gross_sales", label="Gross sales", value=f"${snapshot['sales_summary']['gross_sales']:.2f}"),
+        InsightEvidenceMetric(key="sales_contribution_margin", label="Contribution margin", value=f"${snapshot['sales_summary']['contribution_margin']:.2f}"),
+        InsightEvidenceMetric(key="low_stock_alerts", label="Low stock alerts", value=str(snapshot["inventory_summary"]["alert_count"])),
+        InsightEvidenceMetric(key="attention_printers", label="Printers needing attention", value=str(snapshot["printer_summary"]["attention_count"])),
+        InsightEvidenceMetric(key="printing_printers", label="Printers currently printing", value=str(snapshot["printer_summary"]["printing_count"])),
+    ]
+
+
+def _default_model_for(provider: AIProvider) -> str:
+    if provider == "chatgpt":
+        return "gpt-4.1-mini"
+    if provider == "claude":
+        return "claude-3-5-sonnet-latest"
+    return "grok-3-mini"
+
+
+async def _get_settings_map(db: AsyncSession) -> dict[str, str]:
+    rows = (await db.execute(select(Setting))).scalars().all()
+    return {row.key: row.value for row in rows}
+
+
+async def get_ai_status(db: AsyncSession) -> InsightStatusResponse:
+    settings_map = await _get_settings_map(db)
+    return _build_ai_status(settings_map)
+
+
+def _build_ai_status(settings_map: dict[str, str]) -> InsightStatusResponse:
+    raw_provider = (settings_map.get("ai_provider") or "chatgpt").strip().lower()
+    provider: AIProvider = raw_provider if raw_provider in SUPPORTED_AI_PROVIDERS else "chatgpt"
+    model = (settings_map.get(f"ai_{provider}_model") or _default_model_for(provider)).strip()
+    api_key = (settings_map.get(f"ai_{provider}_api_key") or "").strip()
+    return InsightStatusResponse(
+        provider=provider,
+        model=model,
+        configured=bool(api_key and model),
+        available_providers=SUPPORTED_AI_PROVIDERS,
+        note="Insights are read-only suggestions grounded in app data. Operator approval is still required for any business action.",
+    )
+
+
+async def _get_provider_config(db: AsyncSession) -> ProviderConfig:
+    settings_map = await _get_settings_map(db)
+    status = _build_ai_status(settings_map)
+    api_key = (settings_map.get(f"ai_{status.provider}_api_key") or "").strip()
+    if not api_key:
+        raise AIInsightConfigurationError(
+            f"Configure an API key for the selected provider ({status.provider}) in Admin Settings before generating insights."
+        )
+    return ProviderConfig(provider=status.provider, model=status.model, api_key=api_key)
+
+
+async def _build_snapshot(db: AsyncSession) -> dict:
+    job_row = (
+        await db.execute(
+            select(
+                func.count(Job.id),
+                func.coalesce(func.sum(Job.total_revenue), 0),
+                func.coalesce(func.sum(Job.net_profit), 0),
+            ).where(Job.is_deleted == False)
+        )
+    ).one()
+
+    sale_rows = (
+        await db.execute(select(Sale).where(Sale.is_deleted == False))
+    ).scalars().all()
+    completed_sales = [sale for sale in sale_rows if sale.status not in ("cancelled", "refunded")]
+
+    gross_sales = sum(float(sale.total) for sale in completed_sales)
+    contribution_margin = sum(float(sale.net_revenue) for sale in completed_sales)
+    shipping_costs = sum(float(sale.shipping_cost) for sale in completed_sales)
+    platform_fees = sum(float(sale.platform_fees) for sale in completed_sales)
+
+    top_products_rows = (
+        await db.execute(
+            select(
+                SaleItem.description,
+                func.sum(SaleItem.quantity).label("qty"),
+                func.sum(SaleItem.line_total).label("revenue"),
+            )
+            .join(Sale, Sale.id == SaleItem.sale_id)
+            .where(Sale.is_deleted == False, Sale.status.not_in(["cancelled", "refunded"]))
+            .group_by(SaleItem.description)
+            .order_by(func.sum(SaleItem.line_total).desc())
+            .limit(5)
+        )
+    ).all()
+
+    low_stock_products = (
+        await db.execute(
+            select(Product.name, Product.stock_qty, Product.reorder_point)
+            .where(Product.is_active == True, Product.stock_qty <= Product.reorder_point)
+            .order_by(Product.stock_qty.asc(), Product.name.asc())
+            .limit(5)
+        )
+    ).all()
+    low_stock_materials = (
+        await db.execute(
+            select(Material.name, Material.brand, Material.spools_in_stock, Material.reorder_point)
+            .where(Material.active == True, Material.spools_in_stock <= Material.reorder_point)
+            .order_by(Material.spools_in_stock.asc(), Material.name.asc())
+            .limit(5)
+        )
+    ).all()
+
+    printer_rows = (
+        await db.execute(
+            select(Printer.name, Printer.status, Printer.monitor_status, Printer.monitor_progress_percent)
+            .where(Printer.is_active == True)
+        )
+    ).all()
+    attention_printers = [
+        row for row in printer_rows if (row.monitor_status or row.status) in ATTENTION_PRINTER_STATUSES
+    ]
+    printing_printers = [
+        row for row in printer_rows if (row.monitor_status or row.status) == "printing"
+    ]
+
+    return {
+        "job_summary": {
+            "total_jobs": int(job_row[0] or 0),
+            "total_revenue": float(job_row[1] or 0),
+            "total_net_profit": float(job_row[2] or 0),
+        },
+        "sales_summary": {
+            "total_sales": len(completed_sales),
+            "gross_sales": gross_sales,
+            "contribution_margin": contribution_margin,
+            "shipping_costs": shipping_costs,
+            "platform_fees": platform_fees,
+        },
+        "inventory_summary": {
+            "alert_count": len(low_stock_products) + len(low_stock_materials),
+            "products": [
+                {"name": row.name, "stock_qty": row.stock_qty, "reorder_point": row.reorder_point}
+                for row in low_stock_products
+            ],
+            "materials": [
+                {
+                    "name": row.name,
+                    "brand": row.brand,
+                    "spools_in_stock": row.spools_in_stock,
+                    "reorder_point": row.reorder_point,
+                }
+                for row in low_stock_materials
+            ],
+        },
+        "printer_summary": {
+            "total_active": len(printer_rows),
+            "attention_count": len(attention_printers),
+            "printing_count": len(printing_printers),
+            "attention_printers": [
+                {"name": row.name, "status": row.monitor_status or row.status}
+                for row in attention_printers[:5]
+            ],
+        },
+        "top_products": [
+            {
+                "description": row.description,
+                "quantity": int(row.qty or 0),
+                "revenue": float(row.revenue or 0),
+            }
+            for row in top_products_rows
+        ],
+    }
+
+
+def _build_prompt(snapshot: dict, question: str | None) -> tuple[str, str]:
+    system_prompt = (
+        "You are a read-only business intelligence assistant for a 3D printing business. "
+        "Return specific, grounded operational insight. Do not invent data. "
+        "Respond with a single JSON object using this shape exactly: "
+        "{\"title\": string, \"summary\": string, "
+        "\"recommendations\": [{\"title\": string, \"detail\": string, \"priority\": \"high\"|\"medium\"|\"low\", "
+        "\"evidence\": [string], \"recommended_action\": string}], "
+        "\"risks\": [{\"title\": string, \"detail\": string, \"priority\": \"high\"|\"medium\"|\"low\", "
+        "\"evidence\": [string], \"recommended_action\": string}], "
+        "\"suggested_questions\": [string]}. "
+        "Keep recommendations and risks to at most 3 each. Use evidence strings that point to the provided metrics or entities."
+    )
+    user_prompt = (
+        "Analyze this business snapshot and produce explainable, operator-facing insights.\n\n"
+        f"Operator question: {question or 'What needs attention right now, what should we print or restock next, and where is margin at risk?'}\n\n"
+        f"Business snapshot JSON:\n{json.dumps(snapshot, indent=2)}"
+    )
+    return system_prompt, user_prompt
+
+
+async def _request_openai_chat_completion(config: ProviderConfig, system_prompt: str, user_prompt: str) -> str:
+    async with httpx.AsyncClient(timeout=45) as client:
+        response = await client.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers={"Authorization": f"Bearer {config.api_key}"},
+            json={
+                "model": config.model,
+                "temperature": 0.2,
+                "response_format": {"type": "json_object"},
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+            },
+        )
+    if response.status_code >= 400:
+        raise AIInsightProviderError(f"ChatGPT request failed with status {response.status_code}.")
+    data = response.json()
+    return data["choices"][0]["message"]["content"]
+
+
+async def _request_anthropic_message(config: ProviderConfig, system_prompt: str, user_prompt: str) -> str:
+    async with httpx.AsyncClient(timeout=45) as client:
+        response = await client.post(
+            "https://api.anthropic.com/v1/messages",
+            headers={
+                "x-api-key": config.api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json={
+                "model": config.model,
+                "max_tokens": 1200,
+                "system": system_prompt,
+                "messages": [{"role": "user", "content": user_prompt}],
+            },
+        )
+    if response.status_code >= 400:
+        raise AIInsightProviderError(f"Claude request failed with status {response.status_code}.")
+    data = response.json()
+    return "\n".join(
+        block.get("text", "")
+        for block in data.get("content", [])
+        if block.get("type") == "text"
+    )
+
+
+async def _request_xai_chat_completion(config: ProviderConfig, system_prompt: str, user_prompt: str) -> str:
+    async with httpx.AsyncClient(timeout=45) as client:
+        response = await client.post(
+            "https://api.x.ai/v1/chat/completions",
+            headers={"Authorization": f"Bearer {config.api_key}"},
+            json={
+                "model": config.model,
+                "temperature": 0.2,
+                "response_format": {"type": "json_object"},
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+            },
+        )
+    if response.status_code >= 400:
+        raise AIInsightProviderError(f"Grok request failed with status {response.status_code}.")
+    data = response.json()
+    return data["choices"][0]["message"]["content"]
+
+
+async def generate_insight_summary(db: AsyncSession, *, question: str | None) -> InsightSummaryResponse:
+    config = await _get_provider_config(db)
+    snapshot = await _build_snapshot(db)
+    system_prompt, user_prompt = _build_prompt(snapshot, question)
+
+    if config.provider == "chatgpt":
+        raw_content = await _request_openai_chat_completion(config, system_prompt, user_prompt)
+    elif config.provider == "claude":
+        raw_content = await _request_anthropic_message(config, system_prompt, user_prompt)
+    else:
+        raw_content = await _request_xai_chat_completion(config, system_prompt, user_prompt)
+
+    payload = _extract_json_object(raw_content)
+    recommendations = [
+        InsightItem(**item) for item in payload.get("recommendations", [])[:3]
+    ]
+    risks = [InsightItem(**item) for item in payload.get("risks", [])[:3]]
+
+    return InsightSummaryResponse(
+        provider=config.provider,
+        model=config.model,
+        generated_at=datetime.datetime.now(datetime.timezone.utc),
+        title=payload.get("title") or "Business insight summary",
+        summary=payload.get("summary") or "No summary returned by provider.",
+        question=question,
+        recommendations=recommendations,
+        risks=risks,
+        suggested_questions=payload.get("suggested_questions", [])[:3],
+        evidence_metrics=_build_metrics(snapshot),
+    )

--- a/backend/app/services/settings_defaults.py
+++ b/backend/app/services/settings_defaults.py
@@ -1,0 +1,24 @@
+BUSINESS_SETTINGS_DATA = [
+    ("currency", "USD", "Currency code"),
+    ("default_profit_margin_pct", "40", "Target markup on total cost"),
+    ("platform_fee_pct", "9.5", "Etsy/Amazon/etc."),
+    ("fixed_fee_per_order", "0.45", "Per-transaction fee"),
+    ("sales_tax_pct", "0", "Set if you collect tax"),
+    ("electricity_cost_per_kwh", "0.18", "Check your utility bill"),
+    ("printer_power_draw_watts", "120", "Average draw while printing"),
+    ("failure_rate_pct", "5", "Buffer for failed prints"),
+    ("packaging_cost_per_order", "1.25", "Boxes, tape, padding"),
+    ("shipping_charged_to_customer", "0", "0 = free shipping model"),
+]
+
+AI_SETTINGS_DATA = [
+    ("ai_provider", "chatgpt", "Selected insights provider: chatgpt, claude, or grok."),
+    ("ai_chatgpt_model", "gpt-4.1-mini", "OpenAI model used for read-only business insights."),
+    ("ai_chatgpt_api_key", "", "OpenAI API key for ChatGPT insights."),
+    ("ai_claude_model", "claude-3-5-sonnet-latest", "Anthropic Claude model used for read-only business insights."),
+    ("ai_claude_api_key", "", "Anthropic API key for Claude insights."),
+    ("ai_grok_model", "grok-3-mini", "xAI Grok model used for read-only business insights."),
+    ("ai_grok_api_key", "", "xAI API key for Grok insights."),
+]
+
+SETTINGS_DATA = BUSINESS_SETTINGS_DATA + AI_SETTINGS_DATA

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -27,6 +27,7 @@ from app.models.user import User
 from app.models.camera import Camera  # noqa: F401
 from app.models.printer_history_event import PrinterHistoryEvent  # noqa: F401
 from app.services.accounting_service import seed_chart_of_accounts
+from app.services.settings_defaults import SETTINGS_DATA
 
 TEST_DB_URL = "sqlite+aiosqlite:///./test.db"
 
@@ -109,19 +110,7 @@ async def user_headers(client: AsyncClient, db_session: AsyncSession):
 
 @pytest_asyncio.fixture
 async def seed_settings(db_session: AsyncSession):
-    settings_data = [
-        ("currency", "USD", "Currency"),
-        ("default_profit_margin_pct", "40", "Target markup"),
-        ("platform_fee_pct", "9.5", "Platform fee"),
-        ("fixed_fee_per_order", "0.45", "Per-transaction fee"),
-        ("sales_tax_pct", "0", "Sales tax"),
-        ("electricity_cost_per_kwh", "0.18", "Electricity rate"),
-        ("printer_power_draw_watts", "120", "Printer power"),
-        ("failure_rate_pct", "5", "Failure buffer"),
-        ("packaging_cost_per_order", "1.25", "Packaging cost"),
-        ("shipping_charged_to_customer", "0", "Shipping model"),
-    ]
-    for key, value, notes in settings_data:
+    for key, value, notes in SETTINGS_DATA:
         db_session.add(Setting(key=key, value=value, notes=notes))
     await db_session.commit()
 

--- a/backend/tests/test_api_insights.py
+++ b/backend/tests/test_api_insights.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_insights_status_reports_selected_provider(client, seed_settings, auth_headers):
+    resp = await client.get("/api/v1/insights/status", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["provider"] == "chatgpt"
+    assert data["configured"] is False
+    assert set(data["available_providers"]) == {"chatgpt", "claude", "grok"}
+
+
+@pytest.mark.asyncio
+async def test_insights_summary_requires_configuration(client, seed_settings, auth_headers):
+    resp = await client.post("/api/v1/insights/summary", headers=auth_headers, json={})
+    assert resp.status_code == 409
+    assert "Configure an API key" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_insights_summary_returns_generated_payload(monkeypatch, client, seed_settings, auth_headers):
+    async def fake_generate(_db, *, question):
+        from app.schemas.insight import InsightEvidenceMetric, InsightItem, InsightSummaryResponse
+
+        return InsightSummaryResponse(
+            provider="chatgpt",
+            model="gpt-4.1-mini",
+            generated_at=datetime.datetime(2026, 4, 13, 12, 0, tzinfo=datetime.timezone.utc),
+            title="Weekly business pulse",
+            summary="Sales are healthy, but low stock needs attention.",
+            question=question,
+            recommendations=[
+                InsightItem(
+                    title="Restock your top seller",
+                    detail="Desk Dragon stock is drifting toward its reorder point.",
+                    priority="high",
+                    evidence=["Low stock alerts", "Gross sales"],
+                    recommended_action="Queue a replenishment run before the next event.",
+                )
+            ],
+            risks=[],
+            suggested_questions=["Which SKUs are draining margin?"],
+            evidence_metrics=[InsightEvidenceMetric(key="gross_sales", label="Gross sales", value="$1200.00")],
+        )
+
+    monkeypatch.setattr("app.api.v1.endpoints.insights.generate_insight_summary", fake_generate)
+
+    resp = await client.post(
+        "/api/v1/insights/summary",
+        headers=auth_headers,
+        json={"question": "What needs attention before the craft fair?"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["title"] == "Weekly business pulse"
+    assert data["question"] == "What needs attention before the craft fair?"
+    assert data["provider"] == "chatgpt"

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -4,26 +4,27 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_list_settings(client, seed_settings):
-    resp = await client.get("/api/v1/settings")
+async def test_list_settings(client, seed_settings, auth_headers):
+    resp = await client.get("/api/v1/settings", headers=auth_headers)
     assert resp.status_code == 200
     data = resp.json()
-    assert len(data) == 10
+    assert len(data) >= 17
     keys = {s["key"] for s in data}
     assert "currency" in keys
     assert "platform_fee_pct" in keys
+    assert "ai_provider" in keys
 
 
 @pytest.mark.asyncio
-async def test_get_setting(client, seed_settings):
-    resp = await client.get("/api/v1/settings/currency")
+async def test_get_setting(client, seed_settings, auth_headers):
+    resp = await client.get("/api/v1/settings/currency", headers=auth_headers)
     assert resp.status_code == 200
     assert resp.json()["value"] == "USD"
 
 
 @pytest.mark.asyncio
-async def test_get_setting_not_found(client, seed_settings):
-    resp = await client.get("/api/v1/settings/nonexistent")
+async def test_get_setting_not_found(client, seed_settings, auth_headers):
+    resp = await client.get("/api/v1/settings/nonexistent", headers=auth_headers)
     assert resp.status_code == 404
 
 
@@ -64,3 +65,9 @@ async def test_update_setting_requires_auth(client, seed_settings):
         "/api/v1/settings/currency", json={"value": "EUR"}
     )
     assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_settings_requires_admin(client, seed_settings, user_headers):
+    resp = await client.get("/api/v1/settings", headers=user_headers)
+    assert resp.status_code == 403

--- a/docs/ai_insights.md
+++ b/docs/ai_insights.md
@@ -1,0 +1,57 @@
+# AI Insights
+
+Read-only business intelligence for issue `#112`.
+
+## What This Adds
+
+- A dedicated `/insights` workspace instead of redirecting users into the reports stack.
+- Admin-configurable LLM provider selection for `ChatGPT`, `Claude`, or `Grok`.
+- A read-only insight summary flow grounded in app data from jobs, sales, inventory, materials, and printer status.
+- A separate provider status endpoint so non-admin users can see whether Insights is available without exposing secrets.
+
+## UX Intent
+
+This slice follows the repo UX laws called out in `AGENTS.md`:
+
+- Jakob's Law: `Insights` now behaves like a distinct analysis surface, not a disguised reports redirect.
+- Hick's Law: operators start from one focused question plus a few guided presets instead of a crowded filter wall.
+- Law of Common Region: AI interpretation is visually separated from source-of-truth evidence metrics.
+- Doherty Threshold: the page shows immediate loading and generation feedback for async provider calls.
+
+## Provider Configuration
+
+Provider configuration lives in Admin Settings:
+
+- `ai_provider`
+- `ai_chatgpt_model`
+- `ai_chatgpt_api_key`
+- `ai_claude_model`
+- `ai_claude_api_key`
+- `ai_grok_model`
+- `ai_grok_api_key`
+
+Only admins can read or update `/api/v1/settings` because those records now include API secrets.
+
+## API Surface
+
+- `GET /api/v1/insights/status`
+  - Authenticated
+  - Returns the active provider, model, configured state, and explanatory note
+  - Does not return API keys
+- `POST /api/v1/insights/summary`
+  - Authenticated
+  - Accepts an optional focused natural-language question
+  - Returns a read-only summary, recommendations, risks, suggested follow-up questions, and evidence metrics
+
+## Safety Boundary
+
+- Insights are read-only.
+- No autonomous writes are performed.
+- AI output is framed as recommendation, not source-of-truth record mutation.
+- Business actions still require explicit operator action in the existing transactional workflows.
+
+## Validation
+
+- `python3 -m pytest backend/tests/test_api_settings.py backend/tests/test_api_insights.py -q`
+- `cd frontend && npm test`
+- `cd frontend && npm run build`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ const SalesChannelsPage = lazy(() => import('@/pages/SalesChannelsPage'));
 const POSPage = lazy(() => import('@/pages/POSPage'));
 const CalculatorPage = lazy(() => import('@/pages/CalculatorPage'));
 const OrdersPage = lazy(() => import('@/pages/OrdersPage'));
+const InsightsPage = lazy(() => import('@/pages/InsightsPage'));
 const ReportsLayout = lazy(() => import('@/pages/reports/ReportsLayout'));
 const InventoryReportPage = lazy(() => import('@/pages/reports/InventoryReportPage'));
 const SalesReportPage = lazy(() => import('@/pages/reports/SalesReportPage'));
@@ -122,7 +123,7 @@ export default function App() {
                 <Route path="/orders/jobs/:id/edit" element={<JobFormPage />} />
                 <Route path="/orders/customers" element={<CustomersPage />} />
 
-                <Route path="/insights" element={<Navigate to="/reports/inventory" replace />} />
+                <Route path="/insights" element={<InsightsPage />} />
                 <Route path="/insights/reports" element={<Navigate to="/reports/inventory" replace />} />
 
                 <Route path="/jobs" element={<JobsPage />} />

--- a/frontend/src/components/layout/workspaces.ts
+++ b/frontend/src/components/layout/workspaces.ts
@@ -121,13 +121,14 @@ export const workspaces: WorkspaceDefinition[] = [
   {
     key: 'insights',
     label: 'Insights',
-    description: 'Reports, trends, and financial visibility.',
+    description: 'AI summaries, trends, and read-only recommendations.',
     to: '/insights',
     icon: BarChart3,
     roles: ['admin', 'analyst', 'general'],
     matchPrefixes: ['/insights', '/reports'],
     localLinks: [
-      { to: '/insights', label: 'Reports', matchPrefixes: ['/insights', '/reports'] },
+      { to: '/insights', label: 'AI Summary', matchPrefixes: ['/insights'] },
+      { to: '/reports/inventory', label: 'Reports', matchPrefixes: ['/reports'] },
     ],
   },
   {

--- a/frontend/src/pages/InsightsPage.test.tsx
+++ b/frontend/src/pages/InsightsPage.test.tsx
@@ -1,0 +1,133 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import InsightsPage from '@/pages/InsightsPage';
+import api from '@/api/client';
+
+const toastError = vi.fn();
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+vi.mock('@/api/client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+vi.mock('@/store/auth', () => ({
+  useAuthStore: () => ({
+    user: { id: 'admin-1', role: 'admin' },
+  }),
+}));
+
+const apiGet = api.get as unknown as Mock;
+const apiPost = api.post as unknown as Mock;
+
+function renderInsightsPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <InsightsPage />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('InsightsPage', () => {
+  beforeEach(() => {
+    toastError.mockReset();
+    apiGet.mockReset();
+    apiPost.mockReset();
+  });
+
+  it('surfaces admin configuration guidance when no provider is configured', async () => {
+    apiGet.mockResolvedValue({
+      data: {
+        provider: 'chatgpt',
+        model: 'gpt-4.1-mini',
+        configured: false,
+        available_providers: ['chatgpt', 'claude', 'grok'],
+        note: 'Read-only recommendations only.',
+      },
+    });
+
+    renderInsightsPage();
+
+    expect(await screen.findByText('Read-only business intelligence')).toBeInTheDocument();
+    expect(screen.getByText(/Configure a provider in/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Admin Settings' })).toHaveAttribute('href', '/admin/settings');
+    expect(screen.getByRole('button', { name: 'Generate Insight Summary' })).toBeDisabled();
+  });
+
+  it('generates an insight summary from the focused question flow', async () => {
+    const user = userEvent.setup();
+    apiGet.mockResolvedValue({
+      data: {
+        provider: 'claude',
+        model: 'claude-3-5-sonnet-latest',
+        configured: true,
+        available_providers: ['chatgpt', 'claude', 'grok'],
+        note: 'Read-only recommendations only.',
+      },
+    });
+    apiPost.mockResolvedValue({
+      data: {
+        provider: 'claude',
+        model: 'claude-3-5-sonnet-latest',
+        generated_at: '2026-04-13T12:00:00Z',
+        title: 'Craft fair readiness',
+        summary: 'Restock Desk Dragon and review margin on low-volume add-ons.',
+        question: 'What should I print more of before the next craft fair?',
+        recommendations: [
+          {
+            title: 'Print more Desk Dragon',
+            detail: 'Demand is outpacing on-hand stock.',
+            priority: 'high',
+            evidence: ['Low stock alerts', 'Gross sales'],
+            recommended_action: 'Queue a replenishment run this week.',
+          },
+        ],
+        risks: [],
+        suggested_questions: ['Which products have weak margins?'],
+        evidence_metrics: [
+          { key: 'gross_sales', label: 'Gross sales', value: '$1200.00' },
+        ],
+        read_only: true,
+      },
+    });
+
+    renderInsightsPage();
+
+    await screen.findByText('Read-only business intelligence');
+    await user.type(
+      screen.getByPlaceholderText('Example: What should I print more of before the next market and what inventory is at risk?'),
+      'What should I print more of before the next craft fair?'
+    );
+    await user.click(screen.getByRole('button', { name: 'Generate Insight Summary' }));
+
+    await waitFor(() => {
+      expect(apiPost).toHaveBeenCalledWith('/insights/summary', {
+        question: 'What should I print more of before the next craft fair?',
+      });
+    });
+
+    expect(await screen.findByText('Craft fair readiness')).toBeInTheDocument();
+    expect(screen.getByText('Print more Desk Dragon')).toBeInTheDocument();
+    expect(screen.getByText('Which products have weak margins?')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -1,0 +1,263 @@
+import { useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { Bot, BrainCircuit, LoaderCircle, ShieldCheck, Sparkles } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import { useAuthStore } from '@/store/auth';
+import type { AIInsightStatus, AIInsightSummary } from '@/types';
+
+const presetQuestions = [
+  'What needs attention right now?',
+  'Which products should we print or restock next?',
+  'Where is margin weak or slipping?',
+];
+
+function PriorityBadge({ value }: { value: 'high' | 'medium' | 'low' }) {
+  const classes =
+    value === 'high'
+      ? 'border-red-300 bg-red-50 text-red-800'
+      : value === 'medium'
+        ? 'border-amber-300 bg-amber-50 text-amber-800'
+        : 'border-emerald-300 bg-emerald-50 text-emerald-800';
+
+  return (
+    <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-wide ${classes}`}>
+      {value}
+    </span>
+  );
+}
+
+export default function InsightsPage() {
+  const { user } = useAuthStore();
+  const [question, setQuestion] = useState('');
+
+  const { data: status, isLoading: statusLoading } = useQuery<AIInsightStatus>({
+    queryKey: ['insights', 'status'],
+    queryFn: () => api.get('/insights/status').then((r) => r.data),
+  });
+
+  const summaryMutation = useMutation({
+    mutationFn: async (nextQuestion: string | null) =>
+      api.post('/insights/summary', { question: nextQuestion || null }).then((r) => r.data as AIInsightSummary),
+    onError: (err: any) => {
+      toast.error(err.response?.data?.detail || 'Failed to generate insights');
+    },
+  });
+
+  const isAdmin = user?.role === 'admin';
+  const summary = summaryMutation.data;
+
+  const handleGenerate = async (nextQuestion?: string) => {
+    const selected = nextQuestion ?? question;
+    if (!status?.configured) {
+      toast.error('Configure an AI provider in Admin Settings before generating insights.');
+      return;
+    }
+    await summaryMutation.mutateAsync(selected.trim() || null);
+  };
+
+  if (statusLoading) {
+    return <div className="space-y-6"><div className="h-12 w-72 animate-pulse rounded-2xl bg-card" /><div className="h-64 animate-pulse rounded-3xl bg-card" /></div>;
+  }
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-2xl">
+            <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+              <BrainCircuit className="h-4 w-4" />
+              AI Insights
+            </div>
+            <h1 className="mt-4 text-3xl font-bold">Read-only business intelligence</h1>
+            <p className="mt-3 text-base text-muted-foreground">
+              Ask for explainable recommendations grounded in your app data. This surface is analysis only: no autonomous writes, no silent pricing changes, and no hidden inventory actions.
+            </p>
+          </div>
+          <div className="rounded-[1.5rem] border border-border bg-background/80 p-4 text-sm">
+            <p className="font-semibold text-foreground">Active provider</p>
+            <p className="mt-2 text-lg font-semibold capitalize">{status?.provider || 'Unavailable'}</p>
+            <p className="text-muted-foreground">{status?.model || 'No model selected'}</p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {status?.available_providers.map((provider) => {
+                const isActive = provider === status.provider;
+                return (
+                  <span
+                    key={provider}
+                    className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-wide ${
+                      isActive
+                        ? 'border-primary/30 bg-primary/10 text-primary'
+                        : 'border-border bg-card text-muted-foreground'
+                    }`}
+                  >
+                    {provider}
+                  </span>
+                );
+              })}
+            </div>
+            <div className="mt-3 flex items-start gap-2 text-xs text-muted-foreground">
+              <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{status?.note}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+        <div className="flex flex-col gap-4">
+          <div>
+            <h2 className="text-xl font-semibold">Ask a focused question</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Hick&apos;s Law applies here: start from one clear question instead of dumping every business concern into one prompt.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {presetQuestions.map((item) => (
+              <button
+                key={item}
+                type="button"
+                onClick={() => {
+                  setQuestion(item);
+                  void handleGenerate(item);
+                }}
+                className="rounded-full border border-border px-4 py-2 text-sm font-medium transition-colors hover:border-primary/35 hover:bg-primary/5"
+              >
+                {item}
+              </button>
+            ))}
+          </div>
+
+          <textarea
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            rows={4}
+            placeholder="Example: What should I print more of before the next market and what inventory is at risk?"
+            className="w-full rounded-[1.5rem] border border-input bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={() => void handleGenerate()}
+              disabled={summaryMutation.isPending || !status?.configured}
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
+            >
+              {summaryMutation.isPending ? <LoaderCircle className="h-5 w-5 animate-spin" /> : <Sparkles className="h-5 w-5" />}
+              {summaryMutation.isPending ? 'Generating insights...' : 'Generate Insight Summary'}
+            </button>
+            {!status?.configured ? (
+              <p className="text-sm text-muted-foreground">
+                {isAdmin ? (
+                  <>
+                    Configure a provider in <Link to="/admin/settings" className="text-primary no-underline hover:underline">Admin Settings</Link> first.
+                  </>
+                ) : (
+                  'An admin must configure an AI provider before this workspace can generate insights.'
+                )}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      {summary ? (
+        <>
+          <section className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+            <div className="flex items-start gap-4">
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+                <Bot className="h-6 w-6" />
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                  {summary.provider} • {summary.model}
+                </p>
+                <h2 className="mt-2 text-2xl font-semibold">{summary.title}</h2>
+                <p className="mt-3 text-base text-muted-foreground">{summary.summary}</p>
+                <p className="mt-3 text-xs text-muted-foreground">
+                  Generated {new Date(summary.generated_at).toLocaleString()}
+                </p>
+                {summary.question ? (
+                  <p className="mt-4 text-sm text-muted-foreground">Question: {summary.question}</p>
+                ) : null}
+              </div>
+            </div>
+          </section>
+
+          <section className="grid gap-6 xl:grid-cols-2">
+            <div className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+              <h3 className="text-xl font-semibold">Recommendations</h3>
+              <div className="mt-4 space-y-4">
+                {summary.recommendations.length ? summary.recommendations.map((item, index) => (
+                  <article key={`${item.title}-${index}`} className="rounded-[1.5rem] border border-border bg-background/80 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <h4 className="font-semibold">{item.title}</h4>
+                      <PriorityBadge value={item.priority} />
+                    </div>
+                    <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
+                    {item.recommended_action ? <p className="mt-3 text-sm font-medium text-foreground">Action: {item.recommended_action}</p> : null}
+                    {item.evidence.length ? <p className="mt-3 text-xs text-muted-foreground">Evidence: {item.evidence.join(' • ')}</p> : null}
+                  </article>
+                )) : <p className="text-sm text-muted-foreground">No recommendations returned.</p>}
+              </div>
+            </div>
+
+            <div className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+              <h3 className="text-xl font-semibold">Risks</h3>
+              <div className="mt-4 space-y-4">
+                {summary.risks.length ? summary.risks.map((item, index) => (
+                  <article key={`${item.title}-${index}`} className="rounded-[1.5rem] border border-border bg-background/80 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <h4 className="font-semibold">{item.title}</h4>
+                      <PriorityBadge value={item.priority} />
+                    </div>
+                    <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
+                    {item.recommended_action ? <p className="mt-3 text-sm font-medium text-foreground">Action: {item.recommended_action}</p> : null}
+                    {item.evidence.length ? <p className="mt-3 text-xs text-muted-foreground">Evidence: {item.evidence.join(' • ')}</p> : null}
+                  </article>
+                )) : <p className="text-sm text-muted-foreground">No risks returned.</p>}
+              </div>
+            </div>
+          </section>
+
+          <section className="grid gap-6 xl:grid-cols-[1.4fr_1fr]">
+            <div className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+              <h3 className="text-xl font-semibold">Evidence metrics</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Jakob&apos;s Law and Common Region: the recommendation copy stays separate from the source-of-truth numbers it references.
+              </p>
+              <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                {summary.evidence_metrics.map((metric) => (
+                  <div key={metric.key} className="rounded-[1.3rem] border border-border bg-background/80 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">{metric.label}</p>
+                    <p className="mt-2 text-xl font-semibold">{metric.value}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+              <h3 className="text-xl font-semibold">Suggested follow-ups</h3>
+              <div className="mt-4 space-y-3">
+                {summary.suggested_questions.length ? summary.suggested_questions.map((item) => (
+                  <button
+                    key={item}
+                    type="button"
+                    onClick={() => {
+                      setQuestion(item);
+                      void handleGenerate(item);
+                    }}
+                    className="block w-full rounded-[1.3rem] border border-border bg-background/80 px-4 py-3 text-left text-sm font-medium transition-colors hover:border-primary/35 hover:bg-primary/5"
+                  >
+                    {item}
+                  </button>
+                )) : <p className="text-sm text-muted-foreground">No follow-up questions returned.</p>}
+              </div>
+            </div>
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/SettingsPage.test.tsx
+++ b/frontend/src/pages/admin/SettingsPage.test.tsx
@@ -1,0 +1,103 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import SettingsPage from '@/pages/admin/SettingsPage';
+import api from '@/api/client';
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+vi.mock('@/api/client', () => ({
+  default: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+const apiGet = api.get as unknown as Mock;
+const apiPut = api.put as unknown as Mock;
+
+const settingsResponse = [
+  { key: 'currency', value: 'USD', notes: 'Currency code' },
+  { key: 'default_profit_margin_pct', value: '40', notes: 'Target markup on total cost' },
+  { key: 'platform_fee_pct', value: '9.5', notes: 'Etsy/Amazon/etc.' },
+  { key: 'fixed_fee_per_order', value: '0.45', notes: 'Per-transaction fee' },
+  { key: 'sales_tax_pct', value: '0', notes: 'Set if you collect tax' },
+  { key: 'electricity_cost_per_kwh', value: '0.18', notes: 'Check your utility bill' },
+  { key: 'printer_power_draw_watts', value: '120', notes: 'Average draw while printing' },
+  { key: 'failure_rate_pct', value: '5', notes: 'Buffer for failed prints' },
+  { key: 'packaging_cost_per_order', value: '1.25', notes: 'Boxes, tape, padding' },
+  { key: 'shipping_charged_to_customer', value: '0', notes: '0 = free shipping model' },
+  { key: 'ai_provider', value: 'chatgpt', notes: 'Selected insights provider: chatgpt, claude, or grok.' },
+  { key: 'ai_chatgpt_model', value: 'gpt-4.1-mini', notes: 'OpenAI model used for read-only business insights.' },
+  { key: 'ai_chatgpt_api_key', value: '', notes: 'OpenAI API key for ChatGPT insights.' },
+  { key: 'ai_claude_model', value: 'claude-3-5-sonnet-latest', notes: 'Anthropic Claude model used for read-only business insights.' },
+  { key: 'ai_claude_api_key', value: '', notes: 'Anthropic API key for Claude insights.' },
+  { key: 'ai_grok_model', value: 'grok-3-mini', notes: 'xAI Grok model used for read-only business insights.' },
+  { key: 'ai_grok_api_key', value: '', notes: 'xAI API key for Grok insights.' },
+];
+
+function renderSettingsPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SettingsPage />
+    </QueryClientProvider>
+  );
+}
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    toastSuccess.mockReset();
+    toastError.mockReset();
+    apiGet.mockReset();
+    apiPut.mockReset();
+    apiGet.mockResolvedValue({ data: settingsResponse });
+  });
+
+  it('lets admins switch the active AI provider and save its model plus API key', async () => {
+    const user = userEvent.setup();
+    apiPut.mockResolvedValue({ data: [] });
+
+    renderSettingsPage();
+
+    await screen.findByText('AI Intelligence');
+    await user.click(screen.getByRole('button', { name: /Claude/i }));
+
+    const modelInput = screen.getByDisplayValue('claude-3-5-sonnet-latest');
+    await user.clear(modelInput);
+    await user.type(modelInput, 'claude-3-7-sonnet-latest');
+
+    const apiKeyInput = screen.getByPlaceholderText('Paste API key');
+    await user.type(apiKeyInput, 'claude-secret-key');
+
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    await waitFor(() => {
+      expect(apiPut).toHaveBeenCalledWith('/settings/bulk', {
+        settings: expect.objectContaining({
+          ai_provider: 'claude',
+          ai_claude_model: 'claude-3-7-sonnet-latest',
+          ai_claude_api_key: 'claude-secret-key',
+        }),
+      });
+    });
+
+    expect(toastSuccess).toHaveBeenCalledWith('Settings saved');
+  });
+});

--- a/frontend/src/pages/admin/SettingsPage.tsx
+++ b/frontend/src/pages/admin/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Settings, Save } from 'lucide-react';
+import { Bot, KeyRound, Settings, Save } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import type { Setting } from '@/types';
@@ -23,6 +23,12 @@ const groups: Record<string, { keys: string[]; description: string }> = {
     description: 'Packaging and shipping cost settings',
   },
 };
+
+const aiProviders = [
+  { value: 'chatgpt', label: 'ChatGPT', modelKey: 'ai_chatgpt_model', apiKey: 'ai_chatgpt_api_key' },
+  { value: 'claude', label: 'Claude', modelKey: 'ai_claude_model', apiKey: 'ai_claude_api_key' },
+  { value: 'grok', label: 'Grok', modelKey: 'ai_grok_model', apiKey: 'ai_grok_api_key' },
+] as const;
 
 const formatLabel = (key: string) =>
   key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
@@ -67,6 +73,31 @@ export default function SettingsPage() {
   };
 
   const settingsMap = new Map(settings?.map((s) => [s.key, s]));
+  const activeProvider = values.ai_provider || 'chatgpt';
+  const activeProviderConfig = aiProviders.find((provider) => provider.value === activeProvider) || aiProviders[0];
+
+  const renderSettingInput = (key: string, helperLabel?: string) => {
+    const setting = settingsMap.get(key);
+    if (!setting) return null;
+    const isSecret = key.endsWith('_api_key');
+    return (
+      <div key={key} className="space-y-2">
+        <div>
+          <p className="font-medium text-sm">{helperLabel || formatLabel(key)}</p>
+          {setting.notes && (
+            <p className="text-xs text-muted-foreground">{setting.notes}</p>
+          )}
+        </div>
+        <input
+          type={isSecret ? 'password' : 'text'}
+          value={values[key] ?? ''}
+          onChange={(e) => update(key, e.target.value)}
+          placeholder={isSecret ? 'Paste API key' : undefined}
+          className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring font-mono text-sm"
+        />
+      </div>
+    );
+  };
 
   return (
     <div>
@@ -98,6 +129,61 @@ export default function SettingsPage() {
         </div>
       ) : (
         <div className="space-y-6">
+          <div className="bg-card border border-border rounded-lg p-6">
+            <div className="mb-5 flex items-start gap-3">
+              <div className="rounded-2xl bg-primary/10 p-3 text-primary">
+                <Bot className="h-6 w-6" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold">AI Intelligence</h2>
+                <p className="text-sm text-muted-foreground">
+                  Configure one supported provider for the read-only Insights workspace. Keep the choice obvious, the model explicit, and the secrets scoped to admins only.
+                </p>
+              </div>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-3">
+              {aiProviders.map((provider) => {
+                const isActive = activeProvider === provider.value;
+                return (
+                  <button
+                    key={provider.value}
+                    type="button"
+                    onClick={() => update('ai_provider', provider.value)}
+                    className={`rounded-2xl border p-4 text-left transition-colors ${
+                      isActive
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border bg-background hover:border-primary/30'
+                    }`}
+                  >
+                    <p className="font-semibold">{provider.label}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {values[provider.modelKey] || 'No model configured'}
+                    </p>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="mt-6 rounded-2xl border border-border bg-background/70 p-5">
+              <div className="mb-4 flex items-start gap-3">
+                <div className="rounded-xl bg-primary/10 p-2 text-primary">
+                  <KeyRound className="h-4 w-4" />
+                </div>
+                <div>
+                  <h3 className="font-semibold">{aiProviders.find((provider) => provider.value === activeProviderConfig.value)?.label} configuration</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Progressive disclosure for Hick&apos;s Law: edit the active provider here, switch providers when you want to configure a different one.
+                  </p>
+                </div>
+              </div>
+              <div className="grid gap-4 md:grid-cols-2">
+                {renderSettingInput(activeProviderConfig.modelKey, 'Model')}
+                {renderSettingInput(activeProviderConfig.apiKey, 'API Key')}
+              </div>
+            </div>
+          </div>
+
           {Object.entries(groups).map(([group, { keys, description }]) => (
             <div key={group} className="bg-card border border-border rounded-lg p-6">
               <div className="mb-4">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,42 @@ export interface Setting {
   notes: string | null;
 }
 
+export interface AIInsightStatus {
+  provider: 'chatgpt' | 'claude' | 'grok';
+  model: string;
+  configured: boolean;
+  available_providers: Array<'chatgpt' | 'claude' | 'grok'>;
+  note: string;
+}
+
+export interface AIInsightItem {
+  title: string;
+  detail: string;
+  priority: 'high' | 'medium' | 'low';
+  evidence: string[];
+  recommended_action: string | null;
+}
+
+export interface AIInsightMetric {
+  key: string;
+  label: string;
+  value: string;
+}
+
+export interface AIInsightSummary {
+  provider: 'chatgpt' | 'claude' | 'grok';
+  model: string;
+  generated_at: string;
+  title: string;
+  summary: string;
+  question: string | null;
+  recommendations: AIInsightItem[];
+  risks: AIInsightItem[];
+  suggested_questions: string[];
+  evidence_metrics: AIInsightMetric[];
+  read_only: boolean;
+}
+
 export interface Material {
   id: string;
   name: string;


### PR DESCRIPTION
Closes #112

## Summary
- add a dedicated read-only insights API and UI instead of redirecting Insights into reports
- let admins configure and switch the active LLM provider between ChatGPT, Claude, and Grok
- document the provider workflow and add backend/frontend coverage for the new slice

## Validation
- .venv/bin/python -m pytest backend/tests/test_api_settings.py backend/tests/test_api_insights.py -q
- cd frontend && npm test -- --run src/pages/InsightsPage.test.tsx src/pages/admin/SettingsPage.test.tsx src/pages/POSPage.test.tsx
- cd frontend && npm run build