### PR TITLE
ops: re-enable Header Auth on the web01-deploy webhook

### DIFF
--- a/docs/deployment_n8n_workflow.md
+++ b/docs/deployment_n8n_workflow.md
@@ -84,19 +84,37 @@ Hardening recommendations on the web01 side:
 - In `~/.ssh/authorized_keys`, constrain the key with `from="<n8n host IP>"` so it can only be used from the expected source.
 - Rotate annually.
 
-#### b) Webhook authentication (optional)
+#### b) `web01-deploy-webhook-token` (HTTP Header Auth)
 
-The exported workflow ships with Webhook Trigger `authentication: "none"` — anyone who knows the webhook URL can trigger a deploy. This is acceptable when the n8n instance itself is behind auth (e.g. SSO + Cloudflare Access on the n8n host). To add bearer-token auth:
+> **This credential is already configured on the target n8n instance** (credential ID `fFUBXZdMNbsMY5ek`, type `httpHeaderAuth`). The exported workflow JSON references it by both `id` and `name`. The token value is stored in the credential itself — to retrieve it for client callers, open **Credentials → web01-deploy-webhook-token** in the n8n UI and use **Show** on the `value` field. It is formatted as `Bearer <token>`; when calling the webhook, pass the *entire* string in the `Authorization` header.
+
+To rotate the token:
+
+1. **Credentials** → click `web01-deploy-webhook-token`.
+2. Update the `value` field to `Bearer <new-token>` (generate with e.g. `openssl rand -base64 48`).
+3. Save.
+
+No workflow change is required — the credential ID remains the same.
+
+To create the credential from scratch (disaster recovery or a fresh n8n instance):
 
 1. **Credentials** → **Add credential** → select **Header Auth**.
-2. Name header: `Authorization`.
-3. Value: `Bearer <generate-a-long-random-token>`.
-4. Name the credential (any name, e.g. `web01-deploy-webhook-token`).
-5. Save, note the credential ID.
-6. In n8n, open the `web01-deploy` workflow → click the `Webhook Trigger` node → change **Authentication** from "None" to "Header Auth" → bind the credential → save the workflow.
-7. Alternatively, update `ops/n8n/web01-deploy.json` to set `parameters.authentication: "headerAuth"` and add `credentials.httpHeaderAuth: { id: "<credId>", name: "<credName>" }` on the Webhook Trigger node, then re-import.
+2. Header name: `Authorization`.
+3. Value: `Bearer <generate-a-long-random-token>` (e.g. `openssl rand -base64 48`).
+4. Name the credential exactly `web01-deploy-webhook-token`.
+5. Save, note the new credential ID.
+6. If the new ID differs from `fFUBXZdMNbsMY5ek`, update `ops/n8n/web01-deploy.json` so the `Webhook Trigger` node references the new ID under `credentials.httpHeaderAuth.id`.
 
-Keep the token in your password manager. You will pass it in the `Authorization` header on every webhook call.
+Keep the token in your password manager. Every webhook caller must pass it:
+
+```bash
+curl -X POST "https://n8n.argusai.cc/webhook/web01-deploy" \
+  -H "Authorization: Bearer <your-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"branch": "main", "triggered_by": "cli"}'
+```
+
+Requests without a matching `Authorization` header return **401 Unauthorized**.
 
 ### 3. Import the workflow
 

--- a/ops/n8n/README.md
+++ b/ops/n8n/README.md
@@ -36,9 +36,9 @@ The exported workflow references credentials by both `id` and `name`. The target
 | Credential name | Type | Credential ID | Used by |
 |-----------------|------|---------------|---------|
 | `web01.bengtson.local` | SSH — Password auth (`sshPassword`) | `VIDK7yaGu0SqsBxb` | all 12 SSH nodes |
-| *(optional)* bearer-token credential | HTTP Header Auth (`httpHeaderAuth`) | — | Webhook Trigger (only if you switch auth from `none` to `headerAuth`) |
+| `web01-deploy-webhook-token` | HTTP Header Auth (`httpHeaderAuth`) | `fFUBXZdMNbsMY5ek` | Webhook Trigger |
 
-The Webhook Trigger ships with `authentication: "none"` for simplicity. To add bearer-token auth, follow the runbook at `docs/deployment_n8n_workflow.md`.
+The Webhook Trigger requires `Authorization: Bearer <token>` on every request. The token itself is stored inside the `web01-deploy-webhook-token` credential — retrieve it via the n8n UI (**Credentials → web01-deploy-webhook-token → Show value**). Rotation instructions are in the runbook.
 
 If the credential ID changes (e.g. because the credential was recreated), update every SSH node's `credentials.sshPassword.id` in `web01-deploy.json`. A quick sed works:
 

--- a/ops/n8n/web01-deploy.json
+++ b/ops/n8n/web01-deploy.json
@@ -5,7 +5,7 @@
       "parameters": {
         "httpMethod": "POST",
         "path": "web01-deploy",
-        "authentication": "none",
+        "authentication": "headerAuth",
         "responseMode": "responseNode",
         "options": {}
       },
@@ -18,7 +18,13 @@
         300
       ],
       "webhookId": "web01-deploy-webhook",
-      "notes": "POST /webhook/web01-deploy with JSON body { branch, run_migrations?, force_rebuild?, triggered_by? }. Authentication disabled; add Header Auth credential in n8n to re-enable."
+      "notes": "POST /webhook/web01-deploy with JSON body { branch, run_migrations?, force_rebuild?, triggered_by? }. Requires Authorization: Bearer <token> header (see docs/deployment_n8n_workflow.md for how to retrieve the token).",
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "fFUBXZdMNbsMY5ek",
+          "name": "web01-deploy-webhook-token"
+        }
+      }
     },
     {
       "parameters": {},


### PR DESCRIPTION
## Summary

Now that the n8n `web01-deploy` workflow has been confirmed working end-to-end, restore bearer-token protection on the public webhook entrypoint so the deploy URL cannot be triggered by just knowing the path.

## What changed

- **Webhook Trigger** `authentication` flipped from `none` back to `headerAuth`
- **Webhook Trigger** now binds the real `web01-deploy-webhook-token` credential (`id: fFUBXZdMNbsMY5ek`) in the repo JSON
- **Runbook** (`docs/deployment_n8n_workflow.md`) updated:
  - Documents the real credential ID
  - Explains how to retrieve the token from the n8n UI
  - Documents token rotation (edit the credential's `value`, no workflow change needed)
  - Disaster-recovery instructions for creating the credential from scratch
- **`ops/n8n/README.md`** credential table now lists both credentials with their real IDs

## What was done on the live n8n instance

- `POST /api/v1/credentials` created `web01-deploy-webhook-token` (httpHeaderAuth type)
- `PUT /api/v1/workflows/IG9pBfPQ8rt3Wrc2` bound the credential to the Webhook Trigger and set `authentication: headerAuth`
- `GET` verified the state: webhook auth = `headerAuth`, credential bound correctly, all 12 SSH bindings remain intact

## Test plan

- [x] JSON valid
- [x] Live workflow in n8n shows headerAuth + credential bound
- [ ] Unauthenticated `curl -X POST /webhook/web01-deploy` returns 401
- [ ] `curl -X POST /webhook/web01-deploy -H "Authorization: Bearer <token>" -d '{"branch": "main"}'` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)