### PR TITLE
feat(ui): adopt trust-blue design tokens and Inter typography (phase 1 of #157)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,11 +52,11 @@ function RouteFallback() {
     <div className="min-h-screen bg-background">
       <div className="mx-auto flex max-w-6xl items-center justify-center px-6 py-24">
         <div className="w-full max-w-3xl animate-pulse space-y-4">
-          <div className="h-10 w-56 rounded-2xl bg-card" />
-          <div className="h-40 rounded-3xl bg-card" />
+          <div className="h-10 w-56 rounded-md bg-card" />
+          <div className="h-40 rounded-lg bg-card" />
           <div className="grid gap-4 md:grid-cols-2">
-            <div className="h-32 rounded-3xl bg-card" />
-            <div className="h-32 rounded-3xl bg-card" />
+            <div className="h-32 rounded-lg bg-card" />
+            <div className="h-32 rounded-lg bg-card" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -34,7 +34,7 @@ export default function Header({ onOpenMobileNav }: HeaderProps) {
             </button>
 
             <Link to="/control-center" className="flex min-w-0 items-center gap-3 no-underline">
-              <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-primary/30 bg-primary text-primary-foreground shadow-[0_14px_40px_rgba(34,197,94,0.28)]">
+              <div className="flex h-11 w-11 items-center justify-center rounded-md border border-primary/30 bg-primary text-primary-foreground shadow-sm">
                 <Printer className="h-5 w-5 shrink-0" />
               </div>
               <div className="min-w-0">
@@ -58,7 +58,7 @@ export default function Header({ onOpenMobileNav }: HeaderProps) {
             </button>
 
             {user && (
-              <div className="hidden min-w-0 max-w-[280px] items-center gap-3 rounded-2xl border border-border bg-card/70 px-3 py-2 text-sm text-muted-foreground sm:flex">
+              <div className="hidden min-w-0 max-w-[280px] items-center gap-3 rounded-md border border-border bg-card/70 px-3 py-2 text-sm text-muted-foreground sm:flex">
                 <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-background/80 text-foreground">
                   <User className="h-4 w-4 shrink-0" />
                 </div>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -17,9 +17,9 @@ function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
   return (
     <div className="flex h-full flex-col">
       <div className="px-3 pb-4">
-        <div className="rounded-2xl border border-border bg-background/70 p-4">
+        <div className="rounded-md border border-border bg-background/70 p-4">
           <div className="flex items-center gap-3">
-            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-[0_12px_32px_rgba(34,197,94,0.25)]">
+            <div className="flex h-11 w-11 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-sm">
               <PanelsTopLeft className="h-5 w-5" />
             </div>
             <div>
@@ -51,9 +51,9 @@ function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
             onClick={onNavigate}
             className={() =>
               cn(
-                'flex items-center gap-3 rounded-2xl px-3 py-3 text-sm font-medium transition-colors no-underline',
+                'flex items-center gap-3 rounded-md px-3 py-3 text-sm font-medium transition-colors no-underline',
                 isWorkspaceLinkActive(location.pathname, matchPrefixes)
-                  ? 'bg-primary text-primary-foreground shadow-[0_18px_40px_rgba(34,197,94,0.18)]'
+                  ? 'bg-primary text-primary-foreground shadow-sm'
                   : 'text-muted-foreground hover:bg-accent hover:text-foreground'
               )
             }
@@ -86,7 +86,7 @@ export default function Layout() {
       <div className="mx-auto flex-1 w-full max-w-[96rem] px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
         <div className="flex min-h-full gap-6 lg:gap-8">
           <aside className="hidden w-80 shrink-0 xl:block">
-            <div className="sticky top-24 rounded-[1.9rem] border border-border bg-card/80 p-3 shadow-[0_20px_60px_rgba(8,17,31,0.10)] backdrop-blur">
+            <div className="sticky top-24 rounded-lg border border-border bg-card/80 p-3 shadow-md backdrop-blur">
               <SidebarContent />
             </div>
           </aside>

--- a/frontend/src/components/layout/WorkspaceLocalNav.tsx
+++ b/frontend/src/components/layout/WorkspaceLocalNav.tsx
@@ -7,7 +7,7 @@ export default function WorkspaceLocalNav() {
   const workspace = getWorkspaceForPath(location.pathname);
 
   return (
-    <section className="rounded-[1.75rem] border border-border bg-card/80 p-4 shadow-[0_16px_48px_rgba(8,17,31,0.08)] backdrop-blur">
+    <section className="rounded-lg border border-border bg-card/80 p-4 shadow-md backdrop-blur">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
         <div className="min-w-0">
           <p className="text-[0.7rem] font-semibold uppercase tracking-[0.26em] text-muted-foreground">
@@ -35,7 +35,7 @@ export default function WorkspaceLocalNav() {
                 className={cn(
                   'rounded-full border px-3 py-2 text-sm font-medium no-underline transition-colors',
                   active
-                    ? 'border-primary/40 bg-primary text-primary-foreground shadow-[0_10px_30px_rgba(34,197,94,0.28)]'
+                    ? 'border-primary/40 bg-primary text-primary-foreground shadow-sm'
                     : 'border-border bg-background/70 text-muted-foreground hover:border-primary/30 hover:text-foreground'
                 )}
               >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,70 +1,93 @@
-@import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;500;600;700;800&family=Rubik:wght@500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 @import "tailwindcss";
 
 @theme {
-  --color-primary: #22c55e;
-  --color-primary-foreground: #04110a;
-  --color-secondary: #dbeafe;
-  --color-secondary-foreground: #08111f;
-  --color-destructive: #ef4444;
+  /* Colors — light */
+  --color-primary: #2563eb;              /* trust blue */
+  --color-primary-foreground: #ffffff;
+  --color-secondary: #eff6ff;
+  --color-secondary-foreground: #0f172a;
+  --color-destructive: #dc2626;
   --color-destructive-foreground: #ffffff;
-  --color-muted: #ecf3fb;
-  --color-muted-foreground: #617892;
-  --color-accent: #e5eef8;
-  --color-accent-foreground: #08111f;
-  --color-card: rgba(255, 255, 255, 0.88);
-  --color-card-foreground: #08111f;
-  --color-border: #cad8e7;
-  --color-input: #bfd0e2;
-  --color-ring: #22c55e;
-  --color-background: #f4f8fb;
-  --color-foreground: #08111f;
-  --color-shell: #08111f;
-  --color-panel: #0f1728;
-  --color-panel-2: #152133;
+  --color-success: #10b981;              /* reserved for paid/complete status */
+  --color-success-foreground: #042f1c;
   --color-warning: #f59e0b;
-  --color-info: #38bdf8;
-  --radius-sm: 0.375rem;
-  --radius-md: 0.75rem;
-  --radius-lg: 1rem;
+  --color-warning-foreground: #1f1300;
+  --color-info: #0ea5e9;
+  --color-info-foreground: #051f2d;
+  --color-muted: #f1f5f9;
+  --color-muted-foreground: #475569;     /* 4.5:1 contrast vs muted */
+  --color-accent: #f1f5f9;
+  --color-accent-foreground: #0f172a;
+  --color-card: #ffffff;                 /* opaque */
+  --color-card-foreground: #0f172a;
+  --color-border: #e2e8f0;
+  --color-input: #cbd5e1;
+  --color-ring: #2563eb;
+  --color-background: #f8fafc;           /* flat */
+  --color-foreground: #0f172a;
 
-  --font-sans: 'Nunito Sans', ui-sans-serif, system-ui, sans-serif;
-  --font-display: 'Rubik', ui-sans-serif, system-ui, sans-serif;
+  /* Retained surface tokens for legacy uses (full-bleed kiosk screens, etc.) */
+  --color-shell: #0f172a;
+  --color-panel: #1e293b;
+  --color-panel-2: #334155;
+
+  /* Radii */
+  --radius-sm: 0.375rem;  /* 6px */
+  --radius-md: 0.5rem;    /* 8px */
+  --radius-lg: 0.75rem;   /* 12px */
+  --radius-xl: 1rem;      /* 16px — reserved for modals / full-bleed panels */
+
+  /* Shadows — flat business scale */
+  --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.04);
+  --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.08), 0 1px 2px rgba(15, 23, 42, 0.04);
+  --shadow-md: 0 4px 12px rgba(15, 23, 42, 0.08);
+  --shadow-lg: 0 12px 24px rgba(15, 23, 42, 0.12);
+
+  /* Typography */
+  --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'Inter', ui-sans-serif, system-ui, sans-serif;
 }
 
 .dark {
-  --color-primary: #22c55e;
-  --color-primary-foreground: #04110a;
-  --color-secondary: #17314d;
-  --color-secondary-foreground: #eff6ff;
-  --color-destructive: #f87171;
-  --color-destructive-foreground: #120607;
-  --color-muted: #142033;
-  --color-muted-foreground: #8fa3bf;
-  --color-accent: #152133;
-  --color-accent-foreground: #eff6ff;
-  --color-card: rgba(15, 23, 40, 0.86);
-  --color-card-foreground: #eff6ff;
-  --color-border: #22324a;
-  --color-input: #2b3c56;
-  --color-ring: #22c55e;
-  --color-background: #08111f;
-  --color-foreground: #eff6ff;
-  --color-shell: #040914;
-  --color-panel: #0b1424;
-  --color-panel-2: #122038;
+  --color-primary: #3b82f6;              /* slightly brighter for dark mode */
+  --color-primary-foreground: #ffffff;
+  --color-secondary: #1e293b;
+  --color-secondary-foreground: #f1f5f9;
+  --color-destructive: #ef4444;
+  --color-destructive-foreground: #ffffff;
+  --color-success: #10b981;
+  --color-success-foreground: #d1fae5;
   --color-warning: #fbbf24;
+  --color-warning-foreground: #3b2100;
   --color-info: #38bdf8;
+  --color-info-foreground: #0c2e3f;
+  --color-muted: #1e293b;
+  --color-muted-foreground: #94a3b8;
+  --color-accent: #1e293b;
+  --color-accent-foreground: #f1f5f9;
+  --color-card: #0f172a;                 /* opaque */
+  --color-card-foreground: #f1f5f9;
+  --color-border: #1e293b;
+  --color-input: #334155;
+  --color-ring: #3b82f6;
+  --color-background: #020617;           /* flat */
+  --color-foreground: #f1f5f9;
+
+  --color-shell: #020617;
+  --color-panel: #0f172a;
+  --color-panel-2: #1e293b;
+
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.35);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.40), 0 1px 2px rgba(0, 0, 0, 0.30);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 12px 24px rgba(0, 0, 0, 0.55);
 }
 
 body {
   margin: 0;
   font-family: var(--font-sans);
-  background:
-    radial-gradient(circle at top left, rgba(56, 189, 248, 0.1), transparent 22%),
-    radial-gradient(circle at top right, rgba(34, 197, 94, 0.08), transparent 20%),
-    linear-gradient(180deg, color-mix(in srgb, var(--color-background) 92%, white 8%) 0%, var(--color-background) 100%);
-  background-color: var(--color-background);
+  background: var(--color-background);   /* flat — no decorative gradients */
   color: var(--color-foreground);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -81,5 +104,10 @@ h4,
 h5,
 h6 {
   font-family: var(--font-display);
-  letter-spacing: -0.02em;
+  letter-spacing: -0.01em;
+}
+
+/* Tabular numerals for currency / quantities — Phase 3 will apply this widely */
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
 }

--- a/frontend/src/pages/ControlCenterPage.tsx
+++ b/frontend/src/pages/ControlCenterPage.tsx
@@ -74,7 +74,7 @@ function ModuleCard({
   return (
     <section
       className={cn(
-        'rounded-[1.9rem] border p-5 shadow-[0_18px_50px_rgba(8,17,31,0.08)] backdrop-blur',
+        'rounded-lg border p-5 shadow-md backdrop-blur',
         tone === 'warning' && 'border-amber-300/60 bg-amber-50/90 dark:border-amber-500/30 dark:bg-amber-500/10',
         tone === 'success' && 'border-emerald-300/60 bg-emerald-50/90 dark:border-emerald-500/30 dark:bg-emerald-500/10',
         tone === 'default' && 'border-border bg-card/85'
@@ -106,7 +106,7 @@ function PriorityStat({
   emphasis?: 'default' | 'warning' | 'success';
 }) {
   return (
-    <div className="rounded-[1.6rem] border border-border bg-card/80 p-4 shadow-[0_14px_40px_rgba(8,17,31,0.06)]">
+    <div className="rounded-md border border-border bg-card/80 p-4 shadow-sm">
       <div className="flex items-start justify-between gap-3">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
@@ -124,7 +124,7 @@ function PriorityStat({
           </p>
           {subtext ? <p className="mt-1 text-sm text-muted-foreground">{subtext}</p> : null}
         </div>
-        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+        <div className="flex h-11 w-11 items-center justify-center rounded-md bg-primary/12 text-primary">
           <Icon className="h-5 w-5" />
         </div>
       </div>
@@ -244,7 +244,7 @@ export default function ControlCenterPage() {
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-[2rem] border border-border bg-[linear-gradient(135deg,rgba(8,17,31,0.98),rgba(17,34,53,0.96))] px-6 py-6 text-white shadow-[0_24px_70px_rgba(8,17,31,0.18)]">
+      <section className="overflow-hidden rounded-lg border border-border bg-[linear-gradient(135deg,rgba(8,17,31,0.98),rgba(17,34,53,0.96))] px-6 py-6 text-white shadow-md">
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.65fr)]">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.32em] text-cyan-200/75">
@@ -261,7 +261,7 @@ export default function ControlCenterPage() {
                 <Link
                   key={action.to}
                   to={action.to}
-                  className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline shadow-[0_16px_40px_rgba(34,197,94,0.28)] transition-transform hover:-translate-y-0.5"
+                  className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline shadow-sm transition-transform hover:-translate-y-0.5"
                 >
                   {action.label}
                 </Link>
@@ -343,7 +343,7 @@ export default function ControlCenterPage() {
                         key={printer.id}
                         to={`/print-floor/printers/${printer.id}`}
                         className={cn(
-                          'grid grid-cols-[88px_minmax(0,1fr)] gap-4 rounded-[1.4rem] border p-3 no-underline transition-colors',
+                          'grid grid-cols-[88px_minmax(0,1fr)] gap-4 rounded-md border p-3 no-underline transition-colors',
                           needsAttention
                             ? 'border-amber-300/70 bg-amber-50/80 dark:border-amber-500/30 dark:bg-amber-500/10'
                             : 'border-border bg-background/70 hover:border-primary/30'
@@ -352,7 +352,7 @@ export default function ControlCenterPage() {
                         <PrinterThumbnail
                           src={printer.current_print_thumbnail_url}
                           alt={printer.current_print_name || `${printer.name} thumbnail`}
-                          className="h-[88px] w-[88px] rounded-2xl"
+                          className="h-[88px] w-[88px] rounded-md"
                           imgClassName="object-cover"
                           fallbackLabel="No view"
                         />
@@ -438,7 +438,7 @@ export default function ControlCenterPage() {
                     <Link
                       key={`${alert.type}-${alert.id}`}
                       to={alert.type === 'product' ? `/product-studio/products/${alert.id}` : '/stock/materials'}
-                      className="flex items-center justify-between rounded-[1.25rem] border border-border bg-background/70 px-4 py-3 text-sm no-underline transition-colors hover:border-primary/30"
+                      className="flex items-center justify-between rounded-md border border-border bg-background/70 px-4 py-3 text-sm no-underline transition-colors hover:border-primary/30"
                     >
                       <div className="min-w-0">
                         <p className="truncate font-medium text-foreground">{alert.name}</p>
@@ -465,7 +465,7 @@ export default function ControlCenterPage() {
             tone={attentionPrinters.length + unassignedDraftJobs.length + blockerAlerts.length > 0 ? 'warning' : 'success'}
           >
             <div className="space-y-3">
-              <div className="rounded-[1.25rem] border border-border bg-background/70 p-4">
+              <div className="rounded-md border border-border bg-background/70 p-4">
                 <div className="flex items-center gap-3">
                   <AlertTriangle className="h-5 w-5 text-amber-500" />
                   <div>
@@ -476,7 +476,7 @@ export default function ControlCenterPage() {
                   </div>
                 </div>
               </div>
-              <div className="rounded-[1.25rem] border border-border bg-background/70 p-4">
+              <div className="rounded-md border border-border bg-background/70 p-4">
                 <div className="flex items-center gap-3">
                   <Package className="h-5 w-5 text-primary" />
                   <div>
@@ -487,7 +487,7 @@ export default function ControlCenterPage() {
                   </div>
                 </div>
               </div>
-              <div className="rounded-[1.25rem] border border-border bg-background/70 p-4">
+              <div className="rounded-md border border-border bg-background/70 p-4">
                 <div className="flex items-center gap-3">
                   <Sparkles className="h-5 w-5 text-cyan-500" />
                   <div>
@@ -522,7 +522,7 @@ export default function ControlCenterPage() {
                 />
               </div>
               {financeData ? (
-                <div className="rounded-[1.25rem] border border-border bg-background/70 p-4">
+                <div className="rounded-md border border-border bg-background/70 p-4">
                   <dl className="grid gap-3 text-sm">
                     <div className="flex items-center justify-between gap-3">
                       <dt className="text-muted-foreground">Inventory asset value</dt>

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -58,12 +58,12 @@ export default function InsightsPage() {
   };
 
   if (statusLoading) {
-    return <div className="space-y-6"><div className="h-12 w-72 animate-pulse rounded-2xl bg-card" /><div className="h-64 animate-pulse rounded-3xl bg-card" /></div>;
+    return <div className="space-y-6"><div className="h-12 w-72 animate-pulse rounded-md bg-card" /><div className="h-64 animate-pulse rounded-lg bg-card" /></div>;
   }
 
   return (
     <div className="space-y-8">
-      <section className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+      <section className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
           <div className="max-w-2xl">
             <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
@@ -75,7 +75,7 @@ export default function InsightsPage() {
               Ask for explainable recommendations grounded in your app data. This surface is analysis only: no autonomous writes, no silent pricing changes, and no hidden inventory actions.
             </p>
           </div>
-          <div className="rounded-[1.5rem] border border-border bg-background/80 p-4 text-sm">
+          <div className="rounded-md border border-border bg-background/80 p-4 text-sm">
             <p className="font-semibold text-foreground">Active provider</p>
             <p className="mt-2 text-lg font-semibold capitalize">{status?.provider || 'Unavailable'}</p>
             <p className="text-muted-foreground">{status?.model || 'No model selected'}</p>
@@ -104,7 +104,7 @@ export default function InsightsPage() {
         </div>
       </section>
 
-      <section className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+      <section className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
         <div className="flex flex-col gap-4">
           <div>
             <h2 className="text-xl font-semibold">Ask a focused question</h2>
@@ -134,7 +134,7 @@ export default function InsightsPage() {
             onChange={(e) => setQuestion(e.target.value)}
             rows={4}
             placeholder="Example: What should I print more of before the next market and what inventory is at risk?"
-            className="w-full rounded-[1.5rem] border border-input bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            className="w-full rounded-md border border-input bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
           />
 
           <div className="flex flex-wrap items-center gap-3">
@@ -142,7 +142,7 @@ export default function InsightsPage() {
               type="button"
               onClick={() => void handleGenerate()}
               disabled={summaryMutation.isPending || !status?.configured}
-              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-md bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
             >
               {summaryMutation.isPending ? <LoaderCircle className="h-5 w-5 animate-spin" /> : <Sparkles className="h-5 w-5" />}
               {summaryMutation.isPending ? 'Generating insights...' : 'Generate Insight Summary'}
@@ -164,9 +164,9 @@ export default function InsightsPage() {
 
       {summary ? (
         <>
-          <section className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+          <section className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
             <div className="flex items-start gap-4">
-              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-primary/12 text-primary">
                 <Bot className="h-6 w-6" />
               </div>
               <div>
@@ -186,11 +186,11 @@ export default function InsightsPage() {
           </section>
 
           <section className="grid gap-6 xl:grid-cols-2">
-            <div className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+            <div className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
               <h3 className="text-xl font-semibold">Recommendations</h3>
               <div className="mt-4 space-y-4">
                 {summary.recommendations.length ? summary.recommendations.map((item, index) => (
-                  <article key={`${item.title}-${index}`} className="rounded-[1.5rem] border border-border bg-background/80 p-4">
+                  <article key={`${item.title}-${index}`} className="rounded-md border border-border bg-background/80 p-4">
                     <div className="flex items-start justify-between gap-3">
                       <h4 className="font-semibold">{item.title}</h4>
                       <PriorityBadge value={item.priority} />
@@ -203,11 +203,11 @@ export default function InsightsPage() {
               </div>
             </div>
 
-            <div className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+            <div className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
               <h3 className="text-xl font-semibold">Risks</h3>
               <div className="mt-4 space-y-4">
                 {summary.risks.length ? summary.risks.map((item, index) => (
-                  <article key={`${item.title}-${index}`} className="rounded-[1.5rem] border border-border bg-background/80 p-4">
+                  <article key={`${item.title}-${index}`} className="rounded-md border border-border bg-background/80 p-4">
                     <div className="flex items-start justify-between gap-3">
                       <h4 className="font-semibold">{item.title}</h4>
                       <PriorityBadge value={item.priority} />
@@ -222,14 +222,14 @@ export default function InsightsPage() {
           </section>
 
           <section className="grid gap-6 xl:grid-cols-[1.4fr_1fr]">
-            <div className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+            <div className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
               <h3 className="text-xl font-semibold">Evidence metrics</h3>
               <p className="mt-1 text-sm text-muted-foreground">
                 Jakob&apos;s Law and Common Region: the recommendation copy stays separate from the source-of-truth numbers it references.
               </p>
               <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
                 {summary.evidence_metrics.map((metric) => (
-                  <div key={metric.key} className="rounded-[1.3rem] border border-border bg-background/80 p-4">
+                  <div key={metric.key} className="rounded-md border border-border bg-background/80 p-4">
                     <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">{metric.label}</p>
                     <p className="mt-2 text-xl font-semibold">{metric.value}</p>
                   </div>
@@ -237,7 +237,7 @@ export default function InsightsPage() {
               </div>
             </div>
 
-            <div className="rounded-[2rem] border border-border bg-card/90 p-6 shadow-[0_18px_50px_rgba(8,17,31,0.08)]">
+            <div className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
               <h3 className="text-xl font-semibold">Suggested follow-ups</h3>
               <div className="mt-4 space-y-3">
                 {summary.suggested_questions.length ? summary.suggested_questions.map((item) => (
@@ -248,7 +248,7 @@ export default function InsightsPage() {
                       setQuestion(item);
                       void handleGenerate(item);
                     }}
-                    className="block w-full rounded-[1.3rem] border border-border bg-background/80 px-4 py-3 text-left text-sm font-medium transition-colors hover:border-primary/35 hover:bg-primary/5"
+                    className="block w-full rounded-md border border-border bg-background/80 px-4 py-3 text-left text-sm font-medium transition-colors hover:border-primary/35 hover:bg-primary/5"
                   >
                     {item}
                   </button>

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -53,7 +53,7 @@ function SurfaceButton({ active, label, detail, onClick }: SurfaceButtonProps) {
       onClick={onClick}
       aria-pressed={active}
       className={cn(
-        'rounded-2xl border px-4 py-3 text-left transition-colors',
+        'rounded-md border px-4 py-3 text-left transition-colors',
         active
           ? 'border-primary bg-primary text-primary-foreground shadow-sm'
           : 'border-border bg-background/80 text-foreground hover:border-primary/35'
@@ -73,7 +73,7 @@ interface HeroMetricProps {
 
 function HeroMetric({ label, value, detail }: HeroMetricProps) {
   return (
-    <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+    <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
       <p className="text-xs uppercase tracking-[0.24em] text-white/55">{label}</p>
       <p className="mt-3 text-2xl font-semibold">{value}</p>
       <p className="mt-2 text-sm text-white/70">{detail}</p>
@@ -97,7 +97,7 @@ function TaskCard({
   return (
     <div
       className={cn(
-        'rounded-3xl border p-5 shadow-sm',
+        'rounded-lg border p-5 shadow-sm',
         tone === 'warning' ? 'border-amber-300/70 bg-amber-50' : 'border-border bg-card'
       )}
     >
@@ -107,7 +107,7 @@ function TaskCard({
         type="button"
         onClick={onAction}
         className={cn(
-          'mt-4 inline-flex items-center gap-2 rounded-2xl px-4 py-2 text-sm font-semibold transition-colors',
+          'mt-4 inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold transition-colors',
           tone === 'warning'
             ? 'bg-amber-900 text-white hover:opacity-90'
             : 'bg-primary text-primary-foreground hover:opacity-90'
@@ -258,7 +258,7 @@ export default function InventoryPage() {
 
   return (
     <div className="max-w-7xl mx-auto space-y-6">
-      <section className="rounded-[2rem] border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(19,52,34,0.96)_100%)] p-6 text-white shadow-sm">
+      <section className="rounded-lg border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(19,52,34,0.96)_100%)] p-6 text-white shadow-sm">
         <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
           <div className="max-w-3xl">
             <p className="text-sm uppercase tracking-[0.3em] text-white/65">Stock Workspace</p>
@@ -275,7 +275,7 @@ export default function InventoryPage() {
             <button
               type="button"
               onClick={() => openReconcile()}
-              className="inline-flex min-h-12 items-center gap-2 rounded-2xl bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+              className="inline-flex min-h-12 items-center gap-2 rounded-md bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90"
             >
               <ClipboardCheck className="h-4 w-4" />
               Reconcile stock
@@ -283,7 +283,7 @@ export default function InventoryPage() {
             <button
               type="button"
               onClick={() => openAdjust()}
-              className="inline-flex min-h-12 items-center gap-2 rounded-2xl border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white transition-colors hover:bg-white/15"
+              className="inline-flex min-h-12 items-center gap-2 rounded-md border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white transition-colors hover:bg-white/15"
             >
               <Plus className="h-4 w-4" />
               Quick adjustment
@@ -320,7 +320,7 @@ export default function InventoryPage() {
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
           onClick={(event) => event.target === event.currentTarget && setShowReconcile(false)}
         >
-          <div className="w-full max-w-lg rounded-2xl border border-border bg-card p-6 shadow-xl">
+          <div className="w-full max-w-lg rounded-md border border-border bg-card p-6 shadow-xl">
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-lg font-semibold">Stock reconciliation</h2>
               <button
@@ -431,7 +431,7 @@ export default function InventoryPage() {
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
           onClick={(event) => event.target === event.currentTarget && setShowAdjust(false)}
         >
-          <div className="w-full max-w-md rounded-2xl border border-border bg-card p-6 shadow-xl">
+          <div className="w-full max-w-md rounded-md border border-border bg-card p-6 shadow-xl">
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-lg font-semibold">Quick stock adjustment</h2>
               <button
@@ -554,7 +554,7 @@ export default function InventoryPage() {
         />
       </section>
 
-      <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+      <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <p className="text-sm uppercase tracking-[0.24em] text-muted-foreground">Workspace Surfaces</p>
@@ -584,7 +584,7 @@ export default function InventoryPage() {
       {surface === 'exceptions' ? (
         <div className="space-y-6">
           <section className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]">
-            <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
               <div className="flex items-center gap-2">
                 <TriangleAlert className="h-5 w-5 text-destructive" />
                 <h2 className="text-xl font-semibold">Product exceptions</h2>
@@ -608,7 +608,7 @@ export default function InventoryPage() {
                       <div
                         key={`${alert.type}-${alert.id}`}
                         className={cn(
-                          'rounded-2xl border p-4',
+                          'rounded-md border p-4',
                           isCritical ? 'border-destructive/35 bg-destructive/5' : 'border-amber-300/60 bg-amber-50/70'
                         )}
                       >
@@ -663,23 +663,23 @@ export default function InventoryPage() {
             </div>
 
             <div className="space-y-4">
-              <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+              <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
                 <div className="flex items-center gap-2">
                   <PackageSearch className="h-5 w-5 text-muted-foreground" />
                   <h2 className="text-xl font-semibold">Exception summary</h2>
                 </div>
                 <div className="mt-4 space-y-3">
-                  <div className="rounded-2xl bg-background px-4 py-3">
+                  <div className="rounded-md bg-background px-4 py-3">
                     <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Out of stock</p>
                     <p className="mt-2 text-2xl font-semibold">{outOfStockProducts.length}</p>
                     <p className="mt-1 text-sm text-muted-foreground">Products that cannot be sold from POS right now.</p>
                   </div>
-                  <div className="rounded-2xl bg-background px-4 py-3">
+                  <div className="rounded-md bg-background px-4 py-3">
                     <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Near reorder</p>
                     <p className="mt-2 text-2xl font-semibold">{nearReorderProducts.length}</p>
                     <p className="mt-1 text-sm text-muted-foreground">Products that still have stock but need floor attention soon.</p>
                   </div>
-                  <div className="rounded-2xl bg-background px-4 py-3">
+                  <div className="rounded-md bg-background px-4 py-3">
                     <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Material signals</p>
                     <p className="mt-2 text-2xl font-semibold">{materialAlerts.length}</p>
                     <p className="mt-1 text-sm text-muted-foreground">Raw-material alerts kept in a separate lane.</p>
@@ -687,7 +687,7 @@ export default function InventoryPage() {
                 </div>
               </div>
 
-              <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+              <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
                 <div className="flex items-center gap-2">
                   <ScrollText className="h-5 w-5 text-muted-foreground" />
                   <h2 className="text-xl font-semibold">Recent risky movements</h2>
@@ -698,7 +698,7 @@ export default function InventoryPage() {
                 ) : (
                   <div className="mt-4 space-y-3">
                     {recentRiskTransactions.map((transaction) => (
-                      <div key={transaction.id} className="rounded-2xl border border-border bg-background/80 px-4 py-3">
+                      <div key={transaction.id} className="rounded-md border border-border bg-background/80 px-4 py-3">
                         <div className="flex items-start justify-between gap-3">
                           <div>
                             <p className="font-medium">{transaction.product_name || transaction.product_id}</p>
@@ -725,7 +725,7 @@ export default function InventoryPage() {
                 <button
                   type="button"
                   onClick={() => setSurface('ledger')}
-                  className="mt-4 inline-flex items-center gap-2 rounded-2xl border border-border px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent"
+                  className="mt-4 inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent"
                 >
                   Open full ledger
                   <ArrowRight className="h-4 w-4" />
@@ -735,7 +735,7 @@ export default function InventoryPage() {
           </section>
 
           <section className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
-            <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
               <div className="flex items-center gap-2">
                 <TrendingDown className="h-5 w-5 text-amber-600" />
                 <h2 className="text-xl font-semibold">Materials lane</h2>
@@ -749,7 +749,7 @@ export default function InventoryPage() {
               ) : (
                 <div className="mt-4 space-y-3">
                   {materialAlerts.map((alert) => (
-                    <div key={`${alert.type}-${alert.id}`} className="rounded-2xl border border-border bg-background/80 px-4 py-3">
+                    <div key={`${alert.type}-${alert.id}`} className="rounded-md border border-border bg-background/80 px-4 py-3">
                       <div className="flex items-start justify-between gap-3">
                         <div>
                           <p className="font-medium">{alert.name}</p>
@@ -770,7 +770,7 @@ export default function InventoryPage() {
               )}
             </div>
 
-            <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+            <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
               <div className="flex items-center gap-2">
                 <Clock3 className="h-5 w-5 text-muted-foreground" />
                 <h2 className="text-xl font-semibold">Quick reminders</h2>
@@ -785,7 +785,7 @@ export default function InventoryPage() {
         </div>
       ) : (
         <div className="space-y-6">
-          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
               <div>
                 <div className="flex items-center gap-2">
@@ -799,7 +799,7 @@ export default function InventoryPage() {
               <button
                 type="button"
                 onClick={() => setSurface('exceptions')}
-                className="inline-flex items-center gap-2 rounded-2xl border border-border px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent"
+                className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent"
               >
                 Back to exceptions
               </button>
@@ -853,11 +853,11 @@ export default function InventoryPage() {
           {isLoading ? (
             <SkeletonTable rows={8} cols={8} />
           ) : !items.length ? (
-            <div className="rounded-3xl border border-border bg-card p-8 text-center text-muted-foreground">
+            <div className="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">
               No inventory transactions found
             </div>
           ) : (
-            <div className="overflow-x-auto rounded-3xl border border-border bg-card shadow-sm">
+            <div className="overflow-x-auto rounded-lg border border-border bg-card shadow-sm">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b border-border text-left text-muted-foreground">

--- a/frontend/src/pages/OrdersPage.tsx
+++ b/frontend/src/pages/OrdersPage.tsx
@@ -22,7 +22,7 @@ const ATTENTION_PRINTER_STATUSES = new Set(['paused', 'maintenance', 'offline', 
 
 function QueueStat({ label, value, detail }: { label: string; value: string; detail: string }) {
   return (
-    <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+    <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
       <p className="text-xs uppercase tracking-[0.24em] text-white/55">{label}</p>
       <p className="mt-3 text-2xl font-semibold">{value}</p>
       <p className="mt-2 text-sm text-white/70">{detail}</p>
@@ -99,7 +99,7 @@ export default function OrdersPage() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-[2rem] border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(27,55,44,0.96)_100%)] p-6 text-white shadow-sm">
+      <section className="rounded-lg border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(27,55,44,0.96)_100%)] p-6 text-white shadow-sm">
         <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
           <div className="max-w-3xl">
             <p className="text-sm uppercase tracking-[0.3em] text-white/65">Orders Workspace</p>
@@ -115,14 +115,14 @@ export default function OrdersPage() {
           <div className="flex flex-wrap gap-3">
             <Link
               to="/orders/jobs/new"
-              className="inline-flex min-h-12 items-center gap-2 rounded-2xl bg-primary px-5 py-3 font-semibold text-primary-foreground no-underline transition-opacity hover:opacity-90"
+              className="inline-flex min-h-12 items-center gap-2 rounded-md bg-primary px-5 py-3 font-semibold text-primary-foreground no-underline transition-opacity hover:opacity-90"
             >
               <PackageOpen className="h-4 w-4" />
               New job
             </Link>
             <Link
               to="/orders/jobs"
-              className="inline-flex min-h-12 items-center gap-2 rounded-2xl border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white no-underline transition-colors hover:bg-white/15"
+              className="inline-flex min-h-12 items-center gap-2 rounded-md border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white no-underline transition-colors hover:bg-white/15"
             >
               Open jobs
             </Link>
@@ -139,7 +139,7 @@ export default function OrdersPage() {
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.92fr)]">
         <section className="space-y-6">
-          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
               <div>
                 <div className="flex items-center gap-2">
@@ -163,7 +163,7 @@ export default function OrdersPage() {
                     type="button"
                     onClick={() => setJobStatusFilter(value as typeof jobStatusFilter)}
                     className={cn(
-                      'rounded-2xl border px-4 py-3 text-left transition-colors',
+                      'rounded-md border px-4 py-3 text-left transition-colors',
                       jobStatusFilter === value
                         ? 'border-primary bg-primary text-primary-foreground'
                         : 'border-border bg-background hover:border-primary/35'
@@ -194,7 +194,7 @@ export default function OrdersPage() {
                 {visibleJobs.map((job: Job) => {
                   const missingAssignment = !job.printer_id && job.status !== 'completed' && job.status !== 'cancelled';
                   return (
-                    <div key={job.id} className={cn('rounded-2xl border p-4', missingAssignment ? 'border-amber-300/60 bg-amber-50/70' : 'border-border bg-background/80')}>
+                    <div key={job.id} className={cn('rounded-md border p-4', missingAssignment ? 'border-amber-300/60 bg-amber-50/70' : 'border-border bg-background/80')}>
                       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                         <div className="min-w-0">
                           <div className="flex flex-wrap items-center gap-2">
@@ -245,7 +245,7 @@ export default function OrdersPage() {
             )}
           </div>
 
-          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <div className="flex items-center gap-2">
@@ -258,7 +258,7 @@ export default function OrdersPage() {
               </div>
               <Link
                 to="/sell/sales"
-                className="inline-flex items-center gap-2 rounded-2xl border border-border px-4 py-2 text-sm font-semibold text-foreground no-underline transition-colors hover:bg-accent"
+                className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-semibold text-foreground no-underline transition-colors hover:bg-accent"
               >
                 Open sales inbox
                 <ArrowRight className="h-4 w-4" />
@@ -270,7 +270,7 @@ export default function OrdersPage() {
             ) : (
               <div className="mt-4 space-y-3">
                 {fulfillmentSales.slice(0, 8).map((sale: SaleListItem) => (
-                  <div key={sale.id} className="rounded-2xl border border-border bg-background/80 p-4">
+                  <div key={sale.id} className="rounded-md border border-border bg-background/80 p-4">
                     <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                       <div>
                         <div className="flex flex-wrap items-center gap-2">
@@ -298,23 +298,23 @@ export default function OrdersPage() {
         </section>
 
         <aside className="space-y-4">
-          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex items-center gap-2">
               <TriangleAlert className="h-5 w-5 text-amber-600" />
               <h2 className="text-xl font-semibold">Assignment pressure</h2>
             </div>
             <div className="mt-4 space-y-3">
-              <div className="rounded-2xl bg-background px-4 py-3">
+              <div className="rounded-md bg-background px-4 py-3">
                 <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Unassigned jobs</p>
                 <p className="mt-2 text-2xl font-semibold">{jobsNeedingAssignment.length}</p>
                 <p className="mt-1 text-sm text-muted-foreground">Jobs that need printer selection or reassignment.</p>
               </div>
-              <div className="rounded-2xl bg-background px-4 py-3">
+              <div className="rounded-md bg-background px-4 py-3">
                 <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Ready printers</p>
                 <p className="mt-2 text-2xl font-semibold">{readyPrinters.length}</p>
                 <p className="mt-1 text-sm text-muted-foreground">Idle machines available for production work.</p>
               </div>
-              <div className="rounded-2xl bg-background px-4 py-3">
+              <div className="rounded-md bg-background px-4 py-3">
                 <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Attention printers</p>
                 <p className="mt-2 text-2xl font-semibold">{attentionPrinters.length}</p>
                 <p className="mt-1 text-sm text-muted-foreground">Paused, offline, maintenance, or error states.</p>
@@ -322,7 +322,7 @@ export default function OrdersPage() {
             </div>
           </section>
 
-          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2">
                 <User className="h-5 w-5 text-muted-foreground" />
@@ -330,7 +330,7 @@ export default function OrdersPage() {
               </div>
               <Link
                 to="/orders/customers"
-                className="inline-flex items-center gap-2 rounded-2xl border border-border px-4 py-2 text-sm font-semibold text-foreground no-underline transition-colors hover:bg-accent"
+                className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-semibold text-foreground no-underline transition-colors hover:bg-accent"
               >
                 Open customers
               </Link>
@@ -345,7 +345,7 @@ export default function OrdersPage() {
             ) : (
               <div className="mt-4 space-y-3">
                 {topCustomers.map((customer) => (
-                  <div key={customer.id} className="rounded-2xl border border-border bg-background/80 px-4 py-3">
+                  <div key={customer.id} className="rounded-md border border-border bg-background/80 px-4 py-3">
                     <div className="flex items-center justify-between gap-3">
                       <div>
                         <p className="font-medium">{customer.name}</p>
@@ -362,7 +362,7 @@ export default function OrdersPage() {
             )}
           </section>
 
-          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <h2 className="text-xl font-semibold">Known gap</h2>
             <p className="mt-3 text-sm text-muted-foreground">
               This first pass stitches jobs, sales, printers, and customers client-side. Quote-specific queueing and a dedicated backend fulfillment queue endpoint are still separate follow-on work.

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -50,7 +50,7 @@ interface MetricCardProps {
 
 function MetricCard({ label, value, detail }: MetricCardProps) {
   return (
-    <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+    <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
       <p className="text-xs uppercase tracking-[0.25em] text-white/55">{label}</p>
       <p className="mt-3 text-2xl font-semibold">{value}</p>
       <p className="mt-2 text-sm text-white/70">{detail}</p>
@@ -71,7 +71,7 @@ function QuickFilterButton({ active, label, detail, onClick }: QuickFilterButton
       type="button"
       onClick={onClick}
       className={cn(
-        'rounded-2xl border px-4 py-3 text-left transition-colors',
+        'rounded-md border px-4 py-3 text-left transition-colors',
         active
           ? 'border-primary bg-primary/10 text-foreground shadow-sm'
           : 'border-border bg-background/80 text-muted-foreground hover:border-primary/40 hover:text-foreground'
@@ -98,7 +98,7 @@ function CustomerModeButton({ active, icon: Icon, label, detail, onClick }: Cust
       onClick={onClick}
       aria-pressed={active}
       className={cn(
-        'rounded-2xl border px-4 py-4 text-left transition-colors',
+        'rounded-md border px-4 py-4 text-left transition-colors',
         active
           ? 'border-primary bg-primary/10 text-foreground shadow-sm'
           : 'border-border bg-background/85 text-muted-foreground hover:border-primary/40 hover:text-foreground'
@@ -107,7 +107,7 @@ function CustomerModeButton({ active, icon: Icon, label, detail, onClick }: Cust
       <div className="flex items-start gap-3">
         <div
           className={cn(
-            'rounded-2xl p-2',
+            'rounded-md p-2',
             active ? 'bg-primary text-primary-foreground' : 'bg-accent text-accent-foreground'
           )}
         >
@@ -135,7 +135,7 @@ function PaymentButton({ active, label, onClick }: PaymentButtonProps) {
       onClick={onClick}
       aria-pressed={active}
       className={cn(
-        'rounded-2xl border px-4 py-3 text-sm font-semibold transition-colors',
+        'rounded-md border px-4 py-3 text-sm font-semibold transition-colors',
         active
           ? 'border-primary bg-primary text-primary-foreground shadow-sm'
           : 'border-border bg-background hover:border-primary/40 hover:text-foreground'
@@ -195,7 +195,7 @@ function SalesInboxCard({ sale }: { sale: SaleListItem }) {
   return (
     <Link
       to={`/sell/sales/${sale.id}`}
-      className="block rounded-2xl border border-border bg-background/85 p-4 no-underline transition-colors hover:border-primary/35"
+      className="block rounded-md border border-border bg-background/85 p-4 no-underline transition-colors hover:border-primary/35"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
@@ -452,7 +452,7 @@ export default function POSPage() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-[2rem] border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(19,52,34,0.96)_100%)] p-6 text-white shadow-sm">
+      <section className="rounded-lg border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(19,52,34,0.96)_100%)] p-6 text-white shadow-sm">
         <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
           <div className="max-w-3xl">
             <p className="text-sm uppercase tracking-[0.3em] text-white/65">Sell Workspace</p>
@@ -466,12 +466,12 @@ export default function POSPage() {
           </div>
 
           <div className="grid gap-3 sm:grid-cols-2 xl:min-w-[320px]">
-            <div className="rounded-3xl border border-white/10 bg-white/8 px-4 py-4">
+            <div className="rounded-lg border border-white/10 bg-white/8 px-4 py-4">
               <p className="text-xs uppercase tracking-[0.22em] text-white/60">Shift date</p>
               <p className="mt-2 text-xl font-semibold">{today}</p>
               <p className="mt-1 text-sm text-white/65">Recommended route: `/sell`</p>
             </div>
-            <div className="rounded-3xl border border-white/10 bg-white/8 px-4 py-4">
+            <div className="rounded-lg border border-white/10 bg-white/8 px-4 py-4">
               <p className="text-xs uppercase tracking-[0.22em] text-white/60">Sales inbox</p>
               <p className="mt-2 text-xl font-semibold">{salesNeedingAttention}</p>
               <p className="mt-1 text-sm text-white/65">Pending or refunded sales needing eyes</p>
@@ -488,7 +488,7 @@ export default function POSPage() {
       </section>
 
       {successMessage ? (
-        <div className="rounded-3xl border border-emerald-300 bg-emerald-50 px-5 py-4 text-emerald-900 shadow-sm" role="status">
+        <div className="rounded-lg border border-emerald-300 bg-emerald-50 px-5 py-4 text-emerald-900 shadow-sm" role="status">
           <div className="flex items-start gap-3">
             <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0" />
             <div>
@@ -500,7 +500,7 @@ export default function POSPage() {
       ) : null}
 
       {checkoutError ? (
-        <div className="rounded-3xl border border-destructive/35 bg-destructive/10 px-5 py-4 text-destructive shadow-sm" role="alert">
+        <div className="rounded-lg border border-destructive/35 bg-destructive/10 px-5 py-4 text-destructive shadow-sm" role="alert">
           <div className="flex items-start gap-3">
             <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
             <div>
@@ -513,7 +513,7 @@ export default function POSPage() {
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(360px,0.95fr)]">
         <section className="space-y-4">
-          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
               <div>
                 <div className="flex items-center gap-2">
@@ -540,11 +540,11 @@ export default function POSPage() {
                       onChange={(event) => setScanCode(event.target.value)}
                       placeholder="Scan UPC and press Enter"
                       aria-label="Scan barcode"
-                      className="min-h-14 flex-1 rounded-2xl border border-input bg-background px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
+                      className="min-h-14 flex-1 rounded-md border border-input bg-background px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
                     />
                     <button
                       type="submit"
-                      className="inline-flex min-h-14 items-center justify-center gap-2 rounded-2xl bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+                      className="inline-flex min-h-14 items-center justify-center gap-2 rounded-md bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90"
                     >
                       Resolve scan
                       <ArrowRight className="h-4 w-4" />
@@ -553,7 +553,7 @@ export default function POSPage() {
                 </form>
               </div>
 
-              <div className="rounded-3xl border border-border bg-background/80 p-4">
+              <div className="rounded-lg border border-border bg-background/80 p-4">
                 <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">Lane rules</p>
                 <div className="mt-3 space-y-3 text-sm text-muted-foreground">
                   <p>Exact UPC match only.</p>
@@ -566,7 +566,7 @@ export default function POSPage() {
             {scanStatus ? (
               <div
                 className={cn(
-                  'mt-4 rounded-2xl border px-4 py-3 text-sm',
+                  'mt-4 rounded-md border px-4 py-3 text-sm',
                   scanStatus.startsWith('Scanned ')
                     ? 'border-emerald-300 bg-emerald-50 text-emerald-900'
                     : 'border-amber-300 bg-amber-50 text-amber-900'
@@ -577,7 +577,7 @@ export default function POSPage() {
             ) : null}
           </div>
 
-          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
               <div>
                 <h2 className="text-xl font-semibold">Catalog lane</h2>
@@ -592,7 +592,7 @@ export default function POSPage() {
                   onChange={(event) => setSearch(event.target.value)}
                   placeholder="Search products..."
                   aria-label="Search products"
-                  className="min-h-14 w-full rounded-2xl border border-input bg-background py-3 pl-11 pr-4 text-base focus:outline-none focus:ring-2 focus:ring-ring"
+                  className="min-h-14 w-full rounded-md border border-input bg-background py-3 pl-11 pr-4 text-base focus:outline-none focus:ring-2 focus:ring-ring"
                 />
               </div>
             </div>
@@ -608,11 +608,11 @@ export default function POSPage() {
           {productsLoading ? (
             <div className="grid gap-3 md:grid-cols-2">
               {Array.from({ length: 6 }).map((_, index) => (
-                <div key={index} className="h-48 animate-pulse rounded-3xl border border-border bg-card" />
+                <div key={index} className="h-48 animate-pulse rounded-lg border border-border bg-card" />
               ))}
             </div>
           ) : productsError ? (
-            <div className="rounded-3xl border border-destructive/40 bg-destructive/10 p-6 text-destructive">
+            <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-destructive">
               Unable to load products for POS checkout.
             </div>
           ) : !filteredProducts.length ? (
@@ -624,7 +624,7 @@ export default function POSPage() {
                   ? 'Try a different search term or filter combination.'
                   : 'Add active products with stock before using the POS register.'
               }
-              className="rounded-3xl border border-border bg-card"
+              className="rounded-lg border border-border bg-card"
             />
           ) : (
             <div className="grid gap-3 md:grid-cols-2">
@@ -638,7 +638,7 @@ export default function POSPage() {
                   <article
                     key={product.id}
                     className={cn(
-                      'rounded-3xl border border-border bg-card p-5 shadow-sm transition-colors',
+                      'rounded-lg border border-border bg-card p-5 shadow-sm transition-colors',
                       outOfStock ? 'opacity-70' : 'hover:border-primary/35'
                     )}
                   >
@@ -650,21 +650,21 @@ export default function POSPage() {
                           {product.upc ? `UPC ${product.upc}` : 'No UPC assigned yet'}
                         </p>
                       </div>
-                      <div className="rounded-2xl bg-accent px-4 py-3 text-sm font-semibold text-accent-foreground">
+                      <div className="rounded-md bg-accent px-4 py-3 text-sm font-semibold text-accent-foreground">
                         {formatCurrency(product.unit_price)}
                       </div>
                     </div>
 
                     <div className="mt-4 grid gap-3 sm:grid-cols-3">
-                      <div className="rounded-2xl bg-background px-3 py-3">
+                      <div className="rounded-md bg-background px-3 py-3">
                         <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Stock</p>
                         <p className={cn('mt-2 text-lg font-semibold', lowStock && 'text-amber-600')}>{product.stock_qty}</p>
                       </div>
-                      <div className="rounded-2xl bg-background px-3 py-3">
+                      <div className="rounded-md bg-background px-3 py-3">
                         <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">In cart</p>
                         <p className="mt-2 text-lg font-semibold">{cartQty}</p>
                       </div>
-                      <div className="rounded-2xl bg-background px-3 py-3">
+                      <div className="rounded-md bg-background px-3 py-3">
                         <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Scanner</p>
                         <p className="mt-2 text-sm font-semibold">{product.upc ? 'Ready' : 'Manual only'}</p>
                       </div>
@@ -675,7 +675,7 @@ export default function POSPage() {
                       onClick={() => handleAddProduct(product)}
                       disabled={outOfStock}
                       aria-label={`Add ${product.name} to cart`}
-                      className="mt-4 inline-flex min-h-14 w-full items-center justify-center gap-2 rounded-2xl bg-primary px-4 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
+                      className="mt-4 inline-flex min-h-14 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
                     >
                       <Plus className="h-4 w-4" />
                       {outOfStock ? 'Stock maxed in cart' : 'Add to cart'}
@@ -688,7 +688,7 @@ export default function POSPage() {
         </section>
 
         <aside className="space-y-4 xl:sticky xl:top-6 xl:self-start">
-          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <h2 className="text-xl font-semibold">Cart and checkout</h2>
@@ -700,7 +700,7 @@ export default function POSPage() {
             </div>
 
             {!cart.length ? (
-              <div className="mt-6 rounded-3xl border border-dashed border-border bg-background/70 p-8 text-center">
+              <div className="mt-6 rounded-lg border border-dashed border-border bg-background/70 p-8 text-center">
                 <ShoppingBasket className="mx-auto h-10 w-10 text-muted-foreground" />
                 <p className="mt-4 text-lg font-medium">Cart is empty</p>
                 <p className="mt-2 text-sm text-muted-foreground">Add products from the catalog lane or scan a barcode to start a sale.</p>
@@ -708,7 +708,7 @@ export default function POSPage() {
             ) : (
               <div className="mt-5 space-y-3">
                 {cart.map((line) => (
-                  <div key={line.product_id} className="rounded-3xl border border-border bg-background/85 p-4">
+                  <div key={line.product_id} className="rounded-lg border border-border bg-background/85 p-4">
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <p className="font-medium">{line.name}</p>
@@ -718,14 +718,14 @@ export default function POSPage() {
                         type="button"
                         onClick={() => setCart((prev) => removeProductFromCart(prev, line.product_id))}
                         aria-label={`Remove ${line.name} from cart`}
-                        className="rounded-2xl p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                        className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                       >
                         <Trash2 className="h-4 w-4" />
                       </button>
                     </div>
 
                     <div className="mt-4 flex items-center justify-between gap-3">
-                      <div className="inline-flex items-center rounded-2xl border border-border bg-card">
+                      <div className="inline-flex items-center rounded-md border border-border bg-card">
                         <button
                           type="button"
                           onClick={() => setCart((prev) => updateCartLineQuantity(prev, line.product_id, line.quantity - 1))}
@@ -758,7 +758,7 @@ export default function POSPage() {
               </div>
             )}
 
-            <div className="mt-6 rounded-3xl border border-border bg-background/70 p-4">
+            <div className="mt-6 rounded-lg border border-border bg-background/70 p-4">
               <div className="flex items-center gap-2">
                 <Users className="h-4 w-4 text-muted-foreground" />
                 <h3 className="text-base font-semibold">Customer mode</h3>
@@ -817,7 +817,7 @@ export default function POSPage() {
                       setCheckoutError(null);
                     }}
                     aria-label="Existing customer"
-                    className="min-h-14 w-full rounded-2xl border border-input bg-background px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
+                    className="min-h-14 w-full rounded-md border border-input bg-background px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
                   >
                     <option value="">Select customer</option>
                     {customers.map((customer) => (
@@ -840,13 +840,13 @@ export default function POSPage() {
                     onChange={(event) => setCustomerName(event.target.value)}
                     placeholder="Name for receipt or follow-up"
                     aria-label="Customer name"
-                    className="min-h-14 w-full rounded-2xl border border-input bg-background px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
+                    className="min-h-14 w-full rounded-md border border-input bg-background px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
                   />
                 </div>
               ) : null}
             </div>
 
-            <div className="mt-4 rounded-3xl border border-border bg-background/70 p-4">
+            <div className="mt-4 rounded-lg border border-border bg-background/70 p-4">
               <div className="flex items-center gap-2">
                 <WalletCards className="h-4 w-4 text-muted-foreground" />
                 <h3 className="text-base font-semibold">Payment method</h3>
@@ -879,7 +879,7 @@ export default function POSPage() {
                   value={taxCollected}
                   onChange={(event) => setTaxCollected(Math.max(0, Number(event.target.value) || 0))}
                   aria-label="Tax collected"
-                  className="min-h-14 w-full rounded-2xl border border-input bg-background px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
+                  className="min-h-14 w-full rounded-md border border-input bg-background px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-ring"
                 />
               </div>
 
@@ -894,12 +894,12 @@ export default function POSPage() {
                   rows={3}
                   placeholder="Optional booth or counter notes"
                   aria-label="Notes"
-                  className="w-full rounded-2xl border border-input bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  className="w-full rounded-md border border-input bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 />
               </div>
             </div>
 
-            <div className="mt-4 rounded-3xl bg-background p-4">
+            <div className="mt-4 rounded-lg bg-background p-4">
               <div className="flex items-center justify-between text-sm">
                 <span className="text-muted-foreground">Subtotal</span>
                 <span>{formatCurrency(subtotal)}</span>
@@ -923,7 +923,7 @@ export default function POSPage() {
                 (customerMode === 'existing' && !selectedCustomerId) ||
                 (customerMode === 'new' && !customerName.trim())
               }
-              className="mt-6 inline-flex min-h-14 w-full items-center justify-center gap-2 rounded-2xl bg-primary px-4 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
+              className="mt-6 inline-flex min-h-14 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
             >
               {saving ? 'Processing checkout...' : 'Complete checkout'}
             </button>
@@ -932,14 +932,14 @@ export default function POSPage() {
               <button
                 type="button"
                 onClick={resetCheckoutFields}
-                className="mt-3 inline-flex min-h-14 w-full items-center justify-center gap-2 rounded-2xl border border-border px-4 py-3 font-semibold transition-colors hover:bg-accent"
+                className="mt-3 inline-flex min-h-14 w-full items-center justify-center gap-2 rounded-md border border-border px-4 py-3 font-semibold transition-colors hover:bg-accent"
               >
                 <XCircle className="h-4 w-4" />
                 Clear cart
               </button>
             ) : null}
 
-            <div className="mt-4 rounded-2xl border border-amber-300/60 bg-amber-50 p-3 text-sm text-amber-900">
+            <div className="mt-4 rounded-md border border-amber-300/60 bg-amber-50 p-3 text-sm text-amber-900">
               <div className="flex items-start gap-2">
                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
                 <p>Checkout blocks oversell when requested quantity exceeds available stock.</p>
@@ -947,7 +947,7 @@ export default function POSPage() {
             </div>
           </section>
 
-          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <div className="flex items-center gap-2">
@@ -960,7 +960,7 @@ export default function POSPage() {
               </div>
               <Link
                 to="/sell/sales"
-                className="inline-flex items-center gap-2 rounded-2xl border border-border px-4 py-2 text-sm font-semibold text-foreground no-underline transition-colors hover:bg-accent"
+                className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-semibold text-foreground no-underline transition-colors hover:bg-accent"
               >
                 Open inbox
                 <ArrowRight className="h-4 w-4" />
@@ -970,7 +970,7 @@ export default function POSPage() {
             {salesInboxLoading ? (
               <div className="mt-4 space-y-3">
                 {Array.from({ length: 3 }).map((_, index) => (
-                  <div key={index} className="h-28 animate-pulse rounded-3xl border border-border bg-background" />
+                  <div key={index} className="h-28 animate-pulse rounded-lg border border-border bg-background" />
                 ))}
               </div>
             ) : salesInbox.length ? (

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -97,7 +97,7 @@ function ConsoleStat({
   emphasis?: 'default' | 'warning' | 'success';
 }) {
   return (
-    <div className="rounded-[1.45rem] border border-border bg-card/85 p-4 shadow-[0_14px_40px_rgba(8,17,31,0.06)]">
+    <div className="rounded-md border border-border bg-card/85 p-4 shadow-sm">
       <div className="flex items-start justify-between gap-3">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">{label}</p>
@@ -112,7 +112,7 @@ function ConsoleStat({
           </p>
           {subtext ? <p className="mt-1 text-sm text-muted-foreground">{subtext}</p> : null}
         </div>
-        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+        <div className="flex h-11 w-11 items-center justify-center rounded-md bg-primary/12 text-primary">
           <Icon className="h-5 w-5" />
         </div>
       </div>
@@ -205,7 +205,7 @@ export default function PrinterDetailPage() {
         <ArrowLeft className="h-4 w-4" /> Back to printer wall
       </Link>
 
-      <section className="overflow-hidden rounded-[2rem] border border-border bg-[linear-gradient(135deg,rgba(8,17,31,0.98),rgba(17,34,53,0.96))] px-6 py-6 text-white shadow-[0_24px_70px_rgba(8,17,31,0.18)]">
+      <section className="overflow-hidden rounded-lg border border-border bg-[linear-gradient(135deg,rgba(8,17,31,0.98),rgba(17,34,53,0.96))] px-6 py-6 text-white shadow-md">
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
           <div>
             <div className="flex flex-wrap items-center gap-2">
@@ -230,7 +230,7 @@ export default function PrinterDetailPage() {
                 <>
                   <button
                     onClick={testConnection}
-                    className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-[0_16px_40px_rgba(34,197,94,0.28)]"
+                    className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm"
                   >
                     <PlugZap className="h-4 w-4" /> Test connection
                   </button>
@@ -258,7 +258,7 @@ export default function PrinterDetailPage() {
             </div>
           </div>
 
-          <div className="rounded-[1.6rem] border border-white/10 bg-black/15 p-5">
+          <div className="rounded-md border border-white/10 bg-black/15 p-5">
             <div className="flex items-start justify-between gap-3">
               <div>
                 <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-300/75">Current print</p>
@@ -336,7 +336,7 @@ export default function PrinterDetailPage() {
       </div>
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
-        <section className="rounded-[1.8rem] border border-border bg-card/85 p-5 shadow-[0_16px_40px_rgba(8,17,31,0.06)]">
+        <section className="rounded-lg border border-border bg-card/85 p-5 shadow-md">
           <div className="mb-4 flex items-start justify-between gap-3">
             <div>
               <h2 className="text-xl font-semibold text-foreground">Live monitoring</h2>
@@ -348,25 +348,25 @@ export default function PrinterDetailPage() {
           </div>
 
           {!printer.monitor_enabled ? (
-            <div className="rounded-[1.4rem] border border-dashed border-border bg-background/60 p-6 text-sm text-muted-foreground">
+            <div className="rounded-md border border-dashed border-border bg-background/60 p-6 text-sm text-muted-foreground">
               Monitoring is not configured for this printer yet. The machine is still available as a static tracked record.
             </div>
           ) : (
             <div className="space-y-4">
               <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                <div className="rounded-[1.25rem] border border-border bg-background/60 p-4">
+                <div className="rounded-md border border-border bg-background/60 p-4">
                   <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Provider</p>
                   <p className="mt-2 font-semibold capitalize text-foreground">{printer.monitor_provider || '—'}</p>
                   <p className="mt-1 text-sm text-muted-foreground">{printer.monitor_poll_interval_seconds}s poll interval</p>
                 </div>
-                <div className="rounded-[1.25rem] border border-border bg-background/60 p-4">
+                <div className="rounded-md border border-border bg-background/60 p-4">
                   <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Last event</p>
                   <p className="mt-2 font-semibold text-foreground">
                     {printer.monitor_last_event_type ? printer.monitor_last_event_type.replace('notify_', '').replaceAll('_', ' ') : '—'}
                   </p>
                   <p className="mt-1 text-sm text-muted-foreground">{formatDateTime(printer.monitor_last_event_at)}</p>
                 </div>
-                <div className="rounded-[1.25rem] border border-border bg-background/60 p-4">
+                <div className="rounded-md border border-border bg-background/60 p-4">
                   <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Last seen</p>
                   <p className="mt-2 font-semibold text-foreground">{formatDateTime(printer.monitor_last_seen_at)}</p>
                   <p className="mt-1 text-sm text-muted-foreground">
@@ -379,13 +379,13 @@ export default function PrinterDetailPage() {
                 </div>
               </div>
 
-              <div className="rounded-[1.4rem] border border-border bg-background/60 p-4">
+              <div className="rounded-md border border-border bg-background/60 p-4">
                 <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Provider message</p>
                 <p className="mt-2 text-sm text-foreground">{printer.monitor_last_message || '—'}</p>
               </div>
 
               {printer.monitor_last_error ? (
-                <div className="rounded-[1.4rem] border border-red-300/60 bg-red-50/80 p-4 dark:border-red-500/30 dark:bg-red-500/10">
+                <div className="rounded-md border border-red-300/60 bg-red-50/80 p-4 dark:border-red-500/30 dark:bg-red-500/10">
                   <div className="flex items-start gap-3">
                     <AlertTriangle className="mt-0.5 h-4 w-4 text-red-600 dark:text-red-300" />
                     <div>
@@ -399,7 +399,7 @@ export default function PrinterDetailPage() {
           )}
         </section>
 
-        <section className="rounded-[1.8rem] border border-border bg-card/85 p-5 shadow-[0_16px_40px_rgba(8,17,31,0.06)]">
+        <section className="rounded-lg border border-border bg-card/85 p-5 shadow-md">
           <div className="mb-4 flex items-center justify-between">
             <div>
               <h2 className="text-xl font-semibold text-foreground">Visual console</h2>
@@ -423,24 +423,24 @@ export default function PrinterDetailPage() {
               mseWsUrl={printer.camera_mse_ws_url}
               snapshotUrl={printer.camera_snapshot_url}
               alt={`${printer.name} camera feed`}
-              className="min-h-[280px] rounded-[1.4rem]"
+              className="min-h-[280px] rounded-md"
             />
           ) : (
             <PrinterThumbnail
               src={printer.current_print_thumbnail_url}
               alt={printer.current_print_name ? `${printer.current_print_name} thumbnail` : `${printer.name} current print thumbnail`}
-              className="min-h-[280px] rounded-[1.4rem]"
+              className="min-h-[280px] rounded-md"
               fallbackLabel={printer.current_print_name ? 'No thumbnail in G-code metadata' : 'No active print'}
             />
           )}
 
           <div className="mt-4 grid gap-3 sm:grid-cols-2">
-            <div className="rounded-[1.25rem] border border-border bg-background/60 p-4">
+            <div className="rounded-md border border-border bg-background/60 p-4">
               <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Machine identity</p>
               <p className="mt-2 font-semibold text-foreground">{printer.manufacturer || '—'} {printer.model || ''}</p>
               <p className="mt-1 text-sm text-muted-foreground">{printer.serial_number || 'No serial number'}</p>
             </div>
-            <div className="rounded-[1.25rem] border border-border bg-background/60 p-4">
+            <div className="rounded-md border border-border bg-background/60 p-4">
               <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Current assignment</p>
               {activeJob ? (
                 <>
@@ -456,7 +456,7 @@ export default function PrinterDetailPage() {
           </div>
 
           {printer.notes ? (
-            <div className="mt-4 rounded-[1.25rem] border border-border bg-background/60 p-4">
+            <div className="mt-4 rounded-md border border-border bg-background/60 p-4">
               <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Notes</p>
               <p className="mt-2 whitespace-pre-wrap text-sm text-foreground">{printer.notes}</p>
             </div>
@@ -464,7 +464,7 @@ export default function PrinterDetailPage() {
         </section>
       </div>
 
-      <section className="rounded-[1.8rem] border border-border bg-card/85 p-5 shadow-[0_16px_40px_rgba(8,17,31,0.06)]">
+      <section className="rounded-lg border border-border bg-card/85 p-5 shadow-md">
         <div className="mb-4 flex items-start justify-between gap-3">
           <div>
             <h2 className="text-xl font-semibold text-foreground">Recent floor activity</h2>
@@ -478,7 +478,7 @@ export default function PrinterDetailPage() {
         </div>
 
         {!printer.history_events.length ? (
-          <div className="rounded-[1.4rem] border border-dashed border-border bg-background/60 p-6 text-sm text-muted-foreground">
+          <div className="rounded-md border border-dashed border-border bg-background/60 p-6 text-sm text-muted-foreground">
             No printer activity has been recorded yet.
           </div>
         ) : (
@@ -490,7 +490,7 @@ export default function PrinterDetailPage() {
               const fromPrinter = formatEventMetaValue(event.metadata?.from_printer_name);
               const toPrinter = formatEventMetaValue(event.metadata?.to_printer_name);
               return (
-                <div key={event.id} className="rounded-[1.35rem] border border-border bg-background/60 p-4">
+                <div key={event.id} className="rounded-md border border-border bg-background/60 p-4">
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                     <div>
                       <p className="font-medium text-foreground">{event.title}</p>
@@ -513,7 +513,7 @@ export default function PrinterDetailPage() {
         )}
       </section>
 
-      <section className="rounded-[1.8rem] border border-border bg-card/85 p-5 shadow-[0_16px_40px_rgba(8,17,31,0.06)]">
+      <section className="rounded-lg border border-border bg-card/85 p-5 shadow-md">
         <div className="mb-4 flex items-center justify-between gap-3">
           <div>
             <h2 className="text-xl font-semibold text-foreground">Assigned jobs</h2>
@@ -527,11 +527,11 @@ export default function PrinterDetailPage() {
         {jobsLoading ? (
           <SkeletonTable rows={5} cols={6} />
         ) : !recentJobs.length ? (
-          <div className="rounded-[1.4rem] border border-dashed border-border bg-background/60 p-8 text-center text-muted-foreground">
+          <div className="rounded-md border border-dashed border-border bg-background/60 p-8 text-center text-muted-foreground">
             No jobs assigned to this printer yet.
           </div>
         ) : (
-          <div className="overflow-x-auto rounded-[1.4rem] border border-border bg-background/60">
+          <div className="overflow-x-auto rounded-md border border-border bg-background/60">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-border text-left text-muted-foreground">

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -111,7 +111,7 @@ function SummaryCard({
   emphasis?: 'default' | 'warning' | 'success';
 }) {
   return (
-    <div className="rounded-[1.5rem] border border-border bg-card/80 p-4 shadow-[0_14px_40px_rgba(8,17,31,0.06)]">
+    <div className="rounded-md border border-border bg-card/80 p-4 shadow-sm">
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">{label}</p>
       <p
         className={cn(
@@ -147,7 +147,7 @@ function PrinterWallCard({
   return (
     <article
       className={cn(
-        'rounded-[1.6rem] border p-4 shadow-[0_16px_40px_rgba(8,17,31,0.06)]',
+        'rounded-md border p-4 shadow-md',
         !reducedMotion && 'transition-colors',
         needsAttention
           ? 'border-amber-300/70 bg-amber-50/80 dark:border-amber-500/30 dark:bg-amber-500/10'
@@ -193,14 +193,14 @@ function PrinterWallCard({
             mseWsUrl={printer.camera_mse_ws_url}
             snapshotUrl={printer.camera_snapshot_url}
             alt={`${printer.name} camera`}
-            className="h-[104px] w-[104px] rounded-[1.25rem]"
+            className="h-[104px] w-[104px] rounded-md"
             showLiveBadge={false}
           />
         ) : (
         <PrinterThumbnail
           src={printer.current_print_thumbnail_url}
           alt={printer.current_print_name ? `${printer.current_print_name} thumbnail` : `${printer.name} thumbnail`}
-          className="h-[104px] w-[104px] rounded-[1.25rem]"
+          className="h-[104px] w-[104px] rounded-md"
           imgClassName="object-cover"
           fallbackLabel={printer.current_print_name ? 'No thumbnail' : 'No active print'}
         />
@@ -256,7 +256,7 @@ function PrinterWallCard({
         </div>
       </div>
 
-      <div className="mt-4 rounded-[1.25rem] border border-border bg-background/60 p-3">
+      <div className="mt-4 rounded-md border border-border bg-background/60 p-3">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Current job</p>
@@ -282,7 +282,7 @@ function PrinterWallCard({
       <div className="mt-4 flex flex-wrap gap-2">
         <Link
           to={`/print-floor/printers/${printer.id}`}
-          className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline shadow-[0_12px_32px_rgba(34,197,94,0.22)]"
+          className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline shadow-sm"
         >
           Open console
         </Link>
@@ -486,9 +486,9 @@ export default function PrintersPage() {
   };
 
   return (
-    <div className={cn('space-y-6', wallMode && 'rounded-[2rem] bg-[linear-gradient(180deg,#020617_0%,#08111f_100%)] p-4 text-slate-50')}>
+    <div className={cn('space-y-6', wallMode && 'rounded-lg bg-[linear-gradient(180deg,#020617_0%,#08111f_100%)] p-4 text-slate-50')}>
       <section className={cn(
-        'overflow-hidden rounded-[2rem] border border-border bg-[linear-gradient(135deg,rgba(8,17,31,0.98),rgba(17,34,53,0.96))] px-6 py-6 text-white shadow-[0_24px_70px_rgba(8,17,31,0.18)]',
+        'overflow-hidden rounded-lg border border-border bg-[linear-gradient(135deg,rgba(8,17,31,0.98),rgba(17,34,53,0.96))] px-6 py-6 text-white shadow-md',
         wallMode && 'border-slate-700/80 bg-[linear-gradient(135deg,rgba(2,6,23,0.98),rgba(8,17,31,0.96))] shadow-none'
       )}>
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,0.65fr)]">
@@ -507,7 +507,7 @@ export default function PrintersPage() {
                 <>
                   <Link
                     to="/print-floor/printers/new"
-                    className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline shadow-[0_16px_40px_rgba(34,197,94,0.28)]"
+                    className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline shadow-sm"
                   >
                     <Plus className="h-4 w-4" /> Add printer
                   </Link>
@@ -586,7 +586,7 @@ export default function PrintersPage() {
       </div>
 
       {attentionPrinters.length > 0 ? (
-        <section className="rounded-[1.7rem] border border-amber-300/70 bg-amber-50/80 p-5 shadow-[0_16px_40px_rgba(8,17,31,0.06)] dark:border-amber-500/30 dark:bg-amber-500/10">
+        <section className="rounded-lg border border-amber-300/70 bg-amber-50/80 p-5 shadow-md dark:border-amber-500/30 dark:bg-amber-500/10">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <div>
               <div className="flex items-center gap-2">
@@ -618,7 +618,7 @@ export default function PrintersPage() {
                 setPage(0);
               }}
               placeholder="Search printers by name, model, slug, or location..."
-              className="w-full rounded-[1rem] border border-input bg-card/80 py-3 pl-10 pr-3 focus:outline-none focus:ring-2 focus:ring-ring"
+              className="w-full rounded-md border border-input bg-card/80 py-3 pl-10 pr-3 focus:outline-none focus:ring-2 focus:ring-ring"
             />
           </div>
           <select
@@ -627,7 +627,7 @@ export default function PrintersPage() {
               setStatus(e.target.value);
               setPage(0);
             }}
-            className="rounded-[1rem] border border-input bg-card/80 px-3 py-3 focus:outline-none focus:ring-2 focus:ring-ring"
+            className="rounded-md border border-input bg-card/80 px-3 py-3 focus:outline-none focus:ring-2 focus:ring-ring"
           >
             <option value="">All statuses</option>
             {STATUS_OPTIONS.map((option) => (
@@ -642,7 +642,7 @@ export default function PrintersPage() {
               setActive(e.target.value);
               setPage(0);
             }}
-            className="rounded-[1rem] border border-input bg-card/80 px-3 py-3 focus:outline-none focus:ring-2 focus:ring-ring"
+            className="rounded-md border border-input bg-card/80 px-3 py-3 focus:outline-none focus:ring-2 focus:ring-ring"
           >
             <option value="">Active + inactive</option>
             <option value="true">Active only</option>
@@ -650,7 +650,7 @@ export default function PrintersPage() {
           </select>
         </div>
       ) : (
-        <section className="rounded-[1.7rem] border border-slate-700/80 bg-slate-950/80 p-5 shadow-none">
+        <section className="rounded-lg border border-slate-700/80 bg-slate-950/80 p-5 shadow-none">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <div>
               <h2 className="text-lg font-semibold text-slate-50">Wall-mode monitor behavior</h2>
@@ -673,11 +673,11 @@ export default function PrintersPage() {
       {isLoading || jobsLoading ? (
         <div className={cn('grid gap-4', wallMode ? 'xl:grid-cols-3 2xl:grid-cols-3' : 'xl:grid-cols-3')}>
           {Array.from({ length: 3 }).map((_, index) => (
-            <div key={index} className="rounded-[1.6rem] border border-border bg-card/85 p-4">
+            <div key={index} className="rounded-md border border-border bg-card/85 p-4">
               <div className="mb-4 h-6 w-44 animate-pulse rounded bg-muted" />
               <div className="space-y-3">
                 {Array.from({ length: 2 }).map((__, cardIndex) => (
-                  <div key={cardIndex} className="h-72 animate-pulse rounded-[1.4rem] border border-border bg-background/70" />
+                  <div key={cardIndex} className="h-72 animate-pulse rounded-md border border-border bg-background/70" />
                 ))}
               </div>
             </div>
@@ -704,7 +704,7 @@ export default function PrintersPage() {
             return (
               <section
                 key={group.key}
-                className={cn('rounded-[1.8rem] border p-4 shadow-[0_16px_40px_rgba(8,17,31,0.06)]', group.panelTone || 'border-border bg-card/85')}
+                className={cn('rounded-lg border p-4 shadow-md', group.panelTone || 'border-border bg-card/85')}
               >
                 <div className="mb-4 flex items-start justify-between gap-3">
                   <div>
@@ -733,7 +733,7 @@ export default function PrintersPage() {
                     ))}
                   </div>
                 ) : (
-                  <div className="rounded-[1.4rem] border border-dashed border-border bg-background/60 px-4 py-12 text-center text-sm text-muted-foreground">
+                  <div className="rounded-md border border-dashed border-border bg-background/60 px-4 py-12 text-center text-sm text-muted-foreground">
                     {group.emptyText}
                   </div>
                 )}

--- a/frontend/src/pages/ProductEditorPage.tsx
+++ b/frontend/src/pages/ProductEditorPage.tsx
@@ -142,13 +142,13 @@ export default function ProductEditorPage() {
   }
 
   const inputClass = (field: string) =>
-    `w-full rounded-2xl border px-4 py-3 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring ${
+    `w-full rounded-md border px-4 py-3 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring ${
       formErrors[field] ? 'border-destructive' : 'border-input'
     }`;
 
   return (
     <div className="space-y-6">
-      <section className="rounded-[2rem] border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.12),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(24,24,27,0.96)_100%)] p-6 text-white shadow-sm">
+      <section className="rounded-lg border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.12),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(24,24,27,0.96)_100%)] p-6 text-white shadow-sm">
         <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
           <div className="max-w-3xl">
             <p className="text-sm uppercase tracking-[0.3em] text-white/65">Product Studio</p>
@@ -164,7 +164,7 @@ export default function ProductEditorPage() {
           <div className="flex flex-wrap gap-3">
             <Link
               to="/product-studio"
-              className="inline-flex min-h-12 items-center gap-2 rounded-2xl border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white no-underline transition-colors hover:bg-white/15"
+              className="inline-flex min-h-12 items-center gap-2 rounded-md border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white no-underline transition-colors hover:bg-white/15"
             >
               <ArrowLeft className="h-4 w-4" />
               Back to catalog
@@ -172,7 +172,7 @@ export default function ProductEditorPage() {
             {!isCreate ? (
               <Link
                 to={`/product-studio/products/${id}`}
-                className="inline-flex min-h-12 items-center gap-2 rounded-2xl border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white no-underline transition-colors hover:bg-white/15"
+                className="inline-flex min-h-12 items-center gap-2 rounded-md border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white no-underline transition-colors hover:bg-white/15"
               >
                 View record
                 <ArrowRight className="h-4 w-4" />
@@ -184,7 +184,7 @@ export default function ProductEditorPage() {
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.95fr)]">
         <section className="space-y-6">
-          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex items-center gap-2">
               <ReceiptText className="h-5 w-5 text-muted-foreground" />
               <h2 className="text-xl font-semibold">Identity and sellable details</h2>
@@ -218,7 +218,7 @@ export default function ProductEditorPage() {
 
               <div>
                 <label className="mb-2 block text-sm font-medium">SKU</label>
-                <div className="rounded-2xl border border-border bg-background px-4 py-3 text-sm">
+                <div className="rounded-md border border-border bg-background px-4 py-3 text-sm">
                   {product?.sku || 'Generated after first save'}
                 </div>
               </div>
@@ -287,7 +287,7 @@ export default function ProductEditorPage() {
                 type="button"
                 onClick={save}
                 disabled={saving}
-                className="inline-flex min-h-12 items-center gap-2 rounded-2xl bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+                className="inline-flex min-h-12 items-center gap-2 rounded-md bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
               >
                 <Save className="h-4 w-4" />
                 {saving ? 'Saving...' : isCreate ? 'Create product' : 'Save changes'}
@@ -295,7 +295,7 @@ export default function ProductEditorPage() {
               {!isCreate ? (
                 <Link
                   to={`/product-studio/products/${id}`}
-                  className="inline-flex min-h-12 items-center gap-2 rounded-2xl border border-border px-5 py-3 font-semibold text-foreground no-underline transition-colors hover:bg-accent"
+                  className="inline-flex min-h-12 items-center gap-2 rounded-md border border-border px-5 py-3 font-semibold text-foreground no-underline transition-colors hover:bg-accent"
                 >
                   Open detail record
                 </Link>
@@ -303,7 +303,7 @@ export default function ProductEditorPage() {
             </div>
           </div>
 
-          <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex items-center gap-2">
               <Boxes className="h-5 w-5 text-muted-foreground" />
               <h2 className="text-xl font-semibold">Stock and activity context</h2>
@@ -322,7 +322,7 @@ export default function ProductEditorPage() {
             ) : (
               <div className="mt-4 space-y-3">
                 {recentTransactions.map((transaction: InventoryTransaction) => (
-                  <div key={transaction.id} className="rounded-2xl border border-border bg-background/80 px-4 py-3">
+                  <div key={transaction.id} className="rounded-md border border-border bg-background/80 px-4 py-3">
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <p className="font-medium capitalize">{transaction.type}</p>
@@ -349,14 +349,14 @@ export default function ProductEditorPage() {
         </section>
 
         <aside className="space-y-4 xl:sticky xl:top-6 xl:self-start">
-          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex items-center gap-2">
               <BadgeDollarSign className="h-5 w-5 text-muted-foreground" />
               <h2 className="text-xl font-semibold">Readiness and margin</h2>
             </div>
 
             <div className="mt-4 space-y-3">
-              <div className={cn('rounded-2xl border px-4 py-3', readinessTone(identityReadiness))}>
+              <div className={cn('rounded-md border px-4 py-3', readinessTone(identityReadiness))}>
                 <p className="font-semibold">Identity</p>
                 <p className="mt-1 text-sm">
                   {identityReadiness === 'ready'
@@ -367,7 +367,7 @@ export default function ProductEditorPage() {
                 </p>
               </div>
 
-              <div className={cn('rounded-2xl border px-4 py-3', readinessTone(barcodeReadiness))}>
+              <div className={cn('rounded-md border px-4 py-3', readinessTone(barcodeReadiness))}>
                 <p className="font-semibold">POS readiness</p>
                 <p className="mt-1 text-sm">
                   {barcodeReadiness === 'ready'
@@ -376,7 +376,7 @@ export default function ProductEditorPage() {
                 </p>
               </div>
 
-              <div className={cn('rounded-2xl border px-4 py-3', readinessTone(stockReadiness))}>
+              <div className={cn('rounded-md border px-4 py-3', readinessTone(stockReadiness))}>
                 <p className="font-semibold">Stock policy</p>
                 <p className="mt-1 text-sm">
                   {isCreate
@@ -390,7 +390,7 @@ export default function ProductEditorPage() {
               </div>
             </div>
 
-            <div className="mt-5 space-y-3 rounded-3xl bg-background p-4">
+            <div className="mt-5 space-y-3 rounded-lg bg-background p-4">
               <div className="flex items-center justify-between text-sm">
                 <span className="text-muted-foreground">Unit price</span>
                 <span>{formatCurrency(Number(form.unit_price || 0))}</span>
@@ -418,7 +418,7 @@ export default function ProductEditorPage() {
             </div>
 
             {marginDollars < 0 ? (
-              <div className="mt-4 rounded-2xl border border-destructive/35 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              <div className="mt-4 rounded-md border border-destructive/35 bg-destructive/10 px-4 py-3 text-sm text-destructive">
                 <div className="flex items-start gap-2">
                   <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
                   <p>This price is below the current unit cost.</p>
@@ -427,20 +427,20 @@ export default function ProductEditorPage() {
             ) : null}
           </section>
 
-          <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+          <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <h2 className="text-xl font-semibold">Material context</h2>
             {selectedMaterial ? (
               <div className="mt-4 space-y-3 text-sm">
-                <div className="rounded-2xl bg-background px-4 py-3">
+                <div className="rounded-md bg-background px-4 py-3">
                   <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Material</p>
                   <p className="mt-2 font-semibold">{selectedMaterial.name}</p>
                   <p className="mt-1 text-muted-foreground">{selectedMaterial.brand}</p>
                 </div>
-                <div className="rounded-2xl bg-background px-4 py-3">
+                <div className="rounded-md bg-background px-4 py-3">
                   <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Cost per gram</p>
                   <p className="mt-2 font-semibold">${Number(selectedMaterial.cost_per_g).toFixed(4)}</p>
                 </div>
-                <div className="rounded-2xl bg-background px-4 py-3">
+                <div className="rounded-md bg-background px-4 py-3">
                   <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Material stock</p>
                   <p className="mt-2 font-semibold">{selectedMaterial.spools_in_stock} spools</p>
                   <p className="mt-1 text-muted-foreground">Reorder at {selectedMaterial.reorder_point}</p>

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -52,7 +52,7 @@ export default function ProductsPage() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-[2rem] border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.12),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(24,24,27,0.96)_100%)] p-6 text-white shadow-sm">
+      <section className="rounded-lg border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.12),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(24,24,27,0.96)_100%)] p-6 text-white shadow-sm">
         <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
           <div className="max-w-3xl">
             <p className="text-sm uppercase tracking-[0.3em] text-white/65">Product Studio</p>
@@ -64,7 +64,7 @@ export default function ProductsPage() {
 
           <Link
             to="/product-studio/products/new"
-            className="inline-flex min-h-12 items-center gap-2 rounded-2xl bg-primary px-5 py-3 font-semibold text-primary-foreground no-underline transition-opacity hover:opacity-90"
+            className="inline-flex min-h-12 items-center gap-2 rounded-md bg-primary px-5 py-3 font-semibold text-primary-foreground no-underline transition-opacity hover:opacity-90"
           >
             <Plus className="h-4 w-4" />
             New product
@@ -72,26 +72,26 @@ export default function ProductsPage() {
         </div>
 
         <div className="mt-6 grid gap-3 lg:grid-cols-4">
-          <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+          <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
             <p className="text-xs uppercase tracking-[0.24em] text-white/55">Visible products</p>
             <p className="mt-3 text-2xl font-semibold">{total}</p>
           </div>
-          <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+          <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
             <p className="text-xs uppercase tracking-[0.24em] text-white/55">Low stock</p>
             <p className="mt-3 text-2xl font-semibold">{lowStockCount}</p>
           </div>
-          <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+          <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
             <p className="text-xs uppercase tracking-[0.24em] text-white/55">Barcode ready</p>
             <p className="mt-3 text-2xl font-semibold">{barcodeReadyCount}</p>
           </div>
-          <div className="rounded-3xl border border-white/10 bg-black/20 px-4 py-4">
+          <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
             <p className="text-xs uppercase tracking-[0.24em] text-white/55">Authoring route</p>
             <p className="mt-3 text-lg font-semibold">/product-studio/products/new</p>
           </div>
         </div>
       </section>
 
-      <section className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+      <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <h2 className="text-xl font-semibold">Catalog</h2>
@@ -106,7 +106,7 @@ export default function ProductsPage() {
               setSearch(event.target.value);
               setPage(0);
             }}
-            className="w-full rounded-2xl border border-input bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring lg:max-w-sm"
+            className="w-full rounded-md border border-input bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring lg:max-w-sm"
           />
         </div>
       </section>
@@ -130,7 +130,7 @@ export default function ProductsPage() {
         />
       ) : (
         <>
-          <div className="hidden overflow-x-auto rounded-3xl border border-border bg-card shadow-sm md:block">
+          <div className="hidden overflow-x-auto rounded-lg border border-border bg-card shadow-sm md:block">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-border text-left text-muted-foreground">
@@ -215,7 +215,7 @@ export default function ProductsPage() {
 
           <div className="space-y-3 md:hidden">
             {products.map((product) => (
-              <div key={product.id} className="rounded-3xl border border-border bg-card p-4 shadow-sm">
+              <div key={product.id} className="rounded-lg border border-border bg-card p-4 shadow-sm">
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <p className="font-semibold">{product.name}</p>
@@ -244,14 +244,14 @@ export default function ProductsPage() {
                 <div className="mt-4 flex gap-2">
                   <Link
                     to={`/product-studio/products/${product.id}/edit`}
-                    className="inline-flex flex-1 items-center justify-center gap-2 rounded-2xl bg-primary px-4 py-3 font-semibold text-primary-foreground no-underline"
+                    className="inline-flex flex-1 items-center justify-center gap-2 rounded-md bg-primary px-4 py-3 font-semibold text-primary-foreground no-underline"
                   >
                     <Pencil className="h-4 w-4" />
                     Edit
                   </Link>
                   <Link
                     to={`/product-studio/products/${product.id}`}
-                    className="inline-flex items-center justify-center rounded-2xl border border-border px-4 py-3 text-foreground no-underline"
+                    className="inline-flex items-center justify-center rounded-md border border-border px-4 py-3 text-foreground no-underline"
                   >
                     <ArrowRight className="h-4 w-4" />
                   </Link>

--- a/frontend/src/pages/SalesPage.tsx
+++ b/frontend/src/pages/SalesPage.tsx
@@ -59,7 +59,7 @@ export default function SalesPage() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-[2rem] border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.14),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(22,44,64,0.96)_100%)] p-6 text-white shadow-sm">
+      <section className="rounded-lg border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.14),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(22,44,64,0.96)_100%)] p-6 text-white shadow-sm">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-3xl">
             <p className="text-sm uppercase tracking-[0.3em] text-white/65">Sell Workspace</p>
@@ -68,7 +68,7 @@ export default function SalesPage() {
               Review recent sales, refunds, and follow-up work without dropping back into the general dashboard.
             </p>
           </div>
-          <div className="rounded-3xl border border-white/10 bg-white/8 px-4 py-4">
+          <div className="rounded-lg border border-white/10 bg-white/8 px-4 py-4">
             <p className="text-xs uppercase tracking-[0.22em] text-white/60">Visible sales</p>
             <p className="mt-2 text-2xl font-semibold">{total}</p>
             <p className="mt-1 text-sm text-white/65">Filtered transactions in the current inbox view</p>

--- a/frontend/src/pages/admin/CamerasPage.tsx
+++ b/frontend/src/pages/admin/CamerasPage.tsx
@@ -286,7 +286,7 @@ export default function CamerasPage() {
       {/* Modal */}
       {modal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-          <div className="bg-card border border-border rounded-2xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+          <div className="bg-card border border-border rounded-md shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
             <div className="p-6 space-y-5">
               <h2 className="text-lg font-display font-bold">
                 {modal === 'create' ? 'Add Camera' : 'Edit Camera'}

--- a/frontend/src/pages/admin/SettingsPage.tsx
+++ b/frontend/src/pages/admin/SettingsPage.tsx
@@ -131,7 +131,7 @@ export default function SettingsPage() {
         <div className="space-y-6">
           <div className="bg-card border border-border rounded-lg p-6">
             <div className="mb-5 flex items-start gap-3">
-              <div className="rounded-2xl bg-primary/10 p-3 text-primary">
+              <div className="rounded-md bg-primary/10 p-3 text-primary">
                 <Bot className="h-6 w-6" />
               </div>
               <div>
@@ -150,7 +150,7 @@ export default function SettingsPage() {
                     key={provider.value}
                     type="button"
                     onClick={() => update('ai_provider', provider.value)}
-                    className={`rounded-2xl border p-4 text-left transition-colors ${
+                    className={`rounded-md border p-4 text-left transition-colors ${
                       isActive
                         ? 'border-primary bg-primary/5'
                         : 'border-border bg-background hover:border-primary/30'
@@ -165,7 +165,7 @@ export default function SettingsPage() {
               })}
             </div>
 
-            <div className="mt-6 rounded-2xl border border-border bg-background/70 p-5">
+            <div className="mt-6 rounded-md border border-border bg-background/70 p-5">
               <div className="mb-4 flex items-start gap-3">
                 <div className="rounded-xl bg-primary/10 p-2 text-primary">
                   <KeyRound className="h-4 w-4" />

--- a/frontend/src/pages/reports/SalesReportPage.tsx
+++ b/frontend/src/pages/reports/SalesReportPage.tsx
@@ -93,7 +93,7 @@ export default function SalesReportPage() {
                   <Tooltip formatter={formatTooltipCurrency} contentStyle={{ backgroundColor: 'var(--color-card)', border: '1px solid var(--color-border)', borderRadius: '8px' }} />
                   <Legend />
                   <Line type="monotone" dataKey="gross_sales" name="Gross Sales" stroke="var(--color-primary)" strokeWidth={2} dot={{ r: 3 }} />
-                  <Line type="monotone" dataKey="gross_profit" name="Gross Profit" stroke="#22c55e" strokeWidth={2} dot={{ r: 3 }} />
+                  <Line type="monotone" dataKey="gross_profit" name="Gross Profit" stroke="#10b981" strokeWidth={2} dot={{ r: 3 }} />
                   <Line type="monotone" dataKey="contribution_margin" name="Contribution Margin" stroke="#f59e0b" strokeWidth={2} dot={{ r: 3 }} />
                 </LineChart>
               </ResponsiveContainer>
@@ -144,7 +144,7 @@ export default function SalesReportPage() {
                     <Tooltip formatter={formatTooltipCurrency} contentStyle={{ backgroundColor: 'var(--color-card)', border: '1px solid var(--color-border)', borderRadius: '8px' }} />
                     <Legend />
                     <Bar dataKey="gross_sales" name="Gross Sales" fill="var(--color-primary)" radius={[4, 4, 0, 0]} />
-                    <Bar dataKey="contribution_margin" name="Contribution Margin" fill="#22c55e" radius={[4, 4, 0, 0]} />
+                    <Bar dataKey="contribution_margin" name="Contribution Margin" fill="#10b981" radius={[4, 4, 0, 0]} />
                   </BarChart>
                 </ResponsiveContainer>
                 <div className="mt-4 overflow-x-auto">


### PR DESCRIPTION
Closes #158 (phase 1 of epic #157)

## Summary

Swap the token system to match modern business-SaaS conventions (Stripe / Linear / Shopify / GitHub) — without touching component markup. One `index.css` rewrite + a mechanical find/replace sweep across 17 pages/components shifts the visual identity from "control-room" to "business application" in a single PR.

## Token changes (frontend/src/index.css)

| Token | Before | After |
|-------|--------|-------|
| `--color-primary` | `#22c55e` (neon green) | `#2563eb` light / `#3b82f6` dark (trust blue) |
| `--color-card` | `rgba(255,255,255,0.88)` / `rgba(15,23,40,0.86)` | `#ffffff` / `#0f172a` (opaque) |
| `--color-background` gradient | 2 radials + linear over color-mix | flat — no decorative gradients |
| Fonts | Rubik + Nunito Sans | Inter (single family) |
| Heading letter-spacing | `-0.02em` | `-0.01em` |
| Radii | `sm=6, md=12, lg=16` | `sm=6, md=8, lg=12, xl=16` |
| Shadows | ad-hoc colored glows | 4-tier `--shadow-xs/sm/md/lg` scale |
| Status palette | informal | explicit `--color-success` / `--color-warning` / `--color-info` + foregrounds |

Green is **retained** as `--color-success` (`#10b981`) for paid/complete/positive semantics — matches business-app conventions.

## Page sweep (17 files)

- `rounded-3xl` → `rounded-lg`, `rounded-2xl` → `rounded-md`
- All arbitrary `rounded-[Nrem]` (2rem, 1.9rem, 1.75rem, 1.45rem, 1.4rem, 1.35rem, 1.3rem, 1.25rem, ...) normalized to `rounded-md` / `rounded-lg`
- Decorative colored glow shadows (`rgba(34,197,94,...)` neon green + `rgba(8,17,31,...)` dark blue inside `shadow-[...]`) stripped → replaced with the new `shadow-sm` / `shadow-md` tokens
- Two hardcoded `#22c55e` chart strokes in `SalesReportPage` → `#10b981` (matches new success token)

## Out of scope (deferred)

- Dark hero-banner gradients inside `bg-[linear-gradient(...)]` on list pages — **phase 2** (#159)
- Table markup, status-badge redesign, component primitives — **phases 3 & 4** (#160, #161)

Phase 2 will delete those heroes wholesale, so standardizing them in this PR would be wasted work.

## Acceptance criteria (from #158)

- [x] `index.css` uses Inter as the only font family
- [x] Primary token is trust blue (`#2563eb` light / `#3b82f6` dark)
- [x] `body` has no `radial-gradient` / `linear-gradient`
- [x] Three shadow tokens (`--shadow-xs/sm/md/lg`) defined
- [x] Card token is opaque in both light and dark
- [x] `rg 'rounded-\[[0-9]' frontend/src` → 0 matches
- [x] `rg 'rounded-3xl\|rounded-2xl' frontend/src` → 0 matches
- [x] `rg '#22c55e' frontend/src --glob '!index.css'` → 0 matches
- [x] Heading letter-spacing is `-0.01em`
- [x] `--color-success` retained for status semantics
- [x] No `rgba(34,197,94,...)` colored glow shadows remain
- [x] `npm run build` succeeds (3.61s)
- [x] `npm test` passes (10/10)

## Test plan

- [x] Frontend build passes
- [x] Existing Vitest suite passes (POS, Insights, Settings, shipping-labels)
- [ ] Visual sanity check across workspaces (deployer to confirm after merge): Login, Control Center, Sales, Inventory, Products, Printers in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)