### PR TITLE
docs: harden fresh-start bootstrap for #136

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ Full-stack web application for managing a 3D printing business — job costing, 
 # Clone and start (development)
 git clone <repo-url>
 cd 3d-print-sales
-cp .env.example .env
-# Replace placeholder secrets before first run
-docker compose up -d
+./scripts/bootstrap-env.sh local
+docker compose up -d --build
 
 # Services
 # Frontend:  http://localhost:5173
@@ -29,10 +28,13 @@ docker compose up -d
 # ReDoc:     http://localhost:8000/api/v1/redoc
 ```
 
+If you prefer to set values manually, copy `.env.example` to `.env` and replace the tracked placeholder secrets before first run.
+
 ### Production Deployment
 
 ```bash
-# Production uses nginx on port 80 with API proxy
+# Generate a server env file, then point compose at it
+./scripts/bootstrap-env.sh web01 --output /srv/3d-print-sales/env/web01.env
 docker compose -f docker-compose.prod.yml up -d --build
 
 # Access at http://localhost
@@ -41,6 +43,12 @@ docker compose -f docker-compose.prod.yml up -d --build
 ### Admin Seed Login
 
 The backend seeds an admin user from `ADMIN_EMAIL` and `ADMIN_PASSWORD`. Set those values in your local `.env` before first run. The backend now refuses to start while tracked placeholder secrets remain in place.
+
+### Start Here
+
+- [Fresh Start Guide](docs/getting_started.md) - validated local bootstrap and `web01` deployment path
+- [Docs Hub](docs/index.md) - task-oriented documentation entry point
+- [Reference Map](docs/reference/index.md) - authoritative technical reference index
 
 ## Project Structure
 
@@ -257,6 +265,13 @@ docker compose up -d
 ## CI
 
 Baseline repository CI now lives in [`.github/workflows/ci.yml`](./.github/workflows/ci.yml).
+
+## Deployment Docs
+
+- [Fresh Start Guide](docs/getting_started.md)
+- [web01 Compose Deployment](docs/deployment_web01_compose.md)
+- [web01 Environment and Storage](docs/deployment_web01_env_and_storage.md)
+- [web01 Runbook](docs/deployment_web01_runbook.md)
 
 It runs on pull requests and pushes to `main` with separate jobs for:
 - backend tests via `python -m pytest backend/tests -q`

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # ---------- Base ----------
-FROM python:3.12-slim AS base
+FROM python:3.13-slim AS base
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U printuser -d printsales"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-printuser} -d ${DB_NAME:-printsales}"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Docs Pointer
+
+This file exists for compatibility with older links.
+
+- Use [Documentation Hub](index.md) for task-oriented navigation.
+- Use [Technical Reference Map](reference/index.md) for the maintained source-of-truth reference path.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,141 @@
+# Fresh Start Guide
+
+This is the canonical fresh-start setup path for the repository.
+
+Use this guide when you are standing the app up from a clean machine or validating that the repository is deployable without maintainer-only knowledge.
+
+## Prerequisites
+
+Local development path:
+
+- Docker Desktop or Docker Engine with the Compose plugin
+- Git
+
+Native validation path:
+
+- Python `3.13`
+- Node `22`
+- PostgreSQL `16`
+
+Python `3.14` is not currently a supported backend interpreter for this repository. The pinned `pydantic-core` build chain currently tops out at Python `3.13`, so use the repo's `.python-version` or an explicit `python3.13` install for native backend work.
+
+## Fastest Local Bring-Up
+
+Generate a usable development env file from the tracked template:
+
+```bash
+./scripts/bootstrap-env.sh local
+```
+
+That creates `.env` with randomized values for:
+
+- `DB_PASSWORD`
+- `SECRET_KEY`
+- `ADMIN_PASSWORD`
+
+Then start the stack:
+
+```bash
+docker compose up -d --build
+```
+
+Expected local URLs:
+
+- frontend: `http://localhost:5173`
+- backend health: `http://localhost:8000/health`
+- swagger: `http://localhost:8000/api/v1/docs`
+
+Notes:
+
+- the backend seeds an admin user from `ADMIN_EMAIL` and `ADMIN_PASSWORD` on first startup
+- development startup uses `AUTO_CREATE_SCHEMA=true`, so the app creates tables automatically and then runs seed logic
+- the development database healthcheck now respects custom `DB_USER` and `DB_NAME` values from `.env`
+
+## Manual Local Env Setup
+
+If you prefer to edit the env file yourself:
+
+```bash
+cp .env.example .env
+```
+
+Before startup, replace the tracked placeholder values for:
+
+- `DATABASE_URL` or the `DB_*` fields
+- `SECRET_KEY`
+- `ADMIN_PASSWORD`
+
+The backend refuses to start while tracked placeholder secrets remain in place.
+
+## Native Backend And Frontend Validation
+
+Backend:
+
+```bash
+python3.13 -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+python -m pytest backend/tests -q
+```
+
+Frontend:
+
+```bash
+cd frontend
+npm ci
+npm test
+npm run build
+```
+
+## Production-Like Compose Flow
+
+The maintained production target in this repository is `web01`, which runs from `/srv/3d-print-sales/repo`.
+
+Generate a server env file from the production example:
+
+```bash
+./scripts/bootstrap-env.sh web01 --output /srv/3d-print-sales/env/web01.env
+```
+
+Then run compose with that env file:
+
+```bash
+ENV_FILE=/srv/3d-print-sales/env/web01.env docker compose -f docker-compose.prod.yml up -d --build
+```
+
+The canonical wrapper used on `web01` is:
+
+```bash
+cd /srv/3d-print-sales/repo
+scripts/web01-compose.sh up -d --build
+```
+
+Production notes:
+
+- production compose requires `ENV_FILE`
+- production startup is migration-driven; it does not rely on `create_all()`
+- production frontend serves nginx on `FRONTEND_HTTP_PORT` and proxies `/api/v1` to the backend container
+
+## Post-Start Validation
+
+Local validation:
+
+```bash
+docker compose ps
+curl -fsS http://127.0.0.1:8000/health
+```
+
+`web01` validation:
+
+```bash
+cd /srv/3d-print-sales/repo
+scripts/web01-compose.sh ps
+curl -fsS http://127.0.0.1/health
+curl -I http://127.0.0.1/
+```
+
+## Where To Go Next
+
+- [Documentation Hub](index.md)
+- [Technical Reference Map](reference/index.md)
+- [web01 Runbook](deployment_web01_runbook.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,49 @@
+# Documentation Hub
+
+Start here if you need the maintained documentation path for this repository.
+
+## Getting Started
+
+- [Fresh Start Guide](getting_started.md) - local bootstrap, validation, and the `web01` deployment path
+- [Compatibility Pointer](README.md) - short pointer for older `docs/README.md` links
+
+## Deployment And Operations
+
+- [web01 Compose Deployment](deployment_web01_compose.md)
+- [web01 Environment and Storage](deployment_web01_env_and_storage.md)
+- [web01 Ingress Notes](deployment_web01_ingress.md)
+- [web01 Runbook](deployment_web01_runbook.md)
+- [web01 Audit](deployment_web01_audit.md)
+- [web01 Deployment Plan](deployment_web01_plan.md)
+
+## Feature And Workflow Guides
+
+- [Camera Setup](camera-setup.md)
+- [Shipping Label Printing](shipping_label_printing.md)
+- [AI Insights](ai_insights.md)
+- [POS Barcode Scanning](pos_barcode_scanning.md)
+- [Quotes Workflow](quotes_workflow.md)
+- [Scrap And Waste Workflows](scrap_and_waste_workflows.md)
+- [Refund And Adjustment Approvals](refund_and_adjustment_approvals.md)
+- [Marketplace Settlements](marketplace_settlements.md)
+
+## Accounting And Reporting
+
+- [Starter Chart of Accounts](starter_chart_of_accounts.md)
+- [Inventory Accounting Postings](inventory_accounting_postings.md)
+- [Formal Financial Statements](formal_financial_statements.md)
+- [Finance Dashboard Widgets](finance_dashboard_widgets.md)
+- [Finance Specialized Reports](finance_specialized_reports.md)
+- [Finance Metric Naming](finance_metric_naming.md)
+- [AR Payments and Aging](ar_payments_and_aging.md)
+- [Bills and Expenses](bills_and_expenses.md)
+- [Recurring Expenses and Reporting](recurring_expenses_and_reporting.md)
+- [Sales Tax Liability](sales_tax_liability.md)
+- [Invoice Lifecycle](invoice_lifecycle.md)
+- [Vendors and Expense Categories](vendors_and_expense_categories.md)
+- [Material Receipts Valuation](material_receipts_valuation.md)
+- [POS Sales Metadata](pos_sales_metadata.md)
+
+## Reference
+
+- [Technical Reference Map](reference/index.md) - authoritative map of runtime, deployment, and code reference surfaces

--- a/docs/packageability_audit.md
+++ b/docs/packageability_audit.md
@@ -1,0 +1,58 @@
+# Packageability Audit
+
+This document captures the concrete fresh-start packageability gaps that were addressed as part of issue `#136`.
+
+## Resolved Gaps
+
+### Missing documentation entry points
+
+The repo instructions and `AGENTS.md` referenced these maintained entry points:
+
+- `docs/index.md`
+- `docs/reference/index.md`
+- `docs/README.md`
+
+Those files did not exist, which made the documentation structure harder to navigate for a new adopter.
+
+Resolved by adding the missing docs hub and reference map.
+
+### Manual secret generation blocked first startup
+
+The tracked env examples intentionally use placeholder secrets, and the backend refuses to start while placeholders remain in place. That is correct from a security perspective, but it meant the quick-start flow was not actually runnable from a clean checkout without manual secret creation.
+
+Resolved by adding [`../scripts/bootstrap-env.sh`](../scripts/bootstrap-env.sh) so a new operator can generate a valid `.env` or server env file from the tracked templates.
+
+### Development compose healthcheck assumed default database identifiers
+
+`docker-compose.yml` used `pg_isready -U printuser -d printsales` even when `.env` changed `DB_USER` or `DB_NAME`. That meant fresh-start validation only worked reliably with the baked-in defaults.
+
+Resolved by making the healthcheck honor `DB_USER` and `DB_NAME`.
+
+### Backend container Python version did not match the documented baseline
+
+The repository documentation and `.python-version` declare Python `3.13`, but the backend container used `python:3.12-slim`.
+
+Resolved by aligning the backend Docker image with Python `3.13`.
+
+## Current Fresh-Start Path
+
+Local:
+
+1. `./scripts/bootstrap-env.sh local`
+2. `docker compose up -d --build`
+3. verify `http://localhost:8000/health`
+
+Server / `web01`:
+
+1. `./scripts/bootstrap-env.sh web01 --output /srv/3d-print-sales/env/web01.env`
+2. `scripts/web01-compose.sh up -d --build`
+3. verify compose health and reachability
+
+## Remaining Operator Expectations
+
+These are still expected and are now documented rather than implicit:
+
+- Docker-based production relies on a server-side env file and migration-driven schema management
+- seeded admin credentials come from env configuration and should be rotated as part of first access
+- `web01` remains the canonical live deployment target described by the repository
+- native backend development currently requires Python `3.13`; Python `3.14` is not yet compatible with the pinned backend dependency set

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,37 @@
+# Reference Map
+
+This is the authoritative technical reference index for the current codebase.
+
+## Runtime And Configuration
+
+- [`../getting_started.md`](../getting_started.md) - validated bootstrap flow for fresh local and `web01` installs
+- [`../../.env.example`](../../.env.example) - development environment template
+- [`../../.env.production.example`](../../.env.production.example) - production/server environment template
+- [`../../scripts/bootstrap-env.sh`](../../scripts/bootstrap-env.sh) - generates usable env files from the tracked templates
+- [`../../backend/app/core/config.py`](../../backend/app/core/config.py) - runtime configuration defaults, placeholder enforcement, and derived `DATABASE_URL` behavior
+
+## Startup And Schema Behavior
+
+- [`../../backend/app/main.py`](../../backend/app/main.py) - FastAPI app startup, lifespan, schema creation toggle, and health endpoint
+- [`../../backend/app/seed.py`](../../backend/app/seed.py) - default seed data and admin-user bootstrap behavior
+- [`../../backend/alembic.ini`](../../backend/alembic.ini) - Alembic configuration entry point
+- [`../../backend/alembic/env.py`](../../backend/alembic/env.py) - migration environment wiring
+
+## Containers And Deployment
+
+- [`../../docker-compose.yml`](../../docker-compose.yml) - development compose stack
+- [`../../docker-compose.prod.yml`](../../docker-compose.prod.yml) - production compose stack
+- [`../../backend/Dockerfile`](../../backend/Dockerfile) - backend container build targets
+- [`../../frontend/Dockerfile`](../../frontend/Dockerfile) - frontend container build targets
+- [`../../scripts/web01-compose.sh`](../../scripts/web01-compose.sh) - canonical `web01` compose wrapper
+
+## CI And Repository Safeguards
+
+- [`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml) - baseline backend/frontend validation in GitHub Actions
+- [`../../.github/workflows/secret-scan.yml`](../../.github/workflows/secret-scan.yml) - gitleaks-based repository secret scan
+
+## Maintained Docs Families
+
+- [`../index.md`](../index.md) - task-oriented documentation hub
+- `deployment_web01_*` docs - current `web01` deployment story
+- finance and workflow docs under `docs/` - feature-area technical references that should stay aligned with code changes

--- a/scripts/bootstrap-env.sh
+++ b/scripts/bootstrap-env.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/bootstrap-env.sh local [--output PATH] [--admin-email EMAIL] [--force]
+  scripts/bootstrap-env.sh web01 [--output PATH] [--admin-email EMAIL] [--force]
+
+Modes:
+  local   Generate a development .env from .env.example
+  web01   Generate a server env file from .env.production.example
+
+Examples:
+  scripts/bootstrap-env.sh local
+  scripts/bootstrap-env.sh web01 --output /srv/3d-print-sales/env/web01.env
+EOF
+}
+
+mode=""
+output=""
+admin_email=""
+force=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    local|web01)
+      mode="$1"
+      shift
+      ;;
+    --output|-o)
+      output="${2:?missing output path}"
+      shift 2
+      ;;
+    --admin-email)
+      admin_email="${2:?missing admin email}"
+      shift 2
+      ;;
+    --force|-f)
+      force=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$mode" ]]; then
+  usage >&2
+  exit 1
+fi
+
+case "$mode" in
+  local)
+    template=".env.example"
+    default_output=".env"
+    ;;
+  web01)
+    template=".env.production.example"
+    default_output="./web01.env"
+    ;;
+esac
+
+output="${output:-$default_output}"
+
+if [[ ! -f "$template" ]]; then
+  echo "Missing template: $template" >&2
+  exit 1
+fi
+
+if [[ -e "$output" && "$force" -ne 1 ]]; then
+  echo "Refusing to overwrite existing file: $output" >&2
+  echo "Re-run with --force if you want to replace it." >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$output")"
+
+python3 - "$template" "$output" "$mode" "$admin_email" <<'PY'
+from pathlib import Path
+from secrets import token_urlsafe
+from urllib.parse import quote
+import sys
+
+template_path = Path(sys.argv[1])
+output_path = Path(sys.argv[2])
+mode = sys.argv[3]
+admin_email_override = sys.argv[4]
+
+raw_lines = template_path.read_text().splitlines()
+entries: list[tuple[str, str, str] | tuple[str, str]] = []
+values: dict[str, str] = {}
+
+for line in raw_lines:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in line:
+        entries.append(("raw", line))
+        continue
+    key, value = line.split("=", 1)
+    key = key.strip()
+    values[key] = value
+    entries.append(("kv", key, value))
+
+if admin_email_override:
+    values["ADMIN_EMAIL"] = admin_email_override
+
+values["DB_PASSWORD"] = token_urlsafe(18)
+values["SECRET_KEY"] = token_urlsafe(48)
+values["ADMIN_PASSWORD"] = token_urlsafe(18)
+
+if "DATABASE_URL" in values:
+    db_user = values.get("DB_USER", "printuser")
+    db_name = values.get("DB_NAME", "printsales")
+    db_password = quote(values["DB_PASSWORD"], safe="")
+    db_host = "db"
+    values["DATABASE_URL"] = (
+        f"postgresql+asyncpg://{db_user}:{db_password}@{db_host}:5432/{db_name}"
+    )
+
+rendered: list[str] = []
+for entry in entries:
+    if entry[0] == "raw":
+        rendered.append(entry[1])
+        continue
+    _, key, _ = entry
+    rendered.append(f"{key}={values[key]}")
+
+output_path.write_text("\n".join(rendered) + "\n")
+PY
+
+echo "Generated $output from $template"
+
+if [[ "$mode" == "local" ]]; then
+  echo "Next step: docker compose up -d --build"
+else
+  echo "Next step: ENV_FILE=$output docker compose -f docker-compose.prod.yml up -d --build"
+fi


### PR DESCRIPTION
## Summary
- add a generated env bootstrap script for fresh local and `web01` setup
- add the missing docs hub, reference map, fresh-start guide, and packageability audit docs
- align the backend Docker image with the documented Python 3.13 baseline and fix the dev compose DB healthcheck

## Validation
- `cd frontend && npm test`
- `cd frontend && npm run build`
- markdown link resolution across `README.md` and `docs/**/*.md`
- `docker compose --env-file /tmp/3d-print-sales.env config`
- fresh-start compose bring-up from generated env plus health/reachability checks
- `docker compose --env-file /tmp/3d-print-sales.env exec -T backend python -m pytest tests -q`

Closes #136.