### PR TITLE
ci: publish Docker images for #134

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,87 @@
+name: Docker Publish
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: docker-publish-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE != '' && vars.DOCKERHUB_NAMESPACE || github.repository_owner }}
+
+jobs:
+  docker:
+    name: Docker ${{ matrix.image_name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image_name: backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+            target: production
+            image_repo: 3d-print-sales-backend
+          - image_name: frontend
+            context: ./frontend
+            dockerfile: ./frontend/Dockerfile
+            target: production
+            image_repo: 3d-print-sales-frontend
+
+    env:
+      SHOULD_PUSH: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: env.SHOULD_PUSH == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image_repo }}
+          labels: |
+            org.opencontainers.image.title=3D Print Sales ${{ matrix.image_name }}
+            org.opencontainers.image.vendor=3D Print Sales
+          tags: |
+            type=sha,format=long,prefix=sha-
+            type=raw,value=main,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=ref,event=pr,prefix=pr-
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and optionally push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
+          push: ${{ env.SHOULD_PUSH == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image_name }}
+          cache-to: type=gha,scope=${{ matrix.image_name }},mode=max

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Baseline repository CI now lives in [`.github/workflows/ci.yml`](./.github/workf
 - [web01 Compose Deployment](docs/deployment_web01_compose.md)
 - [web01 Environment and Storage](docs/deployment_web01_env_and_storage.md)
 - [web01 Runbook](docs/deployment_web01_runbook.md)
+- [Docker Image Publishing](docs/docker_image_publish.md)
 
 It runs on pull requests and pushes to `main` with separate jobs for:
 - backend tests via `python -m pytest backend/tests -q`
@@ -279,6 +280,21 @@ It runs on pull requests and pushes to `main` with separate jobs for:
 - frontend build validation via `cd frontend && npm run build`
 
 Keep local validation aligned with those commands before opening or updating a PR.
+
+## Container Publishing
+
+The repository also includes a Docker publish workflow in [`.github/workflows/docker-publish.yml`](./.github/workflows/docker-publish.yml).
+
+It builds production backend and frontend images on pull requests and publishes them to Docker Hub only from approved refs:
+- `main` publishes rolling `main` plus immutable `sha-*` tags
+- release tags such as `v1.2.3` publish release tags plus `latest`
+
+Required GitHub configuration:
+- repository secret `DOCKERHUB_USERNAME`
+- repository secret `DOCKERHUB_TOKEN`
+- repository variable `DOCKERHUB_NAMESPACE`
+
+See [docs/docker_image_publish.md](./docs/docker_image_publish.md) for the full naming, tagging, and promotion model.
 
 ## Environment Variables
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,7 @@ CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload
 # ---------- Production ----------
 FROM base AS production
 COPY . .
-RUN adduser --disabled-password --no-create-home appuser && chown -R appuser:appuser /app
+RUN adduser --disabled-password --gecos "" --no-create-home appuser && chown -R appuser:appuser /app
 USER appuser
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]

--- a/docs/deployment_web01_runbook.md
+++ b/docs/deployment_web01_runbook.md
@@ -72,6 +72,14 @@ PY
 - starts or updates the stack in detached mode
 - applies schema changes through Alembic instead of relying on runtime table creation
 
+### Current relation to CI-published images
+Issue `#134` adds Docker Hub image publishing in GitHub Actions, but `web01` still deploys from the checked-out repository with `--build`.
+
+That means:
+- Docker Hub images exist as reusable release artifacts
+- `web01` is not yet pulling those published images directly
+- a future deployment-automation issue can switch the deployment source when that tradeoff is approved
+
 ---
 
 ## Routine Update Procedure

--- a/docs/docker_image_publish.md
+++ b/docs/docker_image_publish.md
@@ -1,0 +1,95 @@
+# Docker Image Publishing
+
+This document is the source of truth for issue `#134`: how the repository builds and publishes Docker images in GitHub Actions, how tags work, and how those images relate to deployment.
+
+## Published Images
+
+The repository publishes two production images:
+
+- `docker.io/<namespace>/3d-print-sales-backend`
+- `docker.io/<namespace>/3d-print-sales-frontend`
+
+Default namespace behavior:
+
+- the workflow uses the repository variable `DOCKERHUB_NAMESPACE` when it is set
+- otherwise it falls back to the GitHub repository owner name
+
+For this repository, the practical default is currently `bbengt1` unless the GitHub variable overrides it.
+
+## GitHub Actions Workflow
+
+Workflow file:
+
+- [`.github/workflows/docker-publish.yml`](../.github/workflows/docker-publish.yml)
+
+Behavior:
+
+- pull requests: build both production images, but do not push them
+- pushes to `main`: build and push both images
+- pushes to version tags matching `v*`: build and push both images
+- manual dispatch: allowed, but image push still only happens from `main` or `v*` tags
+
+This keeps pull requests as build-only validation while reserving Docker Hub publishing for approved refs.
+
+## Required GitHub Configuration
+
+Repository secrets:
+
+- `DOCKERHUB_USERNAME`
+- `DOCKERHUB_TOKEN`
+
+Repository variable:
+
+- `DOCKERHUB_NAMESPACE`
+
+`DOCKERHUB_TOKEN` should be a Docker Hub access token, not a password.
+
+## Tagging And Promotion Strategy
+
+The repository uses this baseline strategy:
+
+- every publish gets an immutable `sha-<full-commit-sha>` tag
+- pushes to `main` also publish the rolling `main` tag
+- pushes to release tags such as `v1.2.3` publish:
+  - the exact Git tag, for example `v1.2.3`
+  - semver expansion tags such as `1.2.3` and `1.2`
+  - the rolling `latest` tag
+
+PR builds also compute `pr-<number>` metadata tags, but those builds are not pushed to Docker Hub.
+
+This means:
+
+- `sha-*` is the immutable traceable artifact tag
+- `main` is the continuously updated integration tag
+- `latest` is reserved for explicit release tags
+
+## Current Consumption Model
+
+Current `web01` production remains source-build oriented:
+
+- `scripts/web01-compose.sh up -d --build` still rebuilds from the checked-out repository
+- `docker-compose.prod.yml` is not yet switched to consume prebuilt Docker Hub images directly
+
+That is deliberate for now. Issue `#134` establishes artifact publishing first. A later deployment automation step, such as issue `#135`, can choose whether to consume these published images directly.
+
+## Operational Guidance
+
+Use `sha-*` tags when traceability matters more than convenience.
+
+Examples:
+
+- safest explicit backend image reference: `docker.io/<namespace>/3d-print-sales-backend:sha-<full-commit-sha>`
+- rolling integration reference: `docker.io/<namespace>/3d-print-sales-backend:main`
+- release reference: `docker.io/<namespace>/3d-print-sales-backend:1.2.3`
+
+Avoid deploying production from `latest` unless the environment intentionally tracks release tags without a stricter pin.
+
+## Validation Expectations
+
+Validation for this workflow should include:
+
+- workflow YAML parses correctly
+- PR builds complete without pushing
+- pushes to `main` publish both images successfully
+- a published `sha-*` image can be pulled explicitly
+- the documented tags match what appears in Docker Hub

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ Start here if you need the maintained documentation path for this repository.
 - [web01 Runbook](deployment_web01_runbook.md)
 - [web01 Audit](deployment_web01_audit.md)
 - [web01 Deployment Plan](deployment_web01_plan.md)
+- [Docker Image Publishing](docker_image_publish.md)
 
 ## Feature And Workflow Guides
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -24,10 +24,12 @@ This is the authoritative technical reference index for the current codebase.
 - [`../../backend/Dockerfile`](../../backend/Dockerfile) - backend container build targets
 - [`../../frontend/Dockerfile`](../../frontend/Dockerfile) - frontend container build targets
 - [`../../scripts/web01-compose.sh`](../../scripts/web01-compose.sh) - canonical `web01` compose wrapper
+- [`../docker_image_publish.md`](../docker_image_publish.md) - Docker Hub publishing model, tag strategy, and required GitHub secrets/variables
 
 ## CI And Repository Safeguards
 
 - [`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml) - baseline backend/frontend validation in GitHub Actions
+- [`../../.github/workflows/docker-publish.yml`](../../.github/workflows/docker-publish.yml) - Docker Buildx workflow for build-only PR validation and Docker Hub publishing from approved refs
 - [`../../.github/workflows/secret-scan.yml`](../../.github/workflows/secret-scan.yml) - gitleaks-based repository secret scan
 
 ## Maintained Docs Families


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build production backend and frontend images and publish them to Docker Hub from approved refs
- document the image naming, tagging, and promotion model plus required GitHub secrets and variables
- make the backend production Dockerfile user creation non-interactive for clean CI builds

## Validation
- parse `.github/workflows/docker-publish.yml`
- verify markdown links in `README.md` and `docs/**/*.md`
- `docker build --target production -f backend/Dockerfile backend`
- `docker build --target production -f frontend/Dockerfile frontend`

Closes #134.