### PR TITLE
ops(ci): publish images to bbengt1/print-backend and bbengt1/print-frontend

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,12 +32,12 @@ jobs:
             context: ./backend
             dockerfile: ./backend/Dockerfile
             target: production
-            image_repo: 3d-print-sales-backend
+            image_repo: print-backend
           - image_name: frontend
             context: ./frontend
             dockerfile: ./frontend/Dockerfile
             target: production
-            image_repo: 3d-print-sales-frontend
+            image_repo: print-frontend
 
     env:
       SHOULD_PUSH: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}

--- a/docs/docker_image_publish.md
+++ b/docs/docker_image_publish.md
@@ -6,8 +6,8 @@ This document is the source of truth for issue `#134`: how the repository builds
 
 The repository publishes two production images:
 
-- `docker.io/<namespace>/3d-print-sales-backend`
-- `docker.io/<namespace>/3d-print-sales-frontend`
+- `docker.io/<namespace>/print-backend`
+- `docker.io/<namespace>/print-frontend`
 
 Default namespace behavior:
 
@@ -78,9 +78,9 @@ Use `sha-*` tags when traceability matters more than convenience.
 
 Examples:
 
-- safest explicit backend image reference: `docker.io/<namespace>/3d-print-sales-backend:sha-<full-commit-sha>`
-- rolling integration reference: `docker.io/<namespace>/3d-print-sales-backend:main`
-- release reference: `docker.io/<namespace>/3d-print-sales-backend:1.2.3`
+- safest explicit backend image reference: `docker.io/<namespace>/print-backend:sha-<full-commit-sha>`
+- rolling integration reference: `docker.io/<namespace>/print-backend:main`
+- release reference: `docker.io/<namespace>/print-backend:1.2.3`
 
 Avoid deploying production from `latest` unless the environment intentionally tracks release tags without a stricter pin.
 


### PR DESCRIPTION
## Summary

Point the Docker Publish GitHub Action at the operator's preferred Docker Hub repositories:

- Backend image → `bbengt1/print-backend` (was `bbengt1/3d-print-sales-backend`)
- Frontend image → `bbengt1/print-frontend` (was `bbengt1/3d-print-sales-frontend`)

## What changed

- `.github/workflows/docker-publish.yml` — matrix `image_repo` values updated
- `docs/docker_image_publish.md` — Published Images list and Operational Guidance examples updated to match

## Intentionally unchanged

- `docker-compose.prod.yml` `container_name:` entries keep `3d-print-sales-{db,backend,frontend}`. Those are the **local container names** created by Docker Compose on `web01`, not the published image repository names. The n8n `web01-deploy` workflow greps for exactly those container names via `compose ps` to verify health — renaming them would break the deploy workflow.
- `agents.md`, `docs/deployment_web01_runbook.md`, `ops/n8n/web01-deploy.json`, and `docs/deployment_n8n_workflow.md` all reference the container names (not image names) for the same reason.

## Follow-up notes for the operator

Before merging:

- [ ] Ensure `bbengt1/print-backend` and `bbengt1/print-frontend` repositories exist on Docker Hub (private or public per your preference — create them once in the Docker Hub UI)
- [ ] Ensure `DOCKERHUB_TOKEN` GitHub secret has **write** access to both repositories

After merging, the next push to `main` will publish images at:

- https://hub.docker.com/r/bbengt1/print-backend
- https://hub.docker.com/r/bbengt1/print-frontend

The old `3d-print-sales-{backend,frontend}` repositories will stop receiving new tags but existing tags remain available until manually removed.

## Separate GKE-related files (not included in this PR)

There are untracked files in the working tree from a prior in-progress GKE deployment session — `.github/workflows/gke-deploy.yml`, `k8s/gke/**`, `docs/gke_deployment.md`. Those also reference the old image names (`3d-print-sales-backend` etc.) and will need matching updates when that GKE work is eventually committed. They are **not** included in this PR to keep scope clean; handle them in the GKE PR when it lands.

## Test plan

- [x] YAML remains valid
- [ ] CI passes
- [ ] After merge, observe the next `docker-publish.yml` run pushes tags to `bbengt1/print-backend` and `bbengt1/print-frontend` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)