### PR TITLE
ops(ci): add `version` input to Docker Publish workflow_dispatch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,12 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to apply (e.g. "1.2.3" or "v1.2.3"). When set, the published image is tagged with this value AND "latest". Leave blank for a regular build (uses default sha-* tagging only).'
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   group: docker-publish-${{ github.workflow }}-${{ github.ref }}
@@ -40,7 +46,7 @@ jobs:
             image_repo: print-frontend
 
     env:
-      SHOULD_PUSH: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+      SHOULD_PUSH: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.version != '')) }}
 
     steps:
       - name: Check out repository
@@ -69,6 +75,8 @@ jobs:
             type=sha,format=long,prefix=sha-
             type=raw,value=main,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
+            type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
             type=ref,event=pr,prefix=pr-
             type=ref,event=tag
             type=semver,pattern={{version}}

--- a/docs/docker_image_publish.md
+++ b/docs/docker_image_publish.md
@@ -27,9 +27,27 @@ Behavior:
 - pull requests: build both production images, but do not push them
 - pushes to `main`: build and push both images
 - pushes to version tags matching `v*`: build and push both images
-- manual dispatch: allowed, but image push still only happens from `main` or `v*` tags
+- manual dispatch from `main` or `v*` (no `version` input): behaves like the corresponding push
+- manual dispatch with `version` input (e.g. `1.2.3`): builds from the selected ref and pushes with tags `sha-<commit>`, `<version>`, and `latest` — works from any branch so hotfix or off-main releases can be cut without creating a Git tag first
 
 This keeps pull requests as build-only validation while reserving Docker Hub publishing for approved refs.
+
+### Manual dispatch with a version
+
+Use **Actions → Docker Publish → Run workflow** in the GitHub UI and fill in the `version` input (e.g. `1.4.0` or `v1.4.0`). The resulting images are tagged with:
+
+- `sha-<full-commit-sha>` (always, immutable traceable tag)
+- `<version>` (the exact string you typed)
+- `latest`
+
+Example: dispatching from `main` with `version=1.4.0` publishes:
+
+- `docker.io/bbengt1/print-backend:sha-<sha>`
+- `docker.io/bbengt1/print-backend:1.4.0`
+- `docker.io/bbengt1/print-backend:latest`
+- (same three tags for `print-frontend`)
+
+If you leave `version` blank during dispatch, the run falls back to the default ref-based tagging (and only pushes from `main` or `v*` refs).
 
 ## Required GitHub Configuration
 
@@ -53,6 +71,10 @@ The repository uses this baseline strategy:
 - pushes to release tags such as `v1.2.3` publish:
   - the exact Git tag, for example `v1.2.3`
   - semver expansion tags such as `1.2.3` and `1.2`
+  - the rolling `latest` tag
+- manual dispatch with a `version` input publishes:
+  - `sha-<full-commit-sha>`
+  - the exact string supplied (e.g. `1.4.0` or `v1.4.0`)
   - the rolling `latest` tag
 
 PR builds also compute `pr-<number>` metadata tags, but those builds are not pushed to Docker Hub.


### PR DESCRIPTION
## Summary

Let the Docker Publish workflow accept a `version` input on manual dispatch. When provided, the built images are published with both that exact version tag **and** `latest` (on top of the existing immutable `sha-<commit>` tag).

## What changes

- **`.github/workflows/docker-publish.yml`**
  - Add `workflow_dispatch.inputs.version` (optional string).
  - Extend `SHOULD_PUSH` so a dispatch-with-version can push from any ref (the existing `main` / `v*` gate still applies when `version` is blank).
  - Add two `type=raw` tag rules to `docker/metadata-action`, both gated on `github.event_name == 'workflow_dispatch' && inputs.version != ''`:
    - the exact version string
    - `latest`
- **`docs/docker_image_publish.md`** — documents the new dispatch path with a concrete example (`version=1.4.0` → `sha-<sha>` + `1.4.0` + `latest`).

## Use case

Hotfix / off-main release without creating a Git tag first:

1. **Actions → Docker Publish → Run workflow**
2. Pick a branch (can be any branch)
3. Fill in `version` = `1.4.0` (or `v1.4.0`)
4. Run

Result: `bbengt1/print-backend:sha-<sha>`, `bbengt1/print-backend:1.4.0`, `bbengt1/print-backend:latest` (same three tags for frontend).

## Unchanged behavior

- PRs: still build-only, no push
- Pushes to `main`: same rolling `main` tag
- Pushes to `v*` tags: same full semver expansion + `latest`
- Dispatch with blank `version`: same ref-based gating as before

## Test plan

- [x] YAML parses cleanly via `yaml.safe_load`
- [ ] PR build succeeds (CI will validate on this PR)
- [ ] After merge: dispatch with `version=test-0.0.1` from `main` and observe tags `sha-<sha>`, `test-0.0.1`, and `latest` land on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)