### PR TITLE
feat(ui): replace hero banners with compact PageHeader (phase 2 of #157)

### DIFF
--- a/frontend/src/components/layout/KPIStrip.tsx
+++ b/frontend/src/components/layout/KPIStrip.tsx
@@ -1,0 +1,56 @@
+import { type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+interface KPIProps {
+  label: string;
+  value: string | number;
+  delta?: { value: string; positive?: boolean };
+  icon?: ReactNode;
+  /** Subtle emphasis for attention / success signals. */
+  tone?: 'default' | 'warning' | 'success' | 'destructive';
+  /** Optional helper text under the value (e.g. "last 7 days"). */
+  sub?: string;
+}
+
+const toneStyles: Record<NonNullable<KPIProps['tone']>, string> = {
+  default: 'text-foreground',
+  warning: 'text-amber-600 dark:text-amber-300',
+  success: 'text-emerald-600 dark:text-emerald-300',
+  destructive: 'text-destructive',
+};
+
+export function KPI({ label, value, delta, icon, tone = 'default', sub }: KPIProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-md border border-border bg-card px-4 py-3 shadow-xs">
+      {icon ? <div className="shrink-0 text-muted-foreground">{icon}</div> : null}
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+        <p className={cn('mt-0.5 text-lg font-semibold tabular-nums', toneStyles[tone])}>{value}</p>
+        {sub ? <p className="mt-0.5 text-xs text-muted-foreground">{sub}</p> : null}
+      </div>
+      {delta ? (
+        <span
+          className={cn(
+            'shrink-0 text-xs font-medium tabular-nums',
+            delta.positive ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive'
+          )}
+        >
+          {delta.value}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+interface KPIStripProps {
+  children: ReactNode;
+  className?: string;
+  /** Column layout at >= lg. 2, 3, or 4 columns. Default 4. */
+  columns?: 2 | 3 | 4;
+}
+
+export function KPIStrip({ children, className, columns = 4 }: KPIStripProps) {
+  const colClass =
+    columns === 2 ? 'lg:grid-cols-2' : columns === 3 ? 'lg:grid-cols-3' : 'lg:grid-cols-4';
+  return <div className={cn('grid gap-3 sm:grid-cols-2', colClass, className)}>{children}</div>;
+}

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -1,0 +1,57 @@
+import { type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+interface PageHeaderProps {
+  title: string;
+  description?: ReactNode;
+  actions?: ReactNode;
+  breadcrumbs?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Standard page intro for workspace / list pages. Replaces the decorative
+ * dark-gradient hero banners previously used on every page. Keep this
+ * compact — the goal is to get to data in <= 120px of vertical space.
+ *
+ * Usage:
+ *   <PageHeader
+ *     title="Sales"
+ *     description={`${total} total`}
+ *     actions={<Link className="...">New sale</Link>}
+ *   />
+ *
+ * With optional KPI strip or tabs below the title:
+ *   <PageHeader title="Inventory" description="...">
+ *     <KPIStrip>...</KPIStrip>
+ *   </PageHeader>
+ */
+export default function PageHeader({
+  title,
+  description,
+  actions,
+  breadcrumbs,
+  children,
+  className,
+}: PageHeaderProps) {
+  return (
+    <header className={cn('space-y-4', className)}>
+      {breadcrumbs}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">{title}</h1>
+          {description ? (
+            typeof description === 'string' ? (
+              <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+            ) : (
+              <div className="mt-1 text-sm text-muted-foreground">{description}</div>
+            )
+          ) : null}
+        </div>
+        {actions ? <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div> : null}
+      </div>
+      {children}
+    </header>
+  );
+}

--- a/frontend/src/pages/ControlCenterPage.tsx
+++ b/frontend/src/pages/ControlCenterPage.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import api from '@/api/client';
 import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
+import PageHeader from '@/components/layout/PageHeader';
 import { useAuthStore } from '@/store/auth';
 import { cn, formatCurrency, formatPercent } from '@/lib/utils';
 import type {
@@ -244,55 +245,46 @@ export default function ControlCenterPage() {
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-lg border border-border bg-[linear-gradient(135deg,rgba(8,17,31,0.98),rgba(17,34,53,0.96))] px-6 py-6 text-white shadow-md">
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.65fr)]">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-cyan-200/75">
-              {roleHeadline}
-            </p>
-            <h1 className="mt-3 text-3xl font-semibold md:text-4xl">
-              Control Center
-            </h1>
-            <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-200/82 md:text-base">
-              {roleDescription}
-            </p>
-            <div className="mt-5 flex flex-wrap gap-3">
-              {quickActions.map((action) => (
-                <Link
-                  key={action.to}
-                  to={action.to}
-                  className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline shadow-sm transition-transform hover:-translate-y-0.5"
-                >
-                  {action.label}
-                </Link>
-              ))}
+      <PageHeader
+        title={roleHeadline || 'Control Center'}
+        description={roleDescription}
+        actions={
+          <>
+            {quickActions.map((action) => (
               <Link
-                to="/dashboard"
-                className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-2 text-sm font-medium text-white no-underline transition-colors hover:bg-white/12"
+                key={action.to}
+                to={action.to}
+                className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground no-underline transition-opacity hover:opacity-90"
               >
-                Classic Dashboard
+                {action.label}
               </Link>
-            </div>
-          </div>
-
-          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
-            <PriorityStat
-              icon={AlertTriangle}
-              label="Needs Attention"
-              value={String(attentionPrinters.length + blockerAlerts.length)}
-              subtext={`${attentionPrinters.length} printers • ${blockerAlerts.length} stock blockers`}
-              emphasis={attentionPrinters.length + blockerAlerts.length > 0 ? 'warning' : 'success'}
-            />
-            <PriorityStat
-              icon={ClipboardList}
-              label="Draft Queue"
-              value={String(unassignedDraftJobs.length)}
-              subtext="Draft jobs without printer assignment"
-              emphasis={unassignedDraftJobs.length > 0 ? 'warning' : 'default'}
-            />
-          </div>
+            ))}
+            <Link
+              to="/dashboard"
+              className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-sm font-medium no-underline hover:bg-muted transition-colors"
+            >
+              Classic Dashboard
+            </Link>
+          </>
+        }
+      >
+        <div className="grid gap-3 sm:grid-cols-2">
+          <PriorityStat
+            icon={AlertTriangle}
+            label="Needs Attention"
+            value={String(attentionPrinters.length + blockerAlerts.length)}
+            subtext={`${attentionPrinters.length} printers • ${blockerAlerts.length} stock blockers`}
+            emphasis={attentionPrinters.length + blockerAlerts.length > 0 ? 'warning' : 'success'}
+          />
+          <PriorityStat
+            icon={ClipboardList}
+            label="Draft Queue"
+            value={String(unassignedDraftJobs.length)}
+            subtext="Draft jobs without printer assignment"
+            emphasis={unassignedDraftJobs.length > 0 ? 'warning' : 'default'}
+          />
         </div>
-      </section>
+      </PageHeader>
 
       <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
         <PriorityStat

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -3,7 +3,6 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   ArrowRight,
-  Boxes,
   ClipboardCheck,
   Clock3,
   PackageSearch,
@@ -17,6 +16,8 @@ import { toast } from 'sonner';
 import api from '@/api/client';
 import EmptyState from '@/components/ui/EmptyState';
 import { SkeletonTable } from '@/components/ui/Skeleton';
+import PageHeader from '@/components/layout/PageHeader';
+import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
 import { cn, formatCurrency } from '@/lib/utils';
 import type { InventoryAlert, InventoryReconcileResponse, PaginatedProducts, PaginatedTransactions } from '@/types';
 
@@ -65,21 +66,6 @@ function SurfaceButton({ active, label, detail, onClick }: SurfaceButtonProps) {
   );
 }
 
-interface HeroMetricProps {
-  label: string;
-  value: string;
-  detail: string;
-}
-
-function HeroMetric({ label, value, detail }: HeroMetricProps) {
-  return (
-    <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
-      <p className="text-xs uppercase tracking-[0.24em] text-white/55">{label}</p>
-      <p className="mt-3 text-2xl font-semibold">{value}</p>
-      <p className="mt-2 text-sm text-white/70">{detail}</p>
-    </div>
-  );
-}
 
 function TaskCard({
   title,
@@ -258,24 +244,19 @@ export default function InventoryPage() {
 
   return (
     <div className="max-w-7xl mx-auto space-y-6">
-      <section className="rounded-lg border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(19,52,34,0.96)_100%)] p-6 text-white shadow-sm">
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-          <div className="max-w-3xl">
-            <p className="text-sm uppercase tracking-[0.3em] text-white/65">Stock Workspace</p>
-            <h1 className="mt-3 flex items-center gap-3 text-3xl font-bold">
-              <Boxes className="h-8 w-8" />
-              Exceptions first
-            </h1>
-            <p className="mt-3 text-sm text-white/80">
-              Lead with stock problems that affect selling and fulfillment. The ledger is still here, but it no longer gets the best seat in the room.
-            </p>
-          </div>
-
-          <div className="flex flex-wrap gap-3">
+      <PageHeader
+        title="Inventory"
+        description={
+          productAlerts.length > 0
+            ? `${productAlerts.length} ${productAlerts.length === 1 ? 'item needs' : 'items need'} attention`
+            : 'Exceptions first — stock problems affecting selling and fulfillment'
+        }
+        actions={
+          <>
             <button
               type="button"
               onClick={() => openReconcile()}
-              className="inline-flex min-h-12 items-center gap-2 rounded-md bg-primary px-5 py-3 font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
             >
               <ClipboardCheck className="h-4 w-4" />
               Reconcile stock
@@ -283,37 +264,40 @@ export default function InventoryPage() {
             <button
               type="button"
               onClick={() => openAdjust()}
-              className="inline-flex min-h-12 items-center gap-2 rounded-md border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white transition-colors hover:bg-white/15"
+              className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
             >
               <Plus className="h-4 w-4" />
               Quick adjustment
             </button>
-          </div>
-        </div>
-
-        <div className="mt-6 grid gap-3 lg:grid-cols-4">
-          <HeroMetric
-            label="Product Alerts"
-            value={String(productAlerts.length)}
-            detail="POS and finished-goods issues requiring action"
+          </>
+        }
+      >
+        <KPIStrip columns={4}>
+          <KPI
+            label="Product alerts"
+            value={productAlerts.length}
+            sub="POS and finished-goods issues"
+            tone={productAlerts.length > 0 ? 'warning' : 'default'}
           />
-          <HeroMetric
-            label="Critical Stockouts"
-            value={String(criticalProductAlerts.length)}
-            detail="Products already at zero stock"
+          <KPI
+            label="Critical stockouts"
+            value={criticalProductAlerts.length}
+            sub="Products at zero stock"
+            tone={criticalProductAlerts.length > 0 ? 'destructive' : 'default'}
           />
-          <HeroMetric
-            label="Near Reorder"
-            value={String(nearReorderProducts.length)}
-            detail="Products still sellable but nearing depletion"
+          <KPI
+            label="Near reorder"
+            value={nearReorderProducts.length}
+            sub="Nearing depletion"
+            tone={nearReorderProducts.length > 0 ? 'warning' : 'default'}
           />
-          <HeroMetric
-            label="Material Signals"
-            value={String(materialAlerts.length)}
-            detail="Lower-priority material stock issues"
+          <KPI
+            label="Material signals"
+            value={materialAlerts.length}
+            sub="Lower-priority issues"
           />
-        </div>
-      </section>
+        </KPIStrip>
+      </PageHeader>
 
       {showReconcile ? (
         <div

--- a/frontend/src/pages/OrdersPage.tsx
+++ b/frontend/src/pages/OrdersPage.tsx
@@ -4,7 +4,6 @@ import { useQuery } from '@tanstack/react-query';
 import {
   ArrowRight,
   Boxes,
-  ClipboardList,
   Eye,
   PackageOpen,
   Printer,
@@ -15,20 +14,12 @@ import {
 import api from '@/api/client';
 import EmptyState from '@/components/ui/EmptyState';
 import { SkeletonTable } from '@/components/ui/Skeleton';
+import PageHeader from '@/components/layout/PageHeader';
+import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
 import { cn, formatCurrency } from '@/lib/utils';
 import type { Customer, Job, PaginatedJobs, PaginatedPrinters, PaginatedSales, SaleListItem } from '@/types';
 
 const ATTENTION_PRINTER_STATUSES = new Set(['paused', 'maintenance', 'offline', 'error']);
-
-function QueueStat({ label, value, detail }: { label: string; value: string; detail: string }) {
-  return (
-    <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
-      <p className="text-xs uppercase tracking-[0.24em] text-white/55">{label}</p>
-      <p className="mt-3 text-2xl font-semibold">{value}</p>
-      <p className="mt-2 text-sm text-white/70">{detail}</p>
-    </div>
-  );
-}
 
 function statusTone(status: string) {
   if (status === 'completed' || status === 'delivered' || status === 'shipped') {
@@ -99,43 +90,56 @@ export default function OrdersPage() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-lg border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(27,55,44,0.96)_100%)] p-6 text-white shadow-sm">
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-          <div className="max-w-3xl">
-            <p className="text-sm uppercase tracking-[0.3em] text-white/65">Orders Workspace</p>
-            <h1 className="mt-3 flex items-center gap-3 text-3xl font-bold">
-              <ClipboardList className="h-8 w-8" />
-              Production and fulfillment queue
-            </h1>
-            <p className="mt-3 text-sm text-white/80">
-              Bring together print jobs, fulfillment-relevant sales, and printer readiness so floor and owner workflows stop bouncing between unrelated pages.
-            </p>
-          </div>
-
-          <div className="flex flex-wrap gap-3">
+      <PageHeader
+        title="Orders"
+        description={
+          jobsNeedingAssignment.length > 0
+            ? `${jobsNeedingAssignment.length} ${jobsNeedingAssignment.length === 1 ? 'job needs' : 'jobs need'} a printer assignment`
+            : 'Production and fulfillment queue'
+        }
+        actions={
+          <>
             <Link
               to="/orders/jobs/new"
-              className="inline-flex min-h-12 items-center gap-2 rounded-md bg-primary px-5 py-3 font-semibold text-primary-foreground no-underline transition-opacity hover:opacity-90"
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground no-underline transition-opacity hover:opacity-90"
             >
               <PackageOpen className="h-4 w-4" />
               New job
             </Link>
             <Link
               to="/orders/jobs"
-              className="inline-flex min-h-12 items-center gap-2 rounded-md border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white no-underline transition-colors hover:bg-white/15"
+              className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-sm font-medium no-underline hover:bg-muted transition-colors"
             >
               Open jobs
             </Link>
-          </div>
-        </div>
-
-        <div className="mt-6 grid gap-3 lg:grid-cols-4">
-          <QueueStat label="Needs Assignment" value={String(jobsNeedingAssignment.length)} detail="Jobs without a printer assignment" />
-          <QueueStat label="In Progress" value={String(productionActive.length)} detail="Jobs currently on the production floor" />
-          <QueueStat label="Fulfillment Queue" value={String(fulfillmentSales.length)} detail="Sales still pending shipment/delivery follow-up" />
-          <QueueStat label="Ready Printers" value={String(readyPrinters.length)} detail="Idle printers available for reassignment" />
-        </div>
-      </section>
+          </>
+        }
+      >
+        <KPIStrip columns={4}>
+          <KPI
+            label="Needs assignment"
+            value={jobsNeedingAssignment.length}
+            sub="Jobs missing a printer"
+            tone={jobsNeedingAssignment.length > 0 ? 'warning' : 'default'}
+          />
+          <KPI
+            label="In progress"
+            value={productionActive.length}
+            sub="Jobs on the production floor"
+          />
+          <KPI
+            label="Fulfillment queue"
+            value={fulfillmentSales.length}
+            sub="Sales pending ship/deliver"
+          />
+          <KPI
+            label="Ready printers"
+            value={readyPrinters.length}
+            sub="Idle, available for assignment"
+            tone={readyPrinters.length === 0 ? 'warning' : 'default'}
+          />
+        </KPIStrip>
+      </PageHeader>
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.92fr)]">
         <section className="space-y-6">

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -33,6 +33,8 @@ import {
   updateCartLineQuantity,
   type POSCartLine,
 } from '@/pages/posCart';
+import PageHeader from '@/components/layout/PageHeader';
+import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
 import type { Customer, PaginatedProducts, PaginatedSales, Product, Sale, SaleListItem } from '@/types';
 
 const today = new Date().toISOString().split('T')[0];
@@ -41,22 +43,6 @@ const SALES_INBOX_PAGE_SIZE = 6;
 
 type CustomerMode = 'guest' | 'existing' | 'new';
 type ProductFilter = 'all' | 'scannable' | 'low-stock' | 'in-cart';
-
-interface MetricCardProps {
-  label: string;
-  value: string;
-  detail: string;
-}
-
-function MetricCard({ label, value, detail }: MetricCardProps) {
-  return (
-    <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
-      <p className="text-xs uppercase tracking-[0.25em] text-white/55">{label}</p>
-      <p className="mt-3 text-2xl font-semibold">{value}</p>
-      <p className="mt-2 text-sm text-white/70">{detail}</p>
-    </div>
-  );
-}
 
 interface QuickFilterButtonProps {
   active: boolean;
@@ -452,40 +438,27 @@ export default function POSPage() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-lg border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.16),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(19,52,34,0.96)_100%)] p-6 text-white shadow-sm">
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-          <div className="max-w-3xl">
-            <p className="text-sm uppercase tracking-[0.3em] text-white/65">Sell Workspace</p>
-            <h1 className="mt-3 flex items-center gap-3 text-3xl font-bold">
-              <Receipt className="h-8 w-8" />
-              POS register
-            </h1>
-            <p className="mt-3 text-sm text-white/80">
-              Fast counter checkout with a visible scanner lane, larger touch targets, and a sales inbox that keeps follow-up work nearby instead of hidden behind a generic sales list.
-            </p>
-          </div>
-
-          <div className="grid gap-3 sm:grid-cols-2 xl:min-w-[320px]">
-            <div className="rounded-lg border border-white/10 bg-white/8 px-4 py-4">
-              <p className="text-xs uppercase tracking-[0.22em] text-white/60">Shift date</p>
-              <p className="mt-2 text-xl font-semibold">{today}</p>
-              <p className="mt-1 text-sm text-white/65">Recommended route: `/sell`</p>
-            </div>
-            <div className="rounded-lg border border-white/10 bg-white/8 px-4 py-4">
-              <p className="text-xs uppercase tracking-[0.22em] text-white/60">Sales inbox</p>
-              <p className="mt-2 text-xl font-semibold">{salesNeedingAttention}</p>
-              <p className="mt-1 text-sm text-white/65">Pending or refunded sales needing eyes</p>
-            </div>
-          </div>
-        </div>
-
-        <div className="mt-6 grid gap-3 lg:grid-cols-4">
-          <MetricCard label="Cart Total" value={formatCurrency(total)} detail={`${cartUnits} units in the current basket`} />
-          <MetricCard label="Barcode Ready" value={`${scannableCount}`} detail="Active products with UPC for wedge scanners" />
-          <MetricCard label="Low Stock" value={`${lowStockCount}`} detail="Products at or below reorder point" />
-          <MetricCard label="Sales Queue" value={`${salesInbox.length}`} detail="Recent transactions one tap away" />
-        </div>
-      </section>
+      <PageHeader
+        title="Register"
+        description={`Cart: ${cartUnits} ${cartUnits === 1 ? 'unit' : 'units'} · ${formatCurrency(total)}`}
+      >
+        <KPIStrip columns={4}>
+          <KPI label="Cart total" value={formatCurrency(total)} sub={`${cartUnits} units`} />
+          <KPI label="Barcode ready" value={scannableCount} sub="Active UPC products" />
+          <KPI
+            label="Low stock"
+            value={lowStockCount}
+            sub="At or below reorder point"
+            tone={lowStockCount > 0 ? 'warning' : 'default'}
+          />
+          <KPI
+            label="Sales inbox"
+            value={salesNeedingAttention}
+            sub="Pending or refunded sales"
+            tone={salesNeedingAttention > 0 ? 'warning' : 'default'}
+          />
+        </KPIStrip>
+      </PageHeader>
 
       {successMessage ? (
         <div className="rounded-lg border border-emerald-300 bg-emerald-50 px-5 py-4 text-emerald-900 shadow-sm" role="status">

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -20,6 +20,7 @@ import { cn, formatCurrency } from '@/lib/utils';
 import CameraFeed from '@/components/cameras/CameraFeed';
 import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import { SkeletonTable } from '@/components/ui/Skeleton';
+import PageHeader from '@/components/layout/PageHeader';
 import type { Job, PaginatedJobs, Printer, PrinterConnectionTestResult } from '@/types';
 
 const statusClasses: Record<string, string> = {
@@ -205,106 +206,106 @@ export default function PrinterDetailPage() {
         <ArrowLeft className="h-4 w-4" /> Back to printer wall
       </Link>
 
-      <section className="overflow-hidden rounded-lg border border-border bg-[linear-gradient(135deg,rgba(8,17,31,0.98),rgba(17,34,53,0.96))] px-6 py-6 text-white shadow-md">
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
-          <div>
-            <div className="flex flex-wrap items-center gap-2">
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200/75">
-                Printer console
-              </p>
-              <StatusBadge status={liveStatus} />
-              <span className={cn('inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium', printer.is_active ? 'bg-emerald-500/15 text-emerald-200' : 'bg-amber-500/15 text-amber-200')}>
-                {printer.is_active ? 'Active' : 'Inactive'}
-              </span>
-            </div>
-            <h1 className="mt-3 text-3xl font-semibold md:text-4xl">{printer.name}</h1>
-            <p className="mt-2 text-sm uppercase tracking-[0.16em] text-slate-300/80">
+      <PageHeader
+        title={printer.name}
+        description={
+          <span className="flex flex-wrap items-center gap-2">
+            <StatusBadge status={liveStatus} />
+            <span
+              className={cn(
+                'inline-flex items-center rounded-sm px-2 py-0.5 text-xs font-medium',
+                printer.is_active
+                  ? 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+                  : 'bg-amber-500/10 text-amber-700 dark:text-amber-300'
+              )}
+            >
+              {printer.is_active ? 'Active' : 'Inactive'}
+            </span>
+            <span className="text-muted-foreground">
               {[printer.manufacturer, printer.model, printer.location].filter(Boolean).join(' • ') || printer.slug}
-            </p>
-            <p className="mt-4 max-w-3xl text-sm leading-6 text-slate-200/82 md:text-base">
-              Live machine status, current print telemetry, recent floor activity, and assignment context in one place.
-            </p>
-
-            <div className="mt-5 flex flex-wrap gap-3">
-              {printer.monitor_enabled ? (
-                <>
-                  <button
-                    onClick={testConnection}
-                    className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm"
-                  >
-                    <PlugZap className="h-4 w-4" /> Test connection
-                  </button>
-                  <button
-                    onClick={refreshNow}
-                    className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/12"
-                  >
-                    <RefreshCw className="h-4 w-4" /> Refresh now
-                  </button>
-                </>
-              ) : null}
-              <Link
-                to={`/print-floor/printers/${printer.id}/edit`}
-                className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-2 text-sm font-medium text-white no-underline transition-colors hover:bg-white/12"
-              >
-                <Edit className="h-4 w-4" /> Edit
-              </Link>
-              <button
-                onClick={toggleActive}
-                className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/12"
-              >
-                {printer.is_active ? <Archive className="h-4 w-4" /> : <ArchiveRestore className="h-4 w-4" />}
-                {printer.is_active ? 'Deactivate' : 'Restore'}
-              </button>
+            </span>
+          </span>
+        }
+        actions={
+          <>
+            {printer.monitor_enabled ? (
+              <>
+                <button
+                  onClick={testConnection}
+                  className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+                >
+                  <PlugZap className="h-4 w-4" /> Test connection
+                </button>
+                <button
+                  onClick={refreshNow}
+                  className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+                >
+                  <RefreshCw className="h-4 w-4" /> Refresh
+                </button>
+              </>
+            ) : null}
+            <Link
+              to={`/print-floor/printers/${printer.id}/edit`}
+              className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-sm font-medium no-underline hover:bg-muted transition-colors"
+            >
+              <Edit className="h-4 w-4" /> Edit
+            </Link>
+            <button
+              onClick={toggleActive}
+              className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+            >
+              {printer.is_active ? <Archive className="h-4 w-4" /> : <ArchiveRestore className="h-4 w-4" />}
+              {printer.is_active ? 'Deactivate' : 'Restore'}
+            </button>
+          </>
+        }
+      >
+        <div className="rounded-md border border-border bg-card p-5 shadow-xs">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-medium text-muted-foreground">Current print</p>
+              <p className="mt-1 text-base font-semibold text-foreground">{printer.current_print_name || 'No active print'}</p>
             </div>
+            <span className="text-2xl font-semibold tabular-nums">
+              {printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}
+            </span>
           </div>
 
-          <div className="rounded-md border border-white/10 bg-black/15 p-5">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-300/75">Current print</p>
-                <p className="mt-2 text-lg font-semibold text-white">{printer.current_print_name || 'No active print'}</p>
-              </div>
-              <span className="text-2xl font-semibold text-white">
-                {printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}
-              </span>
-            </div>
+          <div className="mt-4 h-2 rounded-full bg-muted">
+            <div
+              className={cn('h-2 rounded-full transition-[width]', needsAttention ? 'bg-amber-500' : 'bg-primary')}
+              style={{ width: `${Math.max(6, progress)}%` }}
+            />
+          </div>
 
-            <div className="mt-4 h-2 rounded-full bg-white/10">
-              <div
-                className={cn('h-2 rounded-full transition-[width]', needsAttention ? 'bg-amber-400' : 'bg-primary')}
-                style={{ width: `${Math.max(6, progress)}%` }}
-              />
+          <div className="mt-4 grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+            <div>
+              <p className="text-xs text-muted-foreground">Layer</p>
+              <p className="mt-1 font-medium tabular-nums">{formatLayer(printer.monitor_current_layer, printer.monitor_total_layers)}</p>
             </div>
-
-            <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
-              <div>
-                <p className="text-xs uppercase tracking-[0.16em] text-slate-300/75">Layer</p>
-                <p className="mt-1 font-medium text-white">{formatLayer(printer.monitor_current_layer, printer.monitor_total_layers)}</p>
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-[0.16em] text-slate-300/75">ETA</p>
-                <p className="mt-1 font-medium text-white">{formatDuration(printer.monitor_remaining_seconds)}</p>
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-[0.16em] text-slate-300/75">Transport</p>
-                <p className="mt-1 font-medium text-white">
-                  {printer.monitor_provider === 'moonraker'
-                    ? printer.monitor_ws_connected
-                      ? 'Socket live'
-                      : 'Polling fallback'
-                    : printer.monitor_enabled
-                      ? 'Polling'
-                      : 'Static record'}
-                </p>
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-[0.16em] text-slate-300/75">Assignment</p>
-                <p className="mt-1 font-medium text-white">{activeJob ? activeJob.job_number : 'Unassigned'}</p>
-              </div>
+            <div>
+              <p className="text-xs text-muted-foreground">ETA</p>
+              <p className="mt-1 font-medium tabular-nums">{formatDuration(printer.monitor_remaining_seconds)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Transport</p>
+              <p className="mt-1 font-medium">
+                {printer.monitor_provider === 'moonraker'
+                  ? printer.monitor_ws_connected
+                    ? 'Socket live'
+                    : 'Polling fallback'
+                  : printer.monitor_enabled
+                    ? 'Polling'
+                    : 'Static record'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Assignment</p>
+              <p className="mt-1 font-medium">{activeJob ? activeJob.job_number : 'Unassigned'}</p>
             </div>
           </div>
         </div>
-      </section>
+      </PageHeader>
 
       <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <ConsoleStat

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -24,6 +24,7 @@ import api from '@/api/client';
 import CameraFeed from '@/components/cameras/CameraFeed';
 import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import EmptyState from '@/components/ui/EmptyState';
+import PageHeader from '@/components/layout/PageHeader';
 import { cn } from '@/lib/utils';
 import type { Job, PaginatedJobs, PaginatedPrinters, Printer } from '@/types';
 
@@ -487,64 +488,42 @@ export default function PrintersPage() {
 
   return (
     <div className={cn('space-y-6', wallMode && 'rounded-lg bg-[linear-gradient(180deg,#020617_0%,#08111f_100%)] p-4 text-slate-50')}>
-      <section className={cn(
-        'overflow-hidden rounded-lg border border-border bg-[linear-gradient(135deg,rgba(8,17,31,0.98),rgba(17,34,53,0.96))] px-6 py-6 text-white shadow-md',
-        wallMode && 'border-slate-700/80 bg-[linear-gradient(135deg,rgba(2,6,23,0.98),rgba(8,17,31,0.96))] shadow-none'
-      )}>
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,0.65fr)]">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-cyan-200/75">
-              {wallMode ? 'Print-floor wall mode' : 'Print-floor workspace'}
-            </p>
-            <h1 className="mt-3 text-3xl font-semibold md:text-4xl">
-              Printer wall
-            </h1>
-            <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-200/82 md:text-base">
-              Scan the fleet by status, jump into a live printer console, and move from machine state to job context without leaving the floor board.
-            </p>
-            <div className="mt-5 flex flex-wrap gap-3">
-              {!wallMode ? (
-                <>
-                  <Link
-                    to="/print-floor/printers/new"
-                    className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline shadow-sm"
-                  >
-                    <Plus className="h-4 w-4" /> Add printer
-                  </Link>
-                  <Link
-                    to="/orders"
-                    className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-2 text-sm font-medium text-white no-underline transition-colors hover:bg-white/12"
-                  >
-                    <ArrowRight className="h-4 w-4" /> Open jobs queue
-                  </Link>
-                </>
-              ) : null}
-              <button
-                type="button"
-                onClick={() => updateWallMode(!wallMode)}
-                className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/12"
-              >
-                {wallMode ? <Shrink className="h-4 w-4" /> : <Expand className="h-4 w-4" />}
-                {wallMode ? 'Exit wall mode' : 'Wall mode'}
-              </button>
-            </div>
-          </div>
-
-          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
-            <SummaryCard
-              label="Attention queue"
-              value={String(summary.attention)}
-              subtext={summary.attention ? `${summary.attention} printers need intervention` : 'No open printer exceptions'}
-              emphasis={summary.attention ? 'warning' : 'success'}
-            />
-            <SummaryCard
-              label="Utilization"
-              value={summary.total ? `${summary.utilization}%` : '—'}
-              subtext={`${summary.printing} printing • ${summary.ready} ready • ${summary.assigned} assigned`}
-            />
-          </div>
-        </div>
-      </section>
+      <PageHeader
+        title={wallMode ? 'Print floor — wall mode' : 'Print Floor'}
+        description={
+          summary.total > 0
+            ? `${summary.printing} printing, ${summary.ready} ready${summary.attention ? `, ${summary.attention} need attention` : ''}`
+            : 'No printers configured yet'
+        }
+        actions={
+          <>
+            {!wallMode ? (
+              <>
+                <Link
+                  to="/print-floor/printers/new"
+                  className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground no-underline transition-opacity hover:opacity-90"
+                >
+                  <Plus className="h-4 w-4" /> Add printer
+                </Link>
+                <Link
+                  to="/orders"
+                  className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-sm font-medium no-underline hover:bg-muted transition-colors"
+                >
+                  <ArrowRight className="h-4 w-4" /> Open jobs queue
+                </Link>
+              </>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => updateWallMode(!wallMode)}
+              className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+            >
+              {wallMode ? <Shrink className="h-4 w-4" /> : <Expand className="h-4 w-4" />}
+              {wallMode ? 'Exit wall mode' : 'Wall mode'}
+            </button>
+          </>
+        }
+      />
 
       <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
         <SummaryCard label="Visible active printers" value={String(summary.total)} />

--- a/frontend/src/pages/ProductEditorPage.tsx
+++ b/frontend/src/pages/ProductEditorPage.tsx
@@ -7,7 +7,6 @@ import {
   ArrowRight,
   BadgeDollarSign,
   Boxes,
-  Package,
   ReceiptText,
   Save,
   ScanBarcode,
@@ -16,6 +15,7 @@ import { toast } from 'sonner';
 import api from '@/api/client';
 import EmptyState from '@/components/ui/EmptyState';
 import { SkeletonTable } from '@/components/ui/Skeleton';
+import PageHeader from '@/components/layout/PageHeader';
 import { cn, formatCurrency } from '@/lib/utils';
 import type { InventoryTransaction, Material, PaginatedTransactions, Product } from '@/types';
 
@@ -148,23 +148,14 @@ export default function ProductEditorPage() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-lg border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.12),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(24,24,27,0.96)_100%)] p-6 text-white shadow-sm">
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-          <div className="max-w-3xl">
-            <p className="text-sm uppercase tracking-[0.3em] text-white/65">Product Studio</p>
-            <h1 className="mt-3 flex items-center gap-3 text-3xl font-bold">
-              <Package className="h-8 w-8" />
-              {isCreate ? 'New product editor' : 'Product editor'}
-            </h1>
-            <p className="mt-3 text-sm text-white/80">
-              Build a sellable product with identity, pricing, material, stock policy, and readiness context visible in one workflow instead of a cramped modal.
-            </p>
-          </div>
-
-          <div className="flex flex-wrap gap-3">
+      <PageHeader
+        title={isCreate ? 'New product' : product?.name || 'Product editor'}
+        description={isCreate ? 'Draft' : product?.is_active ? 'Active' : 'Archived'}
+        actions={
+          <>
             <Link
               to="/product-studio"
-              className="inline-flex min-h-12 items-center gap-2 rounded-md border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white no-underline transition-colors hover:bg-white/15"
+              className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-sm font-medium no-underline hover:bg-muted transition-colors"
             >
               <ArrowLeft className="h-4 w-4" />
               Back to catalog
@@ -172,15 +163,15 @@ export default function ProductEditorPage() {
             {!isCreate ? (
               <Link
                 to={`/product-studio/products/${id}`}
-                className="inline-flex min-h-12 items-center gap-2 rounded-md border border-white/20 bg-white/10 px-5 py-3 font-semibold text-white no-underline transition-colors hover:bg-white/15"
+                className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-sm font-medium no-underline hover:bg-muted transition-colors"
               >
                 View record
                 <ArrowRight className="h-4 w-4" />
               </Link>
             ) : null}
-          </div>
-        </div>
-      </section>
+          </>
+        }
+      />
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.95fr)]">
         <section className="space-y-6">

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import api from '@/api/client';
 import EmptyState from '@/components/ui/EmptyState';
 import { SkeletonTable } from '@/components/ui/Skeleton';
+import PageHeader from '@/components/layout/PageHeader';
 import { formatCurrency } from '@/lib/utils';
 import type { PaginatedProducts, Product } from '@/types';
 
@@ -24,7 +25,6 @@ export default function ProductsPage() {
   const total = data?.total || 0;
   const totalPages = Math.max(1, Math.ceil(total / limit));
   const lowStockCount = products.filter((product) => product.stock_qty <= product.reorder_point).length;
-  const barcodeReadyCount = products.filter((product) => product.upc).length;
 
   const toggleActive = async (product: Product) => {
     const action = product.is_active ? 'archive' : 'restore';
@@ -52,44 +52,28 @@ export default function ProductsPage() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-lg border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.12),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(24,24,27,0.96)_100%)] p-6 text-white shadow-sm">
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-          <div className="max-w-3xl">
-            <p className="text-sm uppercase tracking-[0.3em] text-white/65">Product Studio</p>
-            <h1 className="mt-3 text-3xl font-bold">Catalog and authoring workflow</h1>
-            <p className="mt-3 text-sm text-white/80">
-              Browse the catalog, watch sellability signals, and move straight into the full-page editor when a product needs real setup work.
-            </p>
-          </div>
-
+      <PageHeader
+        title="Products"
+        description={
+          <>
+            <span className="tabular-nums">{total.toLocaleString()} total</span>
+            {lowStockCount > 0 ? (
+              <span className="ml-3 text-warning">
+                · {lowStockCount} low stock
+              </span>
+            ) : null}
+          </>
+        }
+        actions={
           <Link
             to="/product-studio/products/new"
-            className="inline-flex min-h-12 items-center gap-2 rounded-md bg-primary px-5 py-3 font-semibold text-primary-foreground no-underline transition-opacity hover:opacity-90"
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground no-underline transition-opacity hover:opacity-90"
           >
             <Plus className="h-4 w-4" />
             New product
           </Link>
-        </div>
-
-        <div className="mt-6 grid gap-3 lg:grid-cols-4">
-          <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
-            <p className="text-xs uppercase tracking-[0.24em] text-white/55">Visible products</p>
-            <p className="mt-3 text-2xl font-semibold">{total}</p>
-          </div>
-          <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
-            <p className="text-xs uppercase tracking-[0.24em] text-white/55">Low stock</p>
-            <p className="mt-3 text-2xl font-semibold">{lowStockCount}</p>
-          </div>
-          <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
-            <p className="text-xs uppercase tracking-[0.24em] text-white/55">Barcode ready</p>
-            <p className="mt-3 text-2xl font-semibold">{barcodeReadyCount}</p>
-          </div>
-          <div className="rounded-lg border border-white/10 bg-black/20 px-4 py-4">
-            <p className="text-xs uppercase tracking-[0.24em] text-white/55">Authoring route</p>
-            <p className="mt-3 text-lg font-semibold">/product-studio/products/new</p>
-          </div>
-        </div>
-      </section>
+        }
+      />
 
       <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">

--- a/frontend/src/pages/SalesPage.tsx
+++ b/frontend/src/pages/SalesPage.tsx
@@ -6,6 +6,7 @@ import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import EmptyState from '@/components/ui/EmptyState';
+import PageHeader from '@/components/layout/PageHeader';
 import type { PaginatedSales, SalesChannel } from '@/types';
 
 const statusColors: Record<string, string> = {
@@ -59,31 +60,18 @@ export default function SalesPage() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-lg border border-border bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.14),_transparent_24%),linear-gradient(135deg,_rgba(8,17,31,1),_rgba(16,33,52,0.98)_48%,_rgba(22,44,64,0.96)_100%)] p-6 text-white shadow-sm">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-          <div className="max-w-3xl">
-            <p className="text-sm uppercase tracking-[0.3em] text-white/65">Sell Workspace</p>
-            <h1 className="mt-3 text-3xl font-bold">Sales inbox</h1>
-            <p className="mt-3 text-sm text-white/80">
-              Review recent sales, refunds, and follow-up work without dropping back into the general dashboard.
-            </p>
-          </div>
-          <div className="rounded-lg border border-white/10 bg-white/8 px-4 py-4">
-            <p className="text-xs uppercase tracking-[0.22em] text-white/60">Visible sales</p>
-            <p className="mt-2 text-2xl font-semibold">{total}</p>
-            <p className="mt-1 text-sm text-white/65">Filtered transactions in the current inbox view</p>
-          </div>
-        </div>
-      </section>
-
-      <div className="flex items-center justify-between">
-        <Link
-          to="/sell/sales/new"
-          className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 transition-opacity no-underline"
-        >
-          <Plus className="w-4 h-4" /> New Sale
-        </Link>
-      </div>
+      <PageHeader
+        title="Sales"
+        description={`${total.toLocaleString()} ${total === 1 ? 'result' : 'results'}`}
+        actions={
+          <Link
+            to="/sell/sales/new"
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground no-underline transition-opacity hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" /> New sale
+          </Link>
+        }
+      />
 
       {/* Filters */}
       <div className="flex flex-wrap gap-3 mb-4">


### PR DESCRIPTION
Closes #159 (phase 2 of epic #157)

## Summary

Every list / workspace page previously opened with a large `rounded-[2rem]` dark-gradient hero banner. Those consumed 180–220px of vertical space before any data appeared and repeated the workspace label that's already shown in the sidebar + local nav. This PR replaces all of them with a single shared `<PageHeader>` component — title, description, primary actions, optional KPI strip. Business-app pattern (Stripe, Linear, Shopify), WCAG-compliant contrast, and data comes into view immediately.

## New components

| Component | Purpose |
|-----------|---------|
| `components/layout/PageHeader.tsx` | Standard page intro: title, description, actions, optional breadcrumbs slot (reserved for phase 5), optional children slot for KPI strips or tabs. |
| `components/layout/KPIStrip.tsx` | `<KPI>` and `<KPIStrip>` compact metric chips. Tone-aware (default/warning/success/destructive), `tabular-nums`, icon + delta slots ready for phase 6 sparklines. |

## Migrated 9 pages

| Page | Title | KPIs |
|------|-------|------|
| `SalesPage` | Sales | — |
| `InventoryPage` | Inventory | alerts / critical / near-reorder / materials |
| `ProductsPage` | Products | — |
| `PrintersPage` | Print Floor | existing summary cards remain below |
| `OrdersPage` | Orders | assignment / in-progress / fulfilment / ready |
| `ControlCenterPage` | {role-specific} | needs-attention / draft-queue |
| `POSPage` | Register | cart / barcode / low-stock / inbox |
| `ProductEditorPage` | {product.name} | — |
| `PrinterDetailPage` | {printer.name} | current-print readout |

## Also

- Dropped now-unused `HeroMetric` / `MetricCard` / `QueueStat` helpers that only styled the inside of the dark heroes.
- Dropped per-page uppercase workspace labels (`Sell Workspace`, `Stock Workspace`, etc.) — redundant with sidebar + `WorkspaceLocalNav`.
- Replaced `text-white/65` hero descriptions with `muted-foreground` + subtle status tones against the flat background — WCAG AA minimum.

## Acceptance criteria

- [x] `PageHeader` component created
- [x] `KPIStrip` component created
- [x] All 9 pages listed above use `<PageHeader>`
- [x] No remaining `rounded-[2rem]` / `rounded-[1.9rem]` hero banners in `src/pages/`
- [x] No `text-white/\d` classes in list-page headers (remaining uses are all in `PrinterMonitorPage` kiosk, explicitly out of scope)
- [x] Per-page uppercase workspace labels removed from page bodies
- [x] Primary actions right-aligned next to title at ≥ sm breakpoint
- [x] `npm run build` passes
- [x] `npm test` passes (10/10)

## Test plan

- [x] Frontend build clean (508ms)
- [x] Existing Vitest suite passes (POS, Insights, Settings, shipping-labels)
- [ ] Deployer visual check on web01 after merge: Sales, Inventory, Products, Printers, Orders, Control Center in both light and dark mode — expect ~180px reclaimed vertical space and compact KPI rows
- [ ] Keyboard tab order through `PageHeader` actions is sensible (title → actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)