### PR TITLE
feat(ui): data-table primitives + business-app retrofit (phase 3 of #157)

### DIFF
--- a/backend/app/api/v1/endpoints/inventory.py
+++ b/backend/app/api/v1/endpoints/inventory.py
@@ -39,6 +39,12 @@ async def list_transactions(
     date_from: datetime.date | None = Query(None, description="Start date (inclusive)"),
     date_to: datetime.date | None = Query(None, description="End date (inclusive)"),
     search: str | None = Query(None, description="Search by product name or SKU"),
+    sort_by: str = Query(
+        "created_at",
+        description="Sort field (allowlisted)",
+        pattern="^(created_at|type|quantity|unit_cost)$",
+    ),
+    sort_dir: str = Query("desc", description="Sort direction", pattern="^(asc|desc)$"),
     skip: int = Query(0, ge=0, description="Number of records to skip"),
     limit: int = Query(50, ge=1, le=100, description="Max records to return"),
 ):
@@ -65,9 +71,9 @@ async def list_transactions(
     count_stmt = select(func.count()).select_from(base.subquery())
     total = (await db.execute(count_stmt)).scalar() or 0
 
-    result = await db.execute(
-        base.order_by(InventoryTransaction.created_at.desc()).offset(skip).limit(limit)
-    )
+    sort_column = getattr(InventoryTransaction, sort_by, InventoryTransaction.created_at)
+    order = sort_column.desc() if sort_dir == "desc" else sort_column.asc()
+    result = await db.execute(base.order_by(order).offset(skip).limit(limit))
     rows = result.all()
 
     items = [

--- a/backend/app/api/v1/endpoints/products.py
+++ b/backend/app/api/v1/endpoints/products.py
@@ -30,6 +30,12 @@ async def list_products(
     material_id: uuid.UUID | None = Query(None, description="Filter by material ID"),
     low_stock: bool | None = Query(None, description="Filter products below reorder point"),
     search: str | None = Query(None, description="Search by name, SKU, or UPC"),
+    sort_by: str = Query(
+        "name",
+        description="Sort field (allowlisted)",
+        pattern="^(name|sku|unit_price|unit_cost|stock_qty|reorder_point|created_at|updated_at)$",
+    ),
+    sort_dir: str = Query("asc", description="Sort direction", pattern="^(asc|desc)$"),
     skip: int = Query(0, ge=0, description="Number of records to skip"),
     limit: int = Query(50, ge=1, le=100, description="Max records to return"),
 ):
@@ -49,7 +55,9 @@ async def list_products(
     count_stmt = select(func.count()).select_from(base.subquery())
     total = (await db.execute(count_stmt)).scalar() or 0
 
-    result = await db.execute(base.order_by(Product.name).offset(skip).limit(limit))
+    sort_column = getattr(Product, sort_by, Product.name)
+    order = sort_column.desc() if sort_dir == "desc" else sort_column.asc()
+    result = await db.execute(base.order_by(order).offset(skip).limit(limit))
     items = result.scalars().all()
 
     return PaginatedProducts(items=items, total=total, skip=skip, limit=limit)

--- a/backend/app/api/v1/endpoints/sales.py
+++ b/backend/app/api/v1/endpoints/sales.py
@@ -108,6 +108,12 @@ async def list_sales(
     date_from: datetime.date | None = Query(None, description="Start date"),
     date_to: datetime.date | None = Query(None, description="End date"),
     search: str | None = Query(None, description="Search by sale number or customer name"),
+    sort_by: str = Query(
+        "date",
+        description="Sort field (allowlisted)",
+        pattern="^(date|sale_number|total|status|payment_method|created_at)$",
+    ),
+    sort_dir: str = Query("desc", description="Sort direction", pattern="^(asc|desc)$"),
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=100),
 ):
@@ -135,9 +141,11 @@ async def list_sales(
     count_stmt = select(func.count()).select_from(base.subquery())
     total = (await db.execute(count_stmt)).scalar() or 0
 
+    sort_column = getattr(Sale, sort_by, Sale.date)
+    order = sort_column.desc() if sort_dir == "desc" else sort_column.asc()
     result = await db.execute(
         base.options(selectinload(Sale.items), selectinload(Sale.channel))
-        .order_by(Sale.date.desc())
+        .order_by(order)
         .offset(skip)
         .limit(limit)
     )

--- a/backend/tests/test_api_sort_allowlist.py
+++ b/backend/tests/test_api_sort_allowlist.py
@@ -1,0 +1,123 @@
+"""Tests the sort_by / sort_dir query params added in issue #160 for the Sales, Products,
+and Inventory endpoints. The allowlists are enforced by FastAPI's `Query(pattern=...)`
+validation; anything outside the allowlist returns 422.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+
+from app.models.material import Material
+from app.models.product import Product
+
+
+@pytest.mark.asyncio
+async def test_sales_sort_allowlist_accepts_known_and_rejects_unknown(
+    client: AsyncClient, auth_headers: dict, seed_settings, seed_material: Material
+):
+    # known sort columns succeed
+    for col in ("date", "sale_number", "total", "status", "payment_method", "created_at"):
+        resp = await client.get("/api/v1/sales", params={"sort_by": col, "sort_dir": "asc"})
+        assert resp.status_code == 200, f"{col=} should be allowed"
+    # unknown column is rejected
+    resp = await client.get("/api/v1/sales", params={"sort_by": "secret_profit_field"})
+    assert resp.status_code == 422
+
+    # invalid direction is rejected
+    resp = await client.get("/api/v1/sales", params={"sort_by": "date", "sort_dir": "sideways"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_products_sort_allowlist_accepts_known_and_rejects_unknown(
+    client: AsyncClient, auth_headers: dict, seed_material: Material, db_session
+):
+    # Seed a couple of products so the sort actually runs against rows
+    for i, (name, price, stock) in enumerate(
+        [("Zulu widget", Decimal("10"), 1), ("Alpha widget", Decimal("20"), 5)]
+    ):
+        db_session.add(
+            Product(
+                sku=f"PRD-{i}",
+                name=name,
+                material_id=seed_material.id,
+                unit_price=price,
+                unit_cost=Decimal("1"),
+                stock_qty=stock,
+                reorder_point=0,
+            )
+        )
+    await db_session.commit()
+
+    for col in (
+        "name",
+        "sku",
+        "unit_price",
+        "unit_cost",
+        "stock_qty",
+        "reorder_point",
+        "created_at",
+        "updated_at",
+    ):
+        resp = await client.get(
+            "/api/v1/products", params={"sort_by": col, "sort_dir": "desc"}
+        )
+        assert resp.status_code == 200, f"{col=} should be allowed"
+
+    resp = await client.get("/api/v1/products", params={"sort_by": "drop_table"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_products_sort_actually_sorts(
+    client: AsyncClient, auth_headers: dict, seed_material: Material, db_session
+):
+    # Two products, one with higher unit_price
+    p_cheap = Product(
+        sku="PRD-1",
+        name="Cheap",
+        material_id=seed_material.id,
+        unit_price=Decimal("5"),
+        unit_cost=Decimal("1"),
+        stock_qty=0,
+        reorder_point=0,
+    )
+    p_expensive = Product(
+        sku="PRD-2",
+        name="Expensive",
+        material_id=seed_material.id,
+        unit_price=Decimal("50"),
+        unit_cost=Decimal("1"),
+        stock_qty=0,
+        reorder_point=0,
+    )
+    db_session.add_all([p_cheap, p_expensive])
+    await db_session.commit()
+
+    asc = await client.get("/api/v1/products", params={"sort_by": "unit_price", "sort_dir": "asc"})
+    assert asc.status_code == 200
+    asc_names = [p["name"] for p in asc.json()["items"]]
+    assert asc_names.index("Cheap") < asc_names.index("Expensive")
+
+    desc = await client.get("/api/v1/products", params={"sort_by": "unit_price", "sort_dir": "desc"})
+    assert desc.status_code == 200
+    desc_names = [p["name"] for p in desc.json()["items"]]
+    assert desc_names.index("Expensive") < desc_names.index("Cheap")
+
+
+@pytest.mark.asyncio
+async def test_inventory_sort_allowlist_accepts_known_and_rejects_unknown(
+    client: AsyncClient, auth_headers: dict, seed_material: Material
+):
+    for col in ("created_at", "type", "quantity", "unit_cost"):
+        resp = await client.get(
+            "/api/v1/inventory/transactions", params={"sort_by": col, "sort_dir": "asc"}
+        )
+        assert resp.status_code == 200, f"{col=} should be allowed"
+
+    resp = await client.get(
+        "/api/v1/inventory/transactions", params={"sort_by": "password_hash"}
+    )
+    assert resp.status_code == 422

--- a/frontend/src/components/data/DataTable.tsx
+++ b/frontend/src/components/data/DataTable.tsx
@@ -1,0 +1,292 @@
+import { Fragment, type ReactNode, useMemo } from 'react';
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface Column<T> {
+  key: string;
+  header: ReactNode;
+  /** Text alignment for the cell content. Default `left`. Numeric columns auto-right-align. */
+  align?: 'left' | 'right' | 'center';
+  /** Fixed width (e.g. `'120px'` or `'18%'`). Leave undefined for auto. */
+  width?: string;
+  /** Backend-sortable. When true, clicking the header cycles asc → desc → unsorted. */
+  sortable?: boolean;
+  /** If the column is numeric, we add `tabular-nums` and right-align by default. */
+  numeric?: boolean;
+  /** Render the cell content for a given row. */
+  cell: (row: T) => ReactNode;
+  /** Hide this column below a breakpoint (tailwind class). E.g. `'hidden md:table-cell'`. */
+  colClassName?: string;
+}
+
+export type SortDir = 'asc' | 'desc';
+
+interface DataTableProps<T> {
+  data: T[];
+  columns: Column<T>[];
+  rowKey: (row: T) => string;
+
+  /** Row click navigates or opens detail. */
+  onRowClick?: (row: T) => void;
+
+  /** Current sort key and direction (controlled). If both set, header shows direction arrow. */
+  sortKey?: string;
+  sortDir?: SortDir;
+  /** Called when a sortable header is clicked. `key=''` + dir ignored means "unsorted". */
+  onSortChange?: (key: string, dir: SortDir | null) => void;
+
+  /** Enable row selection with checkbox column. */
+  selectable?: boolean;
+  selected?: Set<string>;
+  onSelectedChange?: (selected: Set<string>) => void;
+
+  /** Skeleton rendering when data is being fetched. */
+  loading?: boolean;
+  /** Rendered in the tbody when `loading=false` and `data.length === 0`. */
+  emptyState?: ReactNode;
+
+  /** Rendered above the tbody, inside the same card. */
+  toolbar?: ReactNode;
+  /** Rendered below the tbody (typically pagination). */
+  footer?: ReactNode;
+
+  /** Freeze thead at top on scroll. Default true. */
+  stickyHeader?: boolean;
+  /** Row height variant. `compact` = 32px, `normal` = 40px. Default `compact`. */
+  density?: 'compact' | 'normal';
+
+  /** Extra class names on the outer card. */
+  className?: string;
+}
+
+/**
+ * Shared business-app data table. Target 32–40px row height, tabular-nums on
+ * numeric columns, sticky header, controlled sort + selection state, keyboard
+ * navigation, optional toolbar + pagination footer inside the card.
+ */
+export function DataTable<T>({
+  data,
+  columns,
+  rowKey,
+  onRowClick,
+  sortKey,
+  sortDir,
+  onSortChange,
+  selectable = false,
+  selected,
+  onSelectedChange,
+  loading = false,
+  emptyState,
+  toolbar,
+  footer,
+  stickyHeader = true,
+  density = 'compact',
+  className,
+}: DataTableProps<T>) {
+  const rowHeight = density === 'compact' ? 'h-8' : 'h-10';
+  const cellPy = density === 'compact' ? 'py-1.5' : 'py-2';
+
+  const allSelected = useMemo(() => {
+    if (!selectable || !selected || data.length === 0) return false;
+    return data.every((row) => selected.has(rowKey(row)));
+  }, [selectable, selected, data, rowKey]);
+
+  const someSelected = useMemo(() => {
+    if (!selectable || !selected) return false;
+    return data.some((row) => selected.has(rowKey(row))) && !allSelected;
+  }, [selectable, selected, data, rowKey, allSelected]);
+
+  const toggleAll = () => {
+    if (!onSelectedChange || !selected) return;
+    const next = new Set(selected);
+    if (allSelected) {
+      data.forEach((row) => next.delete(rowKey(row)));
+    } else {
+      data.forEach((row) => next.add(rowKey(row)));
+    }
+    onSelectedChange(next);
+  };
+
+  const toggleRow = (id: string) => {
+    if (!onSelectedChange || !selected) return;
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onSelectedChange(next);
+  };
+
+  const handleHeaderClick = (col: Column<T>) => {
+    if (!col.sortable || !onSortChange) return;
+    if (sortKey !== col.key) {
+      onSortChange(col.key, 'asc');
+      return;
+    }
+    if (sortDir === 'asc') {
+      onSortChange(col.key, 'desc');
+      return;
+    }
+    // Was desc → go back to unsorted (null key)
+    onSortChange('', null);
+  };
+
+  const sortIcon = (col: Column<T>) => {
+    if (!col.sortable) return null;
+    if (sortKey !== col.key) return <ArrowUpDown className="ml-1 inline h-3 w-3 opacity-50" />;
+    return sortDir === 'asc' ? (
+      <ArrowUp className="ml-1 inline h-3 w-3" />
+    ) : (
+      <ArrowDown className="ml-1 inline h-3 w-3" />
+    );
+  };
+
+  return (
+    <div className={cn('overflow-hidden rounded-md border border-border bg-card shadow-xs', className)}>
+      {toolbar ? <div className="border-b border-border">{toolbar}</div> : null}
+
+      <div className="relative overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead
+            className={cn(
+              'border-b border-border bg-card text-xs font-medium uppercase tracking-wide text-muted-foreground',
+              stickyHeader && 'sticky top-0 z-10',
+            )}
+          >
+            <tr>
+              {selectable ? (
+                <th className="w-10 px-3">
+                  <input
+                    type="checkbox"
+                    checked={allSelected}
+                    ref={(el) => {
+                      if (el) el.indeterminate = someSelected;
+                    }}
+                    onChange={toggleAll}
+                    aria-label={allSelected ? 'Deselect all rows' : 'Select all rows'}
+                    className="h-4 w-4 cursor-pointer rounded border-input accent-primary"
+                  />
+                </th>
+              ) : null}
+              {columns.map((col) => {
+                const align = col.align || (col.numeric ? 'right' : 'left');
+                const isSortable = col.sortable && !!onSortChange;
+                return (
+                  <th
+                    key={col.key}
+                    scope="col"
+                    style={col.width ? { width: col.width } : undefined}
+                    className={cn(
+                      'px-3 py-2 text-left font-medium',
+                      align === 'right' && 'text-right',
+                      align === 'center' && 'text-center',
+                      isSortable && 'cursor-pointer select-none hover:text-foreground',
+                      col.colClassName,
+                    )}
+                    onClick={isSortable ? () => handleHeaderClick(col) : undefined}
+                    aria-sort={
+                      sortKey === col.key
+                        ? sortDir === 'asc'
+                          ? 'ascending'
+                          : 'descending'
+                        : isSortable
+                          ? 'none'
+                          : undefined
+                    }
+                  >
+                    <span className="inline-flex items-center">
+                      {col.header}
+                      {sortIcon(col)}
+                    </span>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+
+          <tbody>
+            {loading ? (
+              Array.from({ length: 5 }).map((_, i) => (
+                <tr key={`skeleton-${i}`} className={cn('border-b border-border/60 animate-pulse', rowHeight)}>
+                  {selectable ? (
+                    <td className="px-3">
+                      <div className="h-3 w-3 rounded bg-muted" />
+                    </td>
+                  ) : null}
+                  {columns.map((col) => (
+                    <td key={col.key} className={cn('px-3', cellPy)}>
+                      <div className="h-3 w-full max-w-[160px] rounded bg-muted" />
+                    </td>
+                  ))}
+                </tr>
+              ))
+            ) : data.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={columns.length + (selectable ? 1 : 0)}
+                  className="px-3 py-12 text-center text-sm text-muted-foreground"
+                >
+                  {emptyState ?? 'No results.'}
+                </td>
+              </tr>
+            ) : (
+              data.map((row) => {
+                const id = rowKey(row);
+                const isSelected = selectable && selected?.has(id);
+                return (
+                  <tr
+                    key={id}
+                    className={cn(
+                      'border-b border-border/60 transition-colors',
+                      onRowClick && 'cursor-pointer',
+                      isSelected ? 'bg-primary/5' : 'hover:bg-muted/60',
+                      rowHeight,
+                    )}
+                    onClick={onRowClick ? (e) => {
+                      // Don't trigger rowClick if the click came from the checkbox or an interactive child
+                      const target = e.target as HTMLElement;
+                      if (target.closest('button, a, input, [role="button"]')) return;
+                      onRowClick(row);
+                    } : undefined}
+                  >
+                    {selectable ? (
+                      <td className="px-3">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleRow(id)}
+                          aria-label={isSelected ? 'Deselect row' : 'Select row'}
+                          className="h-4 w-4 cursor-pointer rounded border-input accent-primary"
+                        />
+                      </td>
+                    ) : null}
+                    {columns.map((col) => {
+                      const align = col.align || (col.numeric ? 'right' : 'left');
+                      return (
+                        <td
+                          key={col.key}
+                          className={cn(
+                            'px-3 text-foreground',
+                            cellPy,
+                            align === 'right' && 'text-right',
+                            align === 'center' && 'text-center',
+                            col.numeric && 'tabular-nums',
+                            col.colClassName,
+                          )}
+                        >
+                          {col.cell(row)}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {footer ? <Fragment>{footer}</Fragment> : null}
+    </div>
+  );
+}
+
+export default DataTable;

--- a/frontend/src/components/data/Pagination.tsx
+++ b/frontend/src/components/data/Pagination.tsx
@@ -1,0 +1,113 @@
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface PaginationProps {
+  /** 0-based current page index. */
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (next: number) => void;
+  onPageSizeChange?: (next: number) => void;
+  pageSizeOptions?: number[];
+  className?: string;
+}
+
+/**
+ * Business-app pagination footer: "Showing N–M of T • Rows per page: X • first/prev/next/last".
+ * Always renders even when total is 0 (shows "0 results") to keep the table card footer consistent.
+ */
+export default function Pagination({
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = [10, 25, 50, 100],
+  className,
+}: PaginationProps) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const start = total === 0 ? 0 : page * pageSize + 1;
+  const end = Math.min((page + 1) * pageSize, total);
+  const prevDisabled = page <= 0;
+  const nextDisabled = page >= totalPages - 1;
+
+  const btnBase =
+    'flex h-8 w-8 items-center justify-center rounded-md border border-border bg-card text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50 disabled:hover:bg-card disabled:hover:text-muted-foreground';
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 border-t border-border bg-card/50 px-3 py-2 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between',
+        className,
+      )}
+    >
+      <div className="tabular-nums">
+        {total === 0 ? 'No results' : (
+          <>Showing {start.toLocaleString()}–{end.toLocaleString()} of {total.toLocaleString()}</>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4">
+        {onPageSizeChange ? (
+          <label className="flex items-center gap-2">
+            <span>Rows per page</span>
+            <select
+              value={pageSize}
+              onChange={(e) => onPageSizeChange(Number(e.target.value))}
+              className="rounded-md border border-input bg-background px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+              aria-label="Rows per page"
+            >
+              {pageSizeOptions.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            disabled={prevDisabled}
+            onClick={() => onPageChange(0)}
+            aria-label="First page"
+            className={btnBase}
+          >
+            <ChevronsLeft className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            disabled={prevDisabled}
+            onClick={() => onPageChange(page - 1)}
+            aria-label="Previous page"
+            className={btnBase}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <span className="px-2 tabular-nums">
+            {page + 1} / {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={nextDisabled}
+            onClick={() => onPageChange(page + 1)}
+            aria-label="Next page"
+            className={btnBase}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            disabled={nextDisabled}
+            onClick={() => onPageChange(totalPages - 1)}
+            aria-label="Last page"
+            className={btnBase}
+          >
+            <ChevronsRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/data/SearchInput.tsx
+++ b/frontend/src/components/data/SearchInput.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from 'react';
+import { Search, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface SearchInputProps {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+  /** Debounce delay in ms before calling onChange. 0 to disable. */
+  debounceMs?: number;
+  className?: string;
+  ariaLabel?: string;
+}
+
+/**
+ * Controlled text input with a magnifying glass affordance and clear button.
+ * Debounces `onChange` to keep typing responsive on large datasets.
+ */
+export default function SearchInput({
+  value,
+  onChange,
+  placeholder = 'Search…',
+  debounceMs = 200,
+  className,
+  ariaLabel,
+}: SearchInputProps) {
+  const [local, setLocal] = useState(value);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Keep local in sync when parent resets (e.g. Clear filters)
+  useEffect(() => {
+    setLocal(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (debounceMs <= 0) {
+      onChange(local);
+      return;
+    }
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => onChange(local), debounceMs);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [local, debounceMs]);
+
+  return (
+    <div className={cn('relative min-w-[220px]', className)}>
+      <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <input
+        type="text"
+        value={local}
+        onChange={(e) => setLocal(e.target.value)}
+        placeholder={placeholder}
+        aria-label={ariaLabel || placeholder}
+        className="w-full rounded-md border border-input bg-background py-1.5 pl-8 pr-8 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+      />
+      {local && (
+        <button
+          type="button"
+          onClick={() => setLocal('')}
+          aria-label="Clear search"
+          className="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/data/Select.tsx
+++ b/frontend/src/components/data/Select.tsx
@@ -1,0 +1,48 @@
+import { type SelectHTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, 'onChange' | 'size'> {
+  value: string;
+  onChange: (next: string) => void;
+  options: SelectOption[];
+  placeholder?: string;
+  size?: 'sm' | 'md';
+}
+
+/**
+ * Thin wrapper over native <select>. Uses business-style borders and tabular
+ * sizing. Prefer for toolbar filters; the shared Radix Select primitive will
+ * land in phase 4 and supplant this for form contexts.
+ */
+const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  { value, onChange, options, placeholder, size = 'md', className, ...rest },
+  ref,
+) {
+  return (
+    <select
+      ref={ref}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className={cn(
+        'rounded-md border border-input bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring',
+        size === 'sm' ? 'px-2 py-1' : 'px-3 py-1.5',
+        className,
+      )}
+      {...rest}
+    >
+      {placeholder ? <option value="">{placeholder}</option> : null}
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+});
+
+export default Select;

--- a/frontend/src/components/data/StatusBadge.tsx
+++ b/frontend/src/components/data/StatusBadge.tsx
@@ -1,0 +1,50 @@
+import { type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export type StatusTone = 'success' | 'warning' | 'destructive' | 'info' | 'neutral';
+
+const toneStyles: Record<StatusTone, { dot: string; text: string; bg: string }> = {
+  success: { dot: 'bg-emerald-500', text: 'text-emerald-700 dark:text-emerald-300', bg: 'bg-emerald-50 dark:bg-emerald-500/10' },
+  warning: { dot: 'bg-amber-500', text: 'text-amber-700 dark:text-amber-300', bg: 'bg-amber-50 dark:bg-amber-500/10' },
+  destructive: { dot: 'bg-red-500', text: 'text-red-700 dark:text-red-300', bg: 'bg-red-50 dark:bg-red-500/10' },
+  info: { dot: 'bg-sky-500', text: 'text-sky-700 dark:text-sky-300', bg: 'bg-sky-50 dark:bg-sky-500/10' },
+  neutral: { dot: 'bg-muted-foreground', text: 'text-muted-foreground', bg: 'bg-muted' },
+};
+
+/**
+ * Map common status strings to visual tones. Any unknown status maps to neutral.
+ * Exported so pages can override in one place if the mapping needs tweaking.
+ */
+export function defaultStatusTone(status: string): StatusTone {
+  const s = (status || '').toLowerCase();
+  if (['paid', 'delivered', 'complete', 'completed', 'printing', 'active', 'healthy', 'ready', 'ok'].includes(s)) return 'success';
+  if (['pending', 'draft', 'in_progress', 'low_stock', 'queued', 'backorder', 'paused'].includes(s)) return 'warning';
+  if (['refunded', 'cancelled', 'error', 'offline', 'critical', 'failed'].includes(s)) return 'destructive';
+  if (['shipped', 'maintenance', 'idle', 'scheduled'].includes(s)) return 'info';
+  return 'neutral';
+}
+
+interface StatusBadgeProps {
+  tone?: StatusTone;
+  children: ReactNode;
+  className?: string;
+  /** Hide the leading dot. Useful in very dense grids. */
+  hideDot?: boolean;
+}
+
+export default function StatusBadge({ tone = 'neutral', children, className, hideDot = false }: StatusBadgeProps) {
+  const styles = toneStyles[tone];
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs font-medium',
+        styles.bg,
+        styles.text,
+        className,
+      )}
+    >
+      {!hideDot && <span className={cn('h-1.5 w-1.5 rounded-full', styles.dot)} aria-hidden="true" />}
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/data/TableToolbar.tsx
+++ b/frontend/src/components/data/TableToolbar.tsx
@@ -1,0 +1,52 @@
+import { type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+interface TableToolbarProps {
+  /** Left-aligned controls: search, filter selects, etc. */
+  children?: ReactNode;
+  /** Right-aligned bulk-action or count slot. */
+  actions?: ReactNode;
+  /** Visible result count (right-aligned, muted). */
+  total?: number;
+  /** Show a "Clear filters" link when activeFilters > 0. */
+  activeFilters?: number;
+  onClearFilters?: () => void;
+  className?: string;
+}
+
+/**
+ * Standard toolbar that sits inside the DataTable card, just above the thead.
+ * Use it to group search input, status/channel selects, bulk-action button,
+ * and the result count into a single row.
+ */
+export default function TableToolbar({
+  children,
+  actions,
+  total,
+  activeFilters = 0,
+  onClearFilters,
+  className,
+}: TableToolbarProps) {
+  return (
+    <div className={cn('flex flex-wrap items-center gap-2 px-3 py-2', className)}>
+      <div className="flex flex-wrap items-center gap-2">{children}</div>
+      {activeFilters > 0 && onClearFilters ? (
+        <button
+          type="button"
+          onClick={onClearFilters}
+          className="text-xs font-medium text-muted-foreground hover:text-foreground"
+        >
+          Clear filters ({activeFilters})
+        </button>
+      ) : null}
+      <div className="ml-auto flex items-center gap-3 text-xs text-muted-foreground">
+        {typeof total === 'number' ? (
+          <span className="tabular-nums">
+            {total.toLocaleString()} {total === 1 ? 'result' : 'results'}
+          </span>
+        ) : null}
+        {actions}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/data/__tests__/DataTable.test.tsx
+++ b/frontend/src/components/data/__tests__/DataTable.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DataTable, type Column } from '@/components/data/DataTable';
+
+interface Row {
+  id: string;
+  name: string;
+  amount: number;
+}
+
+const rows: Row[] = [
+  { id: '1', name: 'Alpha', amount: 100 },
+  { id: '2', name: 'Beta', amount: 250 },
+  { id: '3', name: 'Gamma', amount: 42 },
+];
+
+const columns: Column<Row>[] = [
+  { key: 'name', header: 'Name', sortable: true, cell: (r) => r.name },
+  { key: 'amount', header: 'Amount', sortable: true, numeric: true, cell: (r) => String(r.amount) },
+];
+
+describe('DataTable', () => {
+  it('renders all rows and column headers', () => {
+    render(<DataTable data={rows} columns={columns} rowKey={(r) => r.id} />);
+    expect(screen.getByText('Name')).toBeTruthy();
+    expect(screen.getByText('Amount')).toBeTruthy();
+    expect(screen.getByText('Alpha')).toBeTruthy();
+    expect(screen.getByText('Beta')).toBeTruthy();
+    expect(screen.getByText('Gamma')).toBeTruthy();
+  });
+
+  it('shows empty state when data is empty', () => {
+    render(
+      <DataTable
+        data={[]}
+        columns={columns}
+        rowKey={(r) => r.id}
+        emptyState="Nothing here yet"
+      />,
+    );
+    expect(screen.getByText('Nothing here yet')).toBeTruthy();
+  });
+
+  it('cycles sort state asc → desc → unsorted when a sortable header is clicked', () => {
+    const onSortChange = vi.fn();
+    const { rerender } = render(
+      <DataTable data={rows} columns={columns} rowKey={(r) => r.id} onSortChange={onSortChange} />,
+    );
+
+    fireEvent.click(screen.getByText('Name'));
+    expect(onSortChange).toHaveBeenCalledWith('name', 'asc');
+
+    rerender(
+      <DataTable
+        data={rows}
+        columns={columns}
+        rowKey={(r) => r.id}
+        onSortChange={onSortChange}
+        sortKey="name"
+        sortDir="asc"
+      />,
+    );
+    fireEvent.click(screen.getByText('Name'));
+    expect(onSortChange).toHaveBeenCalledWith('name', 'desc');
+
+    rerender(
+      <DataTable
+        data={rows}
+        columns={columns}
+        rowKey={(r) => r.id}
+        onSortChange={onSortChange}
+        sortKey="name"
+        sortDir="desc"
+      />,
+    );
+    fireEvent.click(screen.getByText('Name'));
+    expect(onSortChange).toHaveBeenCalledWith('', null);
+  });
+
+  it('toggles selection on a single row', () => {
+    const onSelectedChange = vi.fn();
+    render(
+      <DataTable
+        data={rows}
+        columns={columns}
+        rowKey={(r) => r.id}
+        selectable
+        selected={new Set()}
+        onSelectedChange={onSelectedChange}
+      />,
+    );
+    const rowCheckboxes = screen.getAllByLabelText(/Select row|Deselect row/);
+    fireEvent.click(rowCheckboxes[0]);
+    expect(onSelectedChange).toHaveBeenCalledWith(new Set(['1']));
+  });
+
+  it('select-all toggle selects every row then deselects', () => {
+    const onSelectedChange = vi.fn();
+    const { rerender } = render(
+      <DataTable
+        data={rows}
+        columns={columns}
+        rowKey={(r) => r.id}
+        selectable
+        selected={new Set()}
+        onSelectedChange={onSelectedChange}
+      />,
+    );
+    const headerCheckbox = screen.getByLabelText('Select all rows');
+    fireEvent.click(headerCheckbox);
+    expect(onSelectedChange).toHaveBeenCalledWith(new Set(['1', '2', '3']));
+
+    // Now render with all selected, header should be checked and clicking should clear
+    onSelectedChange.mockClear();
+    rerender(
+      <DataTable
+        data={rows}
+        columns={columns}
+        rowKey={(r) => r.id}
+        selectable
+        selected={new Set(['1', '2', '3'])}
+        onSelectedChange={onSelectedChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('Deselect all rows'));
+    expect(onSelectedChange).toHaveBeenCalledWith(new Set());
+  });
+
+  it('calls onRowClick when a row is clicked (but not when a checkbox is clicked)', () => {
+    const onRowClick = vi.fn();
+    const onSelectedChange = vi.fn();
+    render(
+      <DataTable
+        data={rows}
+        columns={columns}
+        rowKey={(r) => r.id}
+        onRowClick={onRowClick}
+        selectable
+        selected={new Set()}
+        onSelectedChange={onSelectedChange}
+      />,
+    );
+
+    // Clicking the cell triggers rowClick
+    fireEvent.click(screen.getByText('Alpha'));
+    expect(onRowClick).toHaveBeenCalledWith(rows[0]);
+
+    // Clicking a checkbox does NOT trigger rowClick
+    onRowClick.mockClear();
+    const rowCheckbox = screen.getAllByLabelText(/Select row|Deselect row/)[1];
+    fireEvent.click(rowCheckbox);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('renders loading skeleton rows', () => {
+    const { container } = render(
+      <DataTable data={[]} columns={columns} rowKey={(r) => r.id} loading />,
+    );
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/data/__tests__/Pagination.test.tsx
+++ b/frontend/src/components/data/__tests__/Pagination.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Pagination from '@/components/data/Pagination';
+
+describe('Pagination', () => {
+  it('shows "Showing N–M of T" for a mid-range page', () => {
+    render(<Pagination page={1} pageSize={25} total={100} onPageChange={() => {}} />);
+    // page=1 (0-indexed) = rows 26-50
+    expect(screen.getByText(/Showing 26–50 of 100/)).toBeTruthy();
+  });
+
+  it('shows "No results" when total is 0', () => {
+    render(<Pagination page={0} pageSize={25} total={0} onPageChange={() => {}} />);
+    expect(screen.getByText('No results')).toBeTruthy();
+  });
+
+  it('disables first/prev on page 0', () => {
+    render(<Pagination page={0} pageSize={25} total={100} onPageChange={() => {}} />);
+    expect(screen.getByLabelText('First page').hasAttribute('disabled')).toBe(true);
+    expect(screen.getByLabelText('Previous page').hasAttribute('disabled')).toBe(true);
+  });
+
+  it('disables next/last on final page', () => {
+    render(<Pagination page={3} pageSize={25} total={100} onPageChange={() => {}} />);
+    expect(screen.getByLabelText('Next page').hasAttribute('disabled')).toBe(true);
+    expect(screen.getByLabelText('Last page').hasAttribute('disabled')).toBe(true);
+  });
+
+  it('calls onPageChange with correct indices', () => {
+    const onPageChange = vi.fn();
+    render(<Pagination page={1} pageSize={10} total={100} onPageChange={onPageChange} />);
+    fireEvent.click(screen.getByLabelText('First page'));
+    expect(onPageChange).toHaveBeenCalledWith(0);
+
+    fireEvent.click(screen.getByLabelText('Previous page'));
+    expect(onPageChange).toHaveBeenCalledWith(0);
+
+    fireEvent.click(screen.getByLabelText('Next page'));
+    expect(onPageChange).toHaveBeenCalledWith(2);
+
+    fireEvent.click(screen.getByLabelText('Last page'));
+    expect(onPageChange).toHaveBeenCalledWith(9); // 100/10 = 10 pages, last index = 9
+  });
+
+  it('shows page-size select when onPageSizeChange is provided', () => {
+    const onPageSizeChange = vi.fn();
+    render(
+      <Pagination
+        page={0}
+        pageSize={25}
+        total={100}
+        onPageChange={() => {}}
+        onPageSizeChange={onPageSizeChange}
+      />,
+    );
+    const sel = screen.getByLabelText('Rows per page') as HTMLSelectElement;
+    expect(sel).toBeTruthy();
+    fireEvent.change(sel, { target: { value: '50' } });
+    expect(onPageSizeChange).toHaveBeenCalledWith(50);
+  });
+});

--- a/frontend/src/components/data/__tests__/StatusBadge.test.tsx
+++ b/frontend/src/components/data/__tests__/StatusBadge.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
+
+describe('StatusBadge', () => {
+  it('renders the label', () => {
+    render(<StatusBadge tone="success">Paid</StatusBadge>);
+    expect(screen.getByText('Paid')).toBeTruthy();
+  });
+
+  it('renders a leading dot by default', () => {
+    const { container } = render(<StatusBadge tone="warning">Pending</StatusBadge>);
+    // Dot is a span with rounded-full
+    expect(container.querySelector('span.rounded-full')).not.toBeNull();
+  });
+
+  it('can hide the leading dot', () => {
+    const { container } = render(
+      <StatusBadge tone="warning" hideDot>
+        Pending
+      </StatusBadge>,
+    );
+    expect(container.querySelector('span.rounded-full')).toBeNull();
+  });
+});
+
+describe('defaultStatusTone', () => {
+  it('maps known statuses to expected tones', () => {
+    expect(defaultStatusTone('paid')).toBe('success');
+    expect(defaultStatusTone('pending')).toBe('warning');
+    expect(defaultStatusTone('refunded')).toBe('destructive');
+    expect(defaultStatusTone('cancelled')).toBe('destructive');
+    expect(defaultStatusTone('shipped')).toBe('info');
+    expect(defaultStatusTone('idle')).toBe('info');
+  });
+
+  it('maps unknown statuses to neutral', () => {
+    expect(defaultStatusTone('widget-status')).toBe('neutral');
+    expect(defaultStatusTone('')).toBe('neutral');
+  });
+
+  it('is case-insensitive', () => {
+    expect(defaultStatusTone('PAID')).toBe('success');
+    expect(defaultStatusTone('Draft')).toBe('warning');
+  });
+});

--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -1,8 +1,12 @@
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Plus, Edit, Trash2, X, Search } from 'lucide-react';
+import { Edit, Plus, Trash2, X } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import TableToolbar from '@/components/data/TableToolbar';
+import SearchInput from '@/components/data/SearchInput';
 import type { Customer } from '@/types';
 
 const emptyForm = { name: '', email: '', phone: '', notes: '' };
@@ -58,25 +62,57 @@ export default function CustomersPage() {
     } catch { toast.error('Failed to delete'); }
   };
 
-  return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-3xl font-bold">Customers</h1>
-        <button onClick={openNew} className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 transition-opacity cursor-pointer">
-          <Plus className="w-4 h-4" /> Add Customer
-        </button>
-      </div>
+  const columns: Column<Customer>[] = [
+    { key: 'name', header: 'Name', cell: (c) => <span className="font-medium">{c.name}</span> },
+    { key: 'email', header: 'Email', colClassName: 'hidden md:table-cell', cell: (c) => c.email || <span className="text-muted-foreground">—</span> },
+    { key: 'phone', header: 'Phone', colClassName: 'hidden lg:table-cell', cell: (c) => c.phone || <span className="text-muted-foreground">—</span> },
+    { key: 'job_count', header: 'Jobs', numeric: true, cell: (c) => c.job_count },
+    {
+      key: 'actions',
+      header: <span className="sr-only">Actions</span>,
+      width: '80px',
+      cell: (c) => (
+        <div className="flex items-center justify-end gap-1">
+          <button
+            type="button"
+            onClick={() => openEdit(c)}
+            aria-label={`Edit ${c.name}`}
+            className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <Edit className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => deleteCustomer(c)}
+            aria-label={`Delete ${c.name}`}
+            className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+      ),
+    },
+  ];
 
-      <div className="relative mb-6">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-        <input
-          type="text"
-          placeholder="Search customers..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="w-full pl-10 pr-3 py-2 border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-        />
-      </div>
+  const total = customers?.length ?? 0;
+  const activeFilters = search ? 1 : 0;
+  const clearFilters = () => setSearch('');
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Customers"
+        description={`${total.toLocaleString()} ${total === 1 ? 'customer' : 'customers'}`}
+        actions={
+          <button
+            type="button"
+            onClick={openNew}
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" /> Add customer
+          </button>
+        }
+      />
 
       {editing !== null && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={(e) => e.target === e.currentTarget && close()}>
@@ -99,46 +135,18 @@ export default function CustomersPage() {
         </div>
       )}
 
-      {isLoading ? (
-        <div className="bg-card border border-border rounded-lg p-4 h-48 animate-pulse" />
-      ) : (
-        <div className="overflow-x-auto bg-card border border-border rounded-lg">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border text-left text-muted-foreground">
-                <th className="px-4 py-3 font-medium">Name</th>
-                <th className="px-4 py-3 font-medium">Email</th>
-                <th className="px-4 py-3 font-medium">Phone</th>
-                <th className="px-4 py-3 font-medium text-right">Jobs</th>
-                <th className="px-4 py-3 font-medium">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {customers?.map((c) => (
-                <tr key={c.id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                  <td className="px-4 py-3 font-medium">{c.name}</td>
-                  <td className="px-4 py-3 text-muted-foreground">{c.email || '—'}</td>
-                  <td className="px-4 py-3 text-muted-foreground">{c.phone || '—'}</td>
-                  <td className="px-4 py-3 text-right">{c.job_count}</td>
-                  <td className="px-4 py-3">
-                    <div className="flex gap-1">
-                      <button onClick={() => openEdit(c)} className="p-1.5 hover:bg-accent rounded-md text-muted-foreground cursor-pointer" title="Edit"><Edit className="w-4 h-4" /></button>
-                      <button onClick={() => deleteCustomer(c)} className="p-1.5 hover:bg-destructive/10 rounded-md text-muted-foreground hover:text-destructive cursor-pointer" title="Delete"><Trash2 className="w-4 h-4" /></button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-              {customers?.length === 0 && (
-                <tr>
-                  <td colSpan={5} className="px-4 py-12 text-center text-muted-foreground">
-                    No customers found. Add your first customer to get started.
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <DataTable<Customer>
+        data={customers || []}
+        columns={columns}
+        rowKey={(c) => c.id}
+        loading={isLoading}
+        emptyState={activeFilters > 0 ? 'No customers match this search.' : 'No customers yet — add your first one to get started.'}
+        toolbar={
+          <TableToolbar total={total} activeFilters={activeFilters} onClearFilters={clearFilters}>
+            <SearchInput value={search} onChange={setSearch} placeholder="Search customers…" />
+          </TableToolbar>
+        }
+      />
     </div>
   );
 }

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -15,11 +15,16 @@ import {
 import { toast } from 'sonner';
 import api from '@/api/client';
 import EmptyState from '@/components/ui/EmptyState';
-import { SkeletonTable } from '@/components/ui/Skeleton';
 import PageHeader from '@/components/layout/PageHeader';
 import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
+import DataTable, { type Column, type SortDir } from '@/components/data/DataTable';
+import StatusBadge, { type StatusTone } from '@/components/data/StatusBadge';
+import TableToolbar from '@/components/data/TableToolbar';
+import SearchInput from '@/components/data/SearchInput';
+import Select from '@/components/data/Select';
+import Pagination from '@/components/data/Pagination';
 import { cn, formatCurrency } from '@/lib/utils';
-import type { InventoryAlert, InventoryReconcileResponse, PaginatedProducts, PaginatedTransactions } from '@/types';
+import type { InventoryAlert, InventoryReconcileResponse, InventoryTransaction, PaginatedProducts, PaginatedTransactions } from '@/types';
 
 const TYPE_OPTIONS = [
   { value: '', label: 'All types' },
@@ -115,24 +120,28 @@ export default function InventoryPage() {
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(25);
+  const [sortKey, setSortKey] = useState<string>('created_at');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [showReconcile, setShowReconcile] = useState(false);
   const [reconcileSaving, setReconcileSaving] = useState(false);
   const [reconcileForm, setReconcileForm] = useState({ product_id: '', counted_qty: 0, reason: '', notes: '' });
   const [showAdjust, setShowAdjust] = useState(false);
   const [adjustSaving, setAdjustSaving] = useState(false);
   const [adjustForm, setAdjustForm] = useState({ product_id: '', type: 'adjustment', quantity: 0, notes: '' });
-  const limit = 25;
 
   const params = useMemo(
     () => ({
-      skip: page * limit,
-      limit,
+      skip: page * pageSize,
+      limit: pageSize,
+      sort_by: sortKey || undefined,
+      sort_dir: sortDir,
       ...(search ? { search } : {}),
       ...(type ? { type } : {}),
       ...(dateFrom ? { date_from: dateFrom } : {}),
       ...(dateTo ? { date_to: dateTo } : {}),
     }),
-    [page, limit, search, type, dateFrom, dateTo]
+    [page, pageSize, sortKey, sortDir, search, type, dateFrom, dateTo]
   );
 
   const { data, isLoading } = useQuery<PaginatedTransactions>({
@@ -155,7 +164,6 @@ export default function InventoryPage() {
   const selectedProduct = products.find((product) => product.id === reconcileForm.product_id) || null;
   const adjustProduct = products.find((product) => product.id === adjustForm.product_id) || null;
   const variance = selectedProduct ? reconcileForm.counted_qty - selectedProduct.stock_qty : 0;
-  const totalPages = data ? Math.max(1, Math.ceil(data.total / limit)) : 1;
 
   const productAlerts = alerts.filter((alert) => alert.type === 'product');
   const materialAlerts = alerts.filter((alert) => alert.type !== 'product');
@@ -768,157 +776,184 @@ export default function InventoryPage() {
           </section>
         </div>
       ) : (
-        <div className="space-y-6">
-          <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-              <div>
+        (() => {
+          const typeToneMap: Record<string, StatusTone> = {
+            production: 'success',
+            sale: 'info',
+            adjustment: 'warning',
+            return: 'info',
+            waste: 'destructive',
+          };
+          const activeFilters = [search, type, dateFrom, dateTo].filter(Boolean).length;
+          const clearFilters = () => {
+            setSearch('');
+            setType('');
+            setDateFrom('');
+            setDateTo('');
+            setPage(0);
+          };
+          const handleSortChange = (key: string, dir: SortDir | null) => {
+            if (!key || !dir) {
+              setSortKey('created_at');
+              setSortDir('desc');
+            } else {
+              setSortKey(key);
+              setSortDir(dir);
+            }
+            setPage(0);
+          };
+          const ledgerColumns: Column<InventoryTransaction>[] = [
+            {
+              key: 'created_at',
+              header: 'Date',
+              sortable: true,
+              cell: (t) => (
+                <span className="text-xs tabular-nums">
+                  {t.created_at ? new Date(t.created_at).toLocaleString() : '—'}
+                </span>
+              ),
+            },
+            {
+              key: 'product_name',
+              header: 'Product',
+              cell: (t) =>
+                t.product_name ? (
+                  <Link className="font-medium no-underline hover:underline" to={`/products/${t.product_id}`}>
+                    {t.product_name}
+                  </Link>
+                ) : (
+                  <span className="font-mono text-xs">{t.product_id}</span>
+                ),
+            },
+            {
+              key: 'product_sku',
+              header: 'SKU',
+              colClassName: 'hidden lg:table-cell',
+              cell: (t) => <span className="font-mono text-xs">{t.product_sku || '—'}</span>,
+            },
+            {
+              key: 'type',
+              header: 'Type',
+              sortable: true,
+              cell: (t) => <StatusBadge tone={typeToneMap[t.type] || 'neutral'}>{t.type}</StatusBadge>,
+            },
+            {
+              key: 'quantity',
+              header: 'Qty',
+              sortable: true,
+              numeric: true,
+              cell: (t) => (
+                <span className={t.quantity > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}>
+                  {t.quantity > 0 ? '+' : ''}
+                  {t.quantity}
+                </span>
+              ),
+            },
+            {
+              key: 'unit_cost',
+              header: 'Unit cost',
+              sortable: true,
+              numeric: true,
+              colClassName: 'hidden md:table-cell',
+              cell: (t) => formatCurrency(t.unit_cost),
+            },
+            {
+              key: 'job_id',
+              header: 'Job',
+              colClassName: 'hidden xl:table-cell',
+              cell: (t) => <span className="font-mono text-xs">{t.job_id || '—'}</span>,
+            },
+            {
+              key: 'notes',
+              header: 'Notes',
+              colClassName: 'hidden xl:table-cell',
+              cell: (t) => <span className="text-xs text-muted-foreground">{t.notes || '—'}</span>,
+            },
+          ];
+
+          return (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                  <ScrollText className="h-5 w-5 text-muted-foreground" />
-                  <h2 className="text-xl font-semibold">Inventory ledger</h2>
+                  <ScrollText className="h-4 w-4 text-muted-foreground" />
+                  <h2 className="text-base font-semibold">Inventory ledger</h2>
                 </div>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  Full transaction history stays available for audit work and troubleshooting, but it is intentionally a secondary surface.
-                </p>
+                <button
+                  type="button"
+                  onClick={() => setSurface('exceptions')}
+                  className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-1.5 text-xs font-medium transition-colors hover:bg-muted"
+                >
+                  Back to exceptions
+                </button>
               </div>
-              <button
-                type="button"
-                onClick={() => setSurface('exceptions')}
-                className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent"
-              >
-                Back to exceptions
-              </button>
-            </div>
 
-            <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-4">
-              <input
-                value={search}
-                onChange={(event) => {
-                  setSearch(event.target.value);
-                  setPage(0);
-                }}
-                placeholder="Search product name or SKU"
-                className="rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+              <DataTable<InventoryTransaction>
+                data={items}
+                columns={ledgerColumns}
+                rowKey={(t) => t.id}
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onSortChange={handleSortChange}
+                loading={isLoading}
+                emptyState={activeFilters > 0 ? 'No transactions match these filters.' : 'No inventory transactions recorded yet.'}
+                toolbar={
+                  <TableToolbar total={data?.total ?? 0} activeFilters={activeFilters} onClearFilters={clearFilters}>
+                    <SearchInput
+                      value={search}
+                      onChange={(v) => {
+                        setSearch(v);
+                        setPage(0);
+                      }}
+                      placeholder="Search product or SKU…"
+                    />
+                    <Select
+                      value={type}
+                      onChange={(v) => {
+                        setType(v);
+                        setPage(0);
+                      }}
+                      options={TYPE_OPTIONS.filter((o) => o.value).map((o) => ({ value: o.value, label: o.label }))}
+                      placeholder="All types"
+                      aria-label="Filter by type"
+                    />
+                    <input
+                      type="date"
+                      value={dateFrom}
+                      onChange={(e) => {
+                        setDateFrom(e.target.value);
+                        setPage(0);
+                      }}
+                      className="rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      aria-label="From date"
+                    />
+                    <input
+                      type="date"
+                      value={dateTo}
+                      onChange={(e) => {
+                        setDateTo(e.target.value);
+                        setPage(0);
+                      }}
+                      className="rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      aria-label="To date"
+                    />
+                  </TableToolbar>
+                }
+                footer={
+                  <Pagination
+                    page={page}
+                    pageSize={pageSize}
+                    total={data?.total ?? 0}
+                    onPageChange={setPage}
+                    onPageSizeChange={(n) => {
+                      setPageSize(n);
+                      setPage(0);
+                    }}
+                  />
+                }
               />
-              <select
-                value={type}
-                onChange={(event) => {
-                  setType(event.target.value);
-                  setPage(0);
-                }}
-                className="rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
-              >
-                {TYPE_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-              <input
-                type="date"
-                value={dateFrom}
-                onChange={(event) => {
-                  setDateFrom(event.target.value);
-                  setPage(0);
-                }}
-                className="rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
-              />
-              <input
-                type="date"
-                value={dateTo}
-                onChange={(event) => {
-                  setDateTo(event.target.value);
-                  setPage(0);
-                }}
-                className="rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
-              />
             </div>
-          </section>
-
-          {isLoading ? (
-            <SkeletonTable rows={8} cols={8} />
-          ) : !items.length ? (
-            <div className="rounded-lg border border-border bg-card p-8 text-center text-muted-foreground">
-              No inventory transactions found
-            </div>
-          ) : (
-            <div className="overflow-x-auto rounded-lg border border-border bg-card shadow-sm">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-border text-left text-muted-foreground">
-                    <th className="px-4 py-3 font-medium">Date</th>
-                    <th className="px-4 py-3 font-medium">Product</th>
-                    <th className="px-4 py-3 font-medium">SKU</th>
-                    <th className="px-4 py-3 font-medium">Type</th>
-                    <th className="px-4 py-3 font-medium text-right">Qty</th>
-                    <th className="px-4 py-3 font-medium text-right">Unit Cost</th>
-                    <th className="px-4 py-3 font-medium">Job</th>
-                    <th className="px-4 py-3 font-medium">Notes</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {items.map((transaction) => (
-                    <tr key={transaction.id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                      <td className="px-4 py-3 text-xs">
-                        {transaction.created_at ? new Date(transaction.created_at).toLocaleString() : '-'}
-                      </td>
-                      <td className="px-4 py-3">
-                        {transaction.product_name ? (
-                          <Link className="font-medium hover:underline" to={`/products/${transaction.product_id}`}>
-                            {transaction.product_name}
-                          </Link>
-                        ) : (
-                          transaction.product_id
-                        )}
-                      </td>
-                      <td className="px-4 py-3 font-mono text-xs">{transaction.product_sku || '-'}</td>
-                      <td className="px-4 py-3">
-                        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[transaction.type] || ''}`}>
-                          {transaction.type}
-                        </span>
-                      </td>
-                      <td
-                        className={cn(
-                          'px-4 py-3 text-right font-medium',
-                          transaction.quantity > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
-                        )}
-                      >
-                        {transaction.quantity > 0 ? '+' : ''}
-                        {transaction.quantity}
-                      </td>
-                      <td className="px-4 py-3 text-right">{formatCurrency(transaction.unit_cost)}</td>
-                      <td className="px-4 py-3 font-mono text-xs">{transaction.job_id || '-'}</td>
-                      <td className="px-4 py-3 text-xs text-muted-foreground">{transaction.notes || '-'}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-
-          <div className="flex items-center justify-between text-sm">
-            <p className="text-muted-foreground">
-              Page {page + 1} of {totalPages}
-            </p>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={() => setPage((current) => Math.max(0, current - 1))}
-                disabled={page === 0}
-                className="rounded-xl border border-border px-3 py-2 transition-colors hover:bg-accent disabled:opacity-50"
-              >
-                Previous
-              </button>
-              <button
-                type="button"
-                onClick={() => setPage((current) => (current + 1 < totalPages ? current + 1 : current))}
-                disabled={page + 1 >= totalPages}
-                className="rounded-xl border border-border px-3 py-2 transition-colors hover:bg-accent disabled:opacity-50"
-              >
-                Next
-              </button>
-            </div>
-          </div>
-        </div>
+          );
+        })()
       )}
 
       <div className="sr-only" aria-live="polite">

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -1,43 +1,53 @@
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useNavigate } from 'react-router-dom';
-import { Plus, Search, ChevronLeft, ChevronRight, Copy } from 'lucide-react';
+import { Copy, Plus } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column, type SortDir } from '@/components/data/DataTable';
+import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
+import TableToolbar from '@/components/data/TableToolbar';
+import SearchInput from '@/components/data/SearchInput';
+import Select from '@/components/data/Select';
+import Pagination from '@/components/data/Pagination';
 import { formatCurrency } from '@/lib/utils';
 import type { Job, PaginatedJobs } from '@/types';
+
+const STATUS_OPTIONS = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'in_progress', label: 'In progress' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'cancelled', label: 'Cancelled' },
+];
 
 export default function JobsPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [search, setSearch] = useState('');
   const [status, setStatus] = useState('');
+  const [sortKey, setSortKey] = useState<string>('date');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(25);
   const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
-  const limit = 20;
 
   const { data, isLoading } = useQuery<PaginatedJobs>({
-    queryKey: ['jobs', { search, status, page }],
+    queryKey: ['jobs', { search, status, sortKey, sortDir, page, pageSize }],
     queryFn: () => {
       const params = new URLSearchParams();
       if (search) params.set('search', search);
       if (status) params.set('status', status);
-      params.set('skip', String(page * limit));
-      params.set('limit', String(limit));
+      if (sortKey) params.set('sort_by', sortKey);
+      params.set('sort_dir', sortDir);
+      params.set('skip', String(page * pageSize));
+      params.set('limit', String(pageSize));
       return api.get(`/jobs?${params}`).then((r) => r.data);
     },
   });
 
   const jobs = data?.items || [];
   const total = data?.total || 0;
-  const totalPages = Math.ceil(total / limit);
-
-  const statusColors: Record<string, string> = {
-    completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-    in_progress: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-    draft: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
-    cancelled: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-  };
 
   const handleDuplicate = async (job: Job) => {
     setDuplicatingId(job.id);
@@ -53,140 +63,157 @@ export default function JobsPage() {
     }
   };
 
-  return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-3xl font-bold">Jobs</h1>
-        <Link
-          to="/orders/jobs/new"
-          className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 transition-opacity no-underline"
-        >
-          <Plus className="w-4 h-4" /> New Job
+  const handleSortChange = (key: string, dir: SortDir | null) => {
+    if (!key || !dir) {
+      setSortKey('date');
+      setSortDir('desc');
+    } else {
+      setSortKey(key);
+      setSortDir(dir);
+    }
+    setPage(0);
+  };
+
+  const activeFilters = [search, status].filter(Boolean).length;
+  const clearFilters = () => {
+    setSearch('');
+    setStatus('');
+    setPage(0);
+  };
+
+  const columns: Column<Job>[] = [
+    {
+      key: 'job_number',
+      header: 'Job #',
+      sortable: true,
+      cell: (j) => (
+        <Link to={`/orders/jobs/${j.id}`} className="font-mono text-xs font-medium text-primary no-underline hover:underline">
+          {j.job_number}
         </Link>
-      </div>
-
-      {/* Filters */}
-      <div className="flex flex-col sm:flex-row gap-3 mb-6">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-          <input
-            type="text"
-            placeholder="Search jobs..."
-            value={search}
-            onChange={(e) => { setSearch(e.target.value); setPage(0); }}
-            className="w-full pl-10 pr-3 py-2 border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-          />
-        </div>
-        <select
-          value={status}
-          onChange={(e) => { setStatus(e.target.value); setPage(0); }}
-          className="px-3 py-2 border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+      ),
+    },
+    { key: 'date', header: 'Date', sortable: true, cell: (j) => j.date },
+    {
+      key: 'customer_name',
+      header: 'Customer',
+      colClassName: 'hidden lg:table-cell',
+      cell: (j) => j.customer_name || <span className="text-muted-foreground">—</span>,
+    },
+    { key: 'product_name', header: 'Product', cell: (j) => j.product_name },
+    {
+      key: 'printer',
+      header: 'Printer',
+      colClassName: 'hidden lg:table-cell',
+      cell: (j) => <span className="text-xs text-muted-foreground">{j.printer?.name || '—'}</span>,
+    },
+    { key: 'total_pieces', header: 'Pieces', numeric: true, cell: (j) => j.total_pieces },
+    {
+      key: 'total_revenue',
+      header: 'Revenue',
+      sortable: true,
+      numeric: true,
+      cell: (j) => formatCurrency(j.total_revenue),
+    },
+    {
+      key: 'net_profit',
+      header: 'Profit',
+      sortable: true,
+      numeric: true,
+      colClassName: 'hidden md:table-cell',
+      cell: (j) => (
+        <span className={j.net_profit >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive'}>
+          {formatCurrency(j.net_profit)}
+        </span>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      sortable: true,
+      cell: (j) => <StatusBadge tone={defaultStatusTone(j.status)}>{j.status.replace('_', ' ')}</StatusBadge>,
+    },
+    {
+      key: 'actions',
+      header: <span className="sr-only">Actions</span>,
+      width: '104px',
+      cell: (j) => (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            handleDuplicate(j);
+          }}
+          disabled={duplicatingId === j.id}
+          aria-label={`Copy ${j.job_number}`}
+          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-2.5 text-xs font-medium transition-colors hover:bg-muted disabled:opacity-50"
         >
-          <option value="">All Statuses</option>
-          <option value="draft">Draft</option>
-          <option value="in_progress">In Progress</option>
-          <option value="completed">Completed</option>
-          <option value="cancelled">Cancelled</option>
-        </select>
-      </div>
+          <Copy className="h-3.5 w-3.5" />
+          {duplicatingId === j.id ? 'Copying…' : 'Copy'}
+        </button>
+      ),
+    },
+  ];
 
-      {isLoading ? (
-        <div className="space-y-3">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="bg-card border border-border rounded-lg p-4 h-16 animate-pulse" />
-          ))}
-        </div>
-      ) : (
-        <>
-          <div className="overflow-x-auto bg-card border border-border rounded-lg">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border text-left text-muted-foreground">
-                  <th className="px-4 py-3 font-medium">Job #</th>
-                  <th className="px-4 py-3 font-medium">Date</th>
-                  <th className="px-4 py-3 font-medium">Customer</th>
-                  <th className="px-4 py-3 font-medium">Product</th>
-                  <th className="px-4 py-3 font-medium">Printer</th>
-                  <th className="px-4 py-3 font-medium text-right">Pieces</th>
-                  <th className="px-4 py-3 font-medium text-right">Revenue</th>
-                  <th className="px-4 py-3 font-medium text-right">Profit</th>
-                  <th className="px-4 py-3 font-medium">Status</th>
-                  <th className="px-4 py-3 font-medium text-right">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {jobs.map((job) => (
-                  <tr key={job.id} className="border-b border-border last:border-0 hover:bg-accent/50 transition-colors">
-                    <td className="px-4 py-3">
-                      <Link to={`/orders/jobs/${job.id}`} className="text-primary hover:underline font-medium no-underline">
-                        {job.job_number}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-3">{job.date}</td>
-                    <td className="px-4 py-3">{job.customer_name || '—'}</td>
-                    <td className="px-4 py-3">{job.product_name}</td>
-                    <td className="px-4 py-3 text-xs text-muted-foreground">{job.printer?.name || '—'}</td>
-                    <td className="px-4 py-3 text-right">{job.total_pieces}</td>
-                    <td className="px-4 py-3 text-right">{formatCurrency(job.total_revenue)}</td>
-                    <td className="px-4 py-3 text-right">
-                      <span className={job.net_profit >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'}>
-                        {formatCurrency(job.net_profit)}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${statusColors[job.status] || 'bg-primary/10 text-primary'}`}>
-                        {job.status.replace('_', ' ')}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <button
-                        onClick={() => handleDuplicate(job)}
-                        disabled={duplicatingId === job.id}
-                        className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-border rounded-md text-xs font-medium hover:bg-accent disabled:opacity-50 cursor-pointer"
-                      >
-                        <Copy className="w-3.5 h-3.5" />
-                        {duplicatingId === job.id ? 'Copying...' : 'Copy'}
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-                {jobs.length === 0 && (
-                  <tr>
-                    <td colSpan={10} className="px-4 py-12 text-center text-muted-foreground">
-                      No jobs found. {!search && !status && 'Create your first job to get started.'}
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Jobs"
+        description={`${total.toLocaleString()} ${total === 1 ? 'job' : 'jobs'}`}
+        actions={
+          <Link
+            to="/orders/jobs/new"
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground no-underline transition-opacity hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" /> New job
+          </Link>
+        }
+      />
 
-          {/* Pagination */}
-          {totalPages > 1 && (
-            <div className="flex items-center justify-between mt-4">
-              <p className="text-sm text-muted-foreground">
-                Showing {page * limit + 1}–{Math.min((page + 1) * limit, total)} of {total}
-              </p>
-              <div className="flex gap-1">
-                <button
-                  onClick={() => setPage((p) => Math.max(0, p - 1))}
-                  disabled={page === 0}
-                  className="p-2 rounded-md hover:bg-accent disabled:opacity-30 transition-colors"
-                >
-                  <ChevronLeft className="w-4 h-4" />
-                </button>
-                <button
-                  onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-                  disabled={page >= totalPages - 1}
-                  className="p-2 rounded-md hover:bg-accent disabled:opacity-30 transition-colors"
-                >
-                  <ChevronRight className="w-4 h-4" />
-                </button>
-              </div>
-            </div>
-          )}
-        </>
-      )}
+      <DataTable<Job>
+        data={jobs}
+        columns={columns}
+        rowKey={(j) => j.id}
+        onRowClick={(j) => navigate(`/orders/jobs/${j.id}`)}
+        sortKey={sortKey}
+        sortDir={sortDir}
+        onSortChange={handleSortChange}
+        loading={isLoading}
+        emptyState={activeFilters > 0 ? 'No jobs match these filters.' : 'No jobs yet — create one to get started.'}
+        toolbar={
+          <TableToolbar total={total} activeFilters={activeFilters} onClearFilters={clearFilters}>
+            <SearchInput
+              value={search}
+              onChange={(v) => {
+                setSearch(v);
+                setPage(0);
+              }}
+              placeholder="Search jobs…"
+            />
+            <Select
+              value={status}
+              onChange={(v) => {
+                setStatus(v);
+                setPage(0);
+              }}
+              options={STATUS_OPTIONS}
+              placeholder="All statuses"
+              aria-label="Filter by status"
+            />
+          </TableToolbar>
+        }
+        footer={
+          <Pagination
+            page={page}
+            pageSize={pageSize}
+            total={total}
+            onPageChange={setPage}
+            onPageSizeChange={(n) => {
+              setPageSize(n);
+              setPage(0);
+            }}
+          />
+        }
+      />
     </div>
   );
 }

--- a/frontend/src/pages/MaterialsPage.tsx
+++ b/frontend/src/pages/MaterialsPage.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Plus, Edit, X } from 'lucide-react';
+import { Edit, Plus, X } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
-import { SkeletonTable } from '@/components/ui/Skeleton';
-import EmptyState from '@/components/ui/EmptyState';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import StatusBadge from '@/components/data/StatusBadge';
+import TableToolbar from '@/components/data/TableToolbar';
 import type { Material } from '@/types';
 
 const emptyForm = { name: '', brand: '', spool_weight_g: 1000, spool_price: 20, net_usable_g: 950, notes: '', spools_in_stock: 0, reorder_point: 2 };
@@ -76,14 +78,84 @@ export default function MaterialsPage() {
   const inputCls = (field: string) =>
     `w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring ${formErrors[field] ? 'border-destructive' : 'border-input'}`;
 
-  return (
-    <div>
-      <div className="flex items-center justify-between mb-8">
-        <h1 className="text-3xl font-bold">Materials</h1>
-        <button onClick={openNew} className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 transition-opacity cursor-pointer">
-          <Plus className="w-4 h-4" /> Add Material
+  const columns: Column<Material>[] = [
+    { key: 'name', header: 'Name', cell: (m) => <span className="font-medium">{m.name}</span> },
+    { key: 'brand', header: 'Brand', cell: (m) => m.brand },
+    { key: 'spool_weight_g', header: 'Spool (g)', numeric: true, cell: (m) => m.spool_weight_g },
+    { key: 'spool_price', header: 'Price', numeric: true, cell: (m) => formatCurrency(m.spool_price) },
+    {
+      key: 'net_usable_g',
+      header: 'Usable (g)',
+      numeric: true,
+      colClassName: 'hidden lg:table-cell',
+      cell: (m) => m.net_usable_g,
+    },
+    {
+      key: 'cost_per_g',
+      header: 'Cost/g',
+      numeric: true,
+      cell: (m) => `$${Number(m.cost_per_g).toFixed(4)}`,
+    },
+    {
+      key: 'spools_in_stock',
+      header: 'Spools',
+      numeric: true,
+      cell: (m) => (
+        <span className={m.spools_in_stock <= m.reorder_point ? 'text-amber-600 dark:text-amber-400 font-medium' : ''}>
+          {m.spools_in_stock}
+        </span>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      cell: (m) => (
+        <button
+          type="button"
+          onClick={() => toggleActive(m)}
+          aria-label={m.active ? `Deactivate ${m.name}` : `Activate ${m.name}`}
+          className="cursor-pointer"
+        >
+          <StatusBadge tone={m.active ? 'success' : 'destructive'}>
+            {m.active ? 'Active' : 'Inactive'}
+          </StatusBadge>
         </button>
-      </div>
+      ),
+    },
+    {
+      key: 'actions',
+      header: <span className="sr-only">Actions</span>,
+      width: '48px',
+      cell: (m) => (
+        <button
+          type="button"
+          onClick={() => openEdit(m)}
+          aria-label={`Edit ${m.name}`}
+          className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <Edit className="h-4 w-4" />
+        </button>
+      ),
+    },
+  ];
+
+  const total = materials?.length ?? 0;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Materials"
+        description={`${total.toLocaleString()} ${total === 1 ? 'material' : 'materials'}`}
+        actions={
+          <button
+            type="button"
+            onClick={openNew}
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" /> Add material
+          </button>
+        }
+      />
 
       {/* Modal */}
       {editing !== null && (
@@ -144,91 +216,58 @@ export default function MaterialsPage() {
         </div>
       )}
 
-      {isLoading ? (
-        <SkeletonTable rows={5} cols={7} />
-      ) : !materials?.length ? (
-        <EmptyState
-          icon="materials"
-          title="No materials yet"
-          description="Add your first filament material to start tracking costs."
-          action={
-            <button onClick={openNew} className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 cursor-pointer">
-              <Plus className="w-4 h-4" /> Add Material
-            </button>
-          }
+      {/* Desktop table */}
+      <div className="hidden md:block">
+        <DataTable<Material>
+          data={materials || []}
+          columns={columns}
+          rowKey={(m) => m.id}
+          loading={isLoading}
+          emptyState="No materials yet — add your first filament to start tracking costs."
+          toolbar={<TableToolbar total={total} />}
         />
-      ) : (
-        <>
-          {/* Desktop table */}
-          <div className="hidden md:block overflow-x-auto bg-card border border-border rounded-lg">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border text-left text-muted-foreground">
-                  <th className="px-4 py-3 font-medium">Name</th>
-                  <th className="px-4 py-3 font-medium">Brand</th>
-                  <th className="px-4 py-3 font-medium text-right">Spool (g)</th>
-                  <th className="px-4 py-3 font-medium text-right">Price</th>
-                  <th className="px-4 py-3 font-medium text-right">Usable (g)</th>
-                  <th className="px-4 py-3 font-medium text-right">Cost/g</th>
-                  <th className="px-4 py-3 font-medium text-right">Spools</th>
-                  <th className="px-4 py-3 font-medium">Status</th>
-                  <th className="px-4 py-3 font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {materials.map((m) => (
-                  <tr key={m.id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                    <td className="px-4 py-3 font-medium">{m.name}</td>
-                    <td className="px-4 py-3">{m.brand}</td>
-                    <td className="px-4 py-3 text-right">{m.spool_weight_g}</td>
-                    <td className="px-4 py-3 text-right">{formatCurrency(m.spool_price)}</td>
-                    <td className="px-4 py-3 text-right">{m.net_usable_g}</td>
-                    <td className="px-4 py-3 text-right">${Number(m.cost_per_g).toFixed(4)}</td>
-                    <td className={`px-4 py-3 text-right ${m.spools_in_stock <= m.reorder_point ? 'text-amber-600 dark:text-amber-400 font-medium' : ''}`}>{m.spools_in_stock}</td>
-                    <td className="px-4 py-3">
-                      <button onClick={() => toggleActive(m)} className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium cursor-pointer ${m.active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'}`}>
-                        {m.active ? 'Active' : 'Inactive'}
-                      </button>
-                    </td>
-                    <td className="px-4 py-3">
-                      <button onClick={() => openEdit(m)} className="p-1.5 hover:bg-accent rounded-md text-muted-foreground cursor-pointer" title="Edit">
-                        <Edit className="w-4 h-4" />
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+      </div>
 
-          {/* Mobile cards */}
-          <div className="md:hidden space-y-3">
-            {materials.map((m) => (
-              <div key={m.id} className="bg-card border border-border rounded-lg p-4">
-                <div className="flex items-start justify-between mb-2">
-                  <div>
-                    <p className="font-semibold">{m.name}</p>
-                    <p className="text-xs text-muted-foreground">{m.brand}</p>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <button onClick={() => toggleActive(m)} className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium cursor-pointer ${m.active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'}`}>
-                      {m.active ? 'Active' : 'Inactive'}
-                    </button>
-                    <button onClick={() => openEdit(m)} className="p-1.5 hover:bg-accent rounded-md text-muted-foreground cursor-pointer">
-                      <Edit className="w-4 h-4" />
-                    </button>
-                  </div>
-                </div>
-                <div className="grid grid-cols-3 gap-2 text-sm">
-                  <div><p className="text-xs text-muted-foreground">Spool</p><p>{m.spool_weight_g}g</p></div>
-                  <div><p className="text-xs text-muted-foreground">Price</p><p>{formatCurrency(m.spool_price)}</p></div>
-                  <div><p className="text-xs text-muted-foreground">Cost/g</p><p>${Number(m.cost_per_g).toFixed(4)}</p></div>
-                </div>
+      {/* Mobile cards */}
+      <div className="md:hidden space-y-3">
+        {materials?.map((m) => (
+          <div key={m.id} className="rounded-md border border-border bg-card p-4">
+            <div className="mb-2 flex items-start justify-between">
+              <div>
+                <p className="font-semibold">{m.name}</p>
+                <p className="text-xs text-muted-foreground">{m.brand}</p>
               </div>
-            ))}
+              <div className="flex items-center gap-2">
+                <button type="button" onClick={() => toggleActive(m)}>
+                  <StatusBadge tone={m.active ? 'success' : 'destructive'}>{m.active ? 'Active' : 'Inactive'}</StatusBadge>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => openEdit(m)}
+                  aria-label={`Edit ${m.name}`}
+                  className="rounded-md p-1.5 text-muted-foreground hover:bg-muted"
+                >
+                  <Edit className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+            <div className="grid grid-cols-3 gap-2 text-sm">
+              <div>
+                <p className="text-xs text-muted-foreground">Spool</p>
+                <p className="tabular-nums">{m.spool_weight_g}g</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Price</p>
+                <p className="tabular-nums">{formatCurrency(m.spool_price)}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Cost/g</p>
+                <p className="tabular-nums">${Number(m.cost_per_g).toFixed(4)}</p>
+              </div>
+            </div>
           </div>
-        </>
-      )}
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -1,41 +1,54 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { AlertTriangle, ArrowRight, Archive, ArchiveRestore, Eye, Pencil, Plus, ScanBarcode } from 'lucide-react';
+import { AlertTriangle, Archive, ArchiveRestore, Eye, Pencil, Plus, ScanBarcode } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
-import EmptyState from '@/components/ui/EmptyState';
-import { SkeletonTable } from '@/components/ui/Skeleton';
 import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column, type SortDir } from '@/components/data/DataTable';
+import StatusBadge from '@/components/data/StatusBadge';
+import TableToolbar from '@/components/data/TableToolbar';
+import SearchInput from '@/components/data/SearchInput';
+import Pagination from '@/components/data/Pagination';
 import { formatCurrency } from '@/lib/utils';
 import type { PaginatedProducts, Product } from '@/types';
 
 export default function ProductsPage() {
+  const navigate = useNavigate();
   const [search, setSearch] = useState('');
+  const [sortKey, setSortKey] = useState<string>('name');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [page, setPage] = useState(0);
-  const limit = 25;
+  const [pageSize, setPageSize] = useState(25);
 
   const { data, isLoading, refetch } = useQuery<PaginatedProducts>({
-    queryKey: ['products', search, page],
+    queryKey: ['products', search, sortKey, sortDir, page, pageSize],
     queryFn: () =>
-      api.get('/products', { params: { search: search || undefined, skip: page * limit, limit } }).then((r) => r.data),
+      api
+        .get('/products', {
+          params: {
+            search: search || undefined,
+            sort_by: sortKey || undefined,
+            sort_dir: sortDir,
+            skip: page * pageSize,
+            limit: pageSize,
+          },
+        })
+        .then((r) => r.data),
   });
 
   const products = data?.items || [];
   const total = data?.total || 0;
-  const totalPages = Math.max(1, Math.ceil(total / limit));
-  const lowStockCount = products.filter((product) => product.stock_qty <= product.reorder_point).length;
+  const lowStockCount = products.filter((p) => p.stock_qty <= p.reorder_point).length;
 
   const toggleActive = async (product: Product) => {
     const action = product.is_active ? 'archive' : 'restore';
     const confirmed = window.confirm(
       product.is_active
         ? `Archive ${product.name}?\n\nThis removes it from active selling while preserving history.`
-        : `Restore ${product.name} to active products?`
+        : `Restore ${product.name} to active products?`,
     );
-
     if (!confirmed) return;
-
     try {
       if (product.is_active) {
         await api.delete(`/products/${product.id}`);
@@ -50,6 +63,119 @@ export default function ProductsPage() {
     }
   };
 
+  const handleSortChange = (key: string, dir: SortDir | null) => {
+    if (!key || !dir) {
+      setSortKey('name');
+      setSortDir('asc');
+    } else {
+      setSortKey(key);
+      setSortDir(dir);
+    }
+    setPage(0);
+  };
+
+  const activeFilters = [search].filter(Boolean).length;
+  const clearFilters = () => {
+    setSearch('');
+    setPage(0);
+  };
+
+  const columns: Column<Product>[] = [
+    { key: 'sku', header: 'SKU', sortable: true, cell: (p) => <span className="font-mono text-xs">{p.sku}</span> },
+    {
+      key: 'name',
+      header: 'Name',
+      sortable: true,
+      cell: (p) => (
+        <div>
+          <div className="font-medium">{p.name}</div>
+          <div className="text-xs text-muted-foreground">{p.upc ? `UPC ${p.upc}` : 'No UPC yet'}</div>
+        </div>
+      ),
+    },
+    {
+      key: 'unit_price',
+      header: 'Price',
+      sortable: true,
+      numeric: true,
+      cell: (p) => formatCurrency(p.unit_price),
+    },
+    {
+      key: 'unit_cost',
+      header: 'Cost',
+      sortable: true,
+      numeric: true,
+      colClassName: 'hidden lg:table-cell',
+      cell: (p) => formatCurrency(p.unit_cost),
+    },
+    {
+      key: 'stock_qty',
+      header: 'Stock',
+      sortable: true,
+      numeric: true,
+      cell: (p) => {
+        const low = p.stock_qty <= p.reorder_point;
+        return (
+          <span className={low ? 'text-amber-600 dark:text-amber-400' : ''}>
+            {low ? <AlertTriangle className="mr-1 inline h-3 w-3" /> : null}
+            {p.stock_qty}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'readiness',
+      header: 'Readiness',
+      colClassName: 'hidden lg:table-cell',
+      cell: (p) => (
+        <div className="flex flex-wrap gap-1.5">
+          <StatusBadge tone={p.is_active ? 'success' : 'neutral'}>{p.is_active ? 'Active' : 'Archived'}</StatusBadge>
+          <StatusBadge tone={p.upc ? 'info' : 'neutral'}>
+            {p.upc ? (
+              <>
+                <ScanBarcode className="mr-0.5 h-3 w-3" />
+                POS
+              </>
+            ) : (
+              'Manual'
+            )}
+          </StatusBadge>
+        </div>
+      ),
+    },
+    {
+      key: 'actions',
+      header: <span className="sr-only">Actions</span>,
+      width: '112px',
+      cell: (p) => (
+        <div className="flex items-center justify-end gap-1">
+          <Link
+            to={`/product-studio/products/${p.id}/edit`}
+            aria-label={`Edit ${p.name}`}
+            className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <Pencil className="h-4 w-4" />
+          </Link>
+          <Link
+            to={`/product-studio/products/${p.id}`}
+            aria-label={`View ${p.name}`}
+            className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <Eye className="h-4 w-4" />
+          </Link>
+          <button
+            type="button"
+            onClick={() => toggleActive(p)}
+            aria-label={p.is_active ? `Archive ${p.name}` : `Restore ${p.name}`}
+            className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            {p.is_active ? <Archive className="h-4 w-4" /> : <ArchiveRestore className="h-4 w-4" />}
+          </button>
+        </div>
+      ),
+    },
+  ];
+
   return (
     <div className="space-y-6">
       <PageHeader
@@ -58,9 +184,7 @@ export default function ProductsPage() {
           <>
             <span className="tabular-nums">{total.toLocaleString()} total</span>
             {lowStockCount > 0 ? (
-              <span className="ml-3 text-warning">
-                · {lowStockCount} low stock
-              </span>
+              <span className="ml-3 text-amber-600 dark:text-amber-400">· {lowStockCount} low stock</span>
             ) : null}
           </>
         }
@@ -75,201 +199,107 @@ export default function ProductsPage() {
         }
       />
 
-      <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <h2 className="text-xl font-semibold">Catalog</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Search products and jump to either the full-page editor or the existing detail record.
-            </p>
-          </div>
-          <input
-            placeholder="Search products by name or SKU..."
-            value={search}
-            onChange={(event) => {
-              setSearch(event.target.value);
-              setPage(0);
-            }}
-            className="w-full rounded-md border border-input bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring lg:max-w-sm"
-          />
-        </div>
-      </section>
-
-      {isLoading ? (
-        <SkeletonTable rows={5} cols={8} />
-      ) : !products.length ? (
-        <EmptyState
-          icon="products"
-          title="No products yet"
-          description="Start the catalog in the new full-page product editor."
-          action={
-            <Link
-              to="/product-studio/products/new"
-              className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground no-underline hover:opacity-90"
+      {/* Desktop table */}
+      <div className="hidden md:block">
+        <DataTable<Product>
+          data={products}
+          columns={columns}
+          rowKey={(p) => p.id}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSortChange={handleSortChange}
+          loading={isLoading}
+          emptyState={
+            activeFilters > 0
+              ? 'No products match this search.'
+              : 'No products yet — start in the product editor.'
+          }
+          toolbar={
+            <TableToolbar
+              total={total}
+              activeFilters={activeFilters}
+              onClearFilters={clearFilters}
             >
-              <Plus className="h-4 w-4" />
-              New product
-            </Link>
+              <SearchInput
+                value={search}
+                onChange={(v) => {
+                  setSearch(v);
+                  setPage(0);
+                }}
+                placeholder="Search by name, SKU, or UPC…"
+              />
+            </TableToolbar>
+          }
+          footer={
+            <Pagination
+              page={page}
+              pageSize={pageSize}
+              total={total}
+              onPageChange={setPage}
+              onPageSizeChange={(n) => {
+                setPageSize(n);
+                setPage(0);
+              }}
+            />
           }
         />
-      ) : (
-        <>
-          <div className="hidden overflow-x-auto rounded-lg border border-border bg-card shadow-sm md:block">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border text-left text-muted-foreground">
-                  <th className="px-4 py-3 font-medium">SKU</th>
-                  <th className="px-4 py-3 font-medium">Name</th>
-                  <th className="px-4 py-3 font-medium text-right">Price</th>
-                  <th className="px-4 py-3 font-medium text-right">Cost</th>
-                  <th className="px-4 py-3 font-medium text-right">Stock</th>
-                  <th className="px-4 py-3 font-medium">Readiness</th>
-                  <th className="px-4 py-3 font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {products.map((product) => {
-                  const lowStock = product.stock_qty <= product.reorder_point;
-                  return (
-                    <tr key={product.id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                      <td className="px-4 py-3 font-mono text-xs">{product.sku}</td>
-                      <td className="px-4 py-3">
-                        <div className="font-medium">{product.name}</div>
-                        <div className="mt-0.5 text-xs text-muted-foreground">
-                          {product.upc ? `UPC ${product.upc}` : 'No UPC yet'}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-right">{formatCurrency(product.unit_price)}</td>
-                      <td className="px-4 py-3 text-right">{formatCurrency(product.unit_cost)}</td>
-                      <td className="px-4 py-3 text-right">
-                        <span className={lowStock ? 'text-amber-600 dark:text-amber-400' : ''}>
-                          {lowStock ? <AlertTriangle className="mr-1 inline h-3 w-3" /> : null}
-                          {product.stock_qty}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3">
-                        <div className="flex flex-wrap gap-2">
-                          <span className="inline-flex items-center rounded-full bg-accent px-2.5 py-0.5 text-xs font-medium text-accent-foreground">
-                            {product.is_active ? 'Active' : 'Archived'}
-                          </span>
-                          <span className="inline-flex items-center rounded-full bg-accent px-2.5 py-0.5 text-xs font-medium text-accent-foreground">
-                            {product.upc ? (
-                              <>
-                                <ScanBarcode className="mr-1 h-3 w-3" />
-                                POS ready
-                              </>
-                            ) : (
-                              'Manual lookup'
-                            )}
-                          </span>
-                        </div>
-                      </td>
-                      <td className="px-4 py-3">
-                        <div className="flex gap-1">
-                          <Link
-                            to={`/product-studio/products/${product.id}/edit`}
-                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent"
-                            title="Edit in Product Studio"
-                          >
-                            <Pencil className="h-4 w-4" />
-                          </Link>
-                          <Link
-                            to={`/product-studio/products/${product.id}`}
-                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent"
-                            title="View detail"
-                          >
-                            <Eye className="h-4 w-4" />
-                          </Link>
-                          <button
-                            type="button"
-                            onClick={() => toggleActive(product)}
-                            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent"
-                            title={product.is_active ? 'Archive product' : 'Restore product'}
-                          >
-                            {product.is_active ? <Archive className="h-4 w-4" /> : <ArchiveRestore className="h-4 w-4" />}
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+      </div>
 
-          <div className="space-y-3 md:hidden">
-            {products.map((product) => (
-              <div key={product.id} className="rounded-lg border border-border bg-card p-4 shadow-sm">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="font-semibold">{product.name}</p>
-                    <p className="font-mono text-xs text-muted-foreground">{product.sku}</p>
-                  </div>
-                  <span className="rounded-full bg-accent px-2.5 py-0.5 text-xs font-medium text-accent-foreground">
-                    {product.is_active ? 'Active' : 'Archived'}
-                  </span>
-                </div>
-                <div className="mt-4 grid grid-cols-3 gap-2 text-sm">
-                  <div>
-                    <p className="text-xs text-muted-foreground">Price</p>
-                    <p>{formatCurrency(product.unit_price)}</p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Cost</p>
-                    <p>{formatCurrency(product.unit_cost)}</p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Stock</p>
-                    <p className={product.stock_qty <= product.reorder_point ? 'text-amber-600 dark:text-amber-400' : ''}>
-                      {product.stock_qty}
-                    </p>
-                  </div>
-                </div>
-                <div className="mt-4 flex gap-2">
-                  <Link
-                    to={`/product-studio/products/${product.id}/edit`}
-                    className="inline-flex flex-1 items-center justify-center gap-2 rounded-md bg-primary px-4 py-3 font-semibold text-primary-foreground no-underline"
-                  >
-                    <Pencil className="h-4 w-4" />
-                    Edit
-                  </Link>
-                  <Link
-                    to={`/product-studio/products/${product.id}`}
-                    className="inline-flex items-center justify-center rounded-md border border-border px-4 py-3 text-foreground no-underline"
-                  >
-                    <ArrowRight className="h-4 w-4" />
-                  </Link>
-                </div>
+      {/* Mobile cards */}
+      <div className="space-y-3 md:hidden">
+        {products.map((product) => (
+          <div key={product.id} className="rounded-md border border-border bg-card p-4 shadow-xs">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="font-semibold">{product.name}</p>
+                <p className="font-mono text-xs text-muted-foreground">{product.sku}</p>
               </div>
-            ))}
-          </div>
-
-          {totalPages > 1 ? (
-            <div className="flex items-center justify-between text-sm">
-              <p className="text-muted-foreground">{total} products</p>
-              <div className="flex gap-2">
-                <button
-                  disabled={page === 0}
-                  onClick={() => setPage(page - 1)}
-                  className="rounded-md border border-border px-3 py-1 transition-colors hover:bg-accent disabled:opacity-50"
+              <StatusBadge tone={product.is_active ? 'success' : 'neutral'}>
+                {product.is_active ? 'Active' : 'Archived'}
+              </StatusBadge>
+            </div>
+            <div className="mt-4 grid grid-cols-3 gap-2 text-sm">
+              <div>
+                <p className="text-xs text-muted-foreground">Price</p>
+                <p className="tabular-nums">{formatCurrency(product.unit_price)}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Cost</p>
+                <p className="tabular-nums">{formatCurrency(product.unit_cost)}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Stock</p>
+                <p
+                  className={
+                    product.stock_qty <= product.reorder_point
+                      ? 'tabular-nums text-amber-600 dark:text-amber-400'
+                      : 'tabular-nums'
+                  }
                 >
-                  Prev
-                </button>
-                <span className="px-3 py-1">
-                  {page + 1} / {totalPages}
-                </span>
-                <button
-                  disabled={page >= totalPages - 1}
-                  onClick={() => setPage(page + 1)}
-                  className="rounded-md border border-border px-3 py-1 transition-colors hover:bg-accent disabled:opacity-50"
-                >
-                  Next
-                </button>
+                  {product.stock_qty}
+                </p>
               </div>
             </div>
-          ) : null}
-        </>
-      )}
+            <div className="mt-4 flex gap-2">
+              <Link
+                to={`/product-studio/products/${product.id}/edit`}
+                className="inline-flex flex-1 items-center justify-center gap-2 rounded-md bg-primary px-4 py-3 font-medium text-primary-foreground no-underline"
+              >
+                <Pencil className="h-4 w-4" />
+                Edit
+              </Link>
+              <button
+                type="button"
+                onClick={() => navigate(`/product-studio/products/${product.id}`)}
+                aria-label={`View ${product.name}`}
+                className="inline-flex h-12 w-12 items-center justify-center rounded-md border border-border text-foreground"
+              >
+                <Eye className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/RatesPage.tsx
+++ b/frontend/src/pages/RatesPage.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Plus, Edit, X } from 'lucide-react';
+import { Edit, Plus, X } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
-import { SkeletonTable } from '@/components/ui/Skeleton';
-import EmptyState from '@/components/ui/EmptyState';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import StatusBadge from '@/components/data/StatusBadge';
+import TableToolbar from '@/components/data/TableToolbar';
 import type { Rate } from '@/types';
 
 const emptyForm = { name: '', value: 0, unit: '$/hour', notes: '' };
@@ -72,14 +74,66 @@ export default function RatesPage() {
   const inputCls = (field: string) =>
     `w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring ${formErrors[field] ? 'border-destructive' : 'border-input'}`;
 
-  return (
-    <div>
-      <div className="flex items-center justify-between mb-8">
-        <h1 className="text-3xl font-bold">Rates</h1>
-        <button onClick={openNew} className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 transition-opacity cursor-pointer">
-          <Plus className="w-4 h-4" /> Add Rate
+  const columns: Column<Rate>[] = [
+    { key: 'name', header: 'Name', cell: (r) => <span className="font-medium">{r.name}</span> },
+    { key: 'value', header: 'Value', numeric: true, cell: (r) => Number(r.value).toFixed(2) },
+    { key: 'unit', header: 'Unit', cell: (r) => r.unit },
+    {
+      key: 'notes',
+      header: 'Notes',
+      colClassName: 'hidden lg:table-cell',
+      cell: (r) => r.notes || <span className="text-muted-foreground">—</span>,
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      cell: (r) => (
+        <button
+          type="button"
+          onClick={() => toggleActive(r)}
+          aria-label={r.active ? `Deactivate ${r.name}` : `Activate ${r.name}`}
+          className="cursor-pointer"
+        >
+          <StatusBadge tone={r.active ? 'success' : 'destructive'}>
+            {r.active ? 'Active' : 'Inactive'}
+          </StatusBadge>
         </button>
-      </div>
+      ),
+    },
+    {
+      key: 'actions',
+      header: <span className="sr-only">Actions</span>,
+      width: '48px',
+      cell: (r) => (
+        <button
+          type="button"
+          onClick={() => openEdit(r)}
+          aria-label={`Edit ${r.name}`}
+          className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <Edit className="h-4 w-4" />
+        </button>
+      ),
+    },
+  ];
+
+  const total = rates?.length ?? 0;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Rates"
+        description={`${total.toLocaleString()} ${total === 1 ? 'rate' : 'rates'}`}
+        actions={
+          <button
+            type="button"
+            onClick={openNew}
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" /> Add rate
+          </button>
+        }
+      />
 
       {editing !== null && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={(e) => e.target === e.currentTarget && close()}>
@@ -119,81 +173,47 @@ export default function RatesPage() {
         </div>
       )}
 
-      {isLoading ? (
-        <SkeletonTable rows={3} cols={5} />
-      ) : !rates?.length ? (
-        <EmptyState
-          icon="rates"
-          title="No rates configured"
-          description="Add labor, machine, and overhead rates to enable cost calculations."
-          action={
-            <button onClick={openNew} className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 cursor-pointer">
-              <Plus className="w-4 h-4" /> Add Rate
-            </button>
-          }
+      <div className="hidden md:block">
+        <DataTable<Rate>
+          data={rates || []}
+          columns={columns}
+          rowKey={(r) => r.id}
+          loading={isLoading}
+          emptyState="No rates configured. Add labor, machine, and overhead rates to enable cost calculations."
+          toolbar={<TableToolbar total={total} />}
         />
-      ) : (
-        <>
-          {/* Desktop table */}
-          <div className="hidden md:block overflow-x-auto bg-card border border-border rounded-lg">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border text-left text-muted-foreground">
-                  <th className="px-4 py-3 font-medium">Name</th>
-                  <th className="px-4 py-3 font-medium text-right">Value</th>
-                  <th className="px-4 py-3 font-medium">Unit</th>
-                  <th className="px-4 py-3 font-medium">Notes</th>
-                  <th className="px-4 py-3 font-medium">Status</th>
-                  <th className="px-4 py-3 font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {rates.map((r) => (
-                  <tr key={r.id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                    <td className="px-4 py-3 font-medium">{r.name}</td>
-                    <td className="px-4 py-3 text-right">{Number(r.value).toFixed(2)}</td>
-                    <td className="px-4 py-3">{r.unit}</td>
-                    <td className="px-4 py-3 text-muted-foreground">{r.notes || '—'}</td>
-                    <td className="px-4 py-3">
-                      <button onClick={() => toggleActive(r)} className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium cursor-pointer ${r.active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'}`}>
-                        {r.active ? 'Active' : 'Inactive'}
-                      </button>
-                    </td>
-                    <td className="px-4 py-3">
-                      <button onClick={() => openEdit(r)} className="p-1.5 hover:bg-accent rounded-md text-muted-foreground cursor-pointer" title="Edit">
-                        <Edit className="w-4 h-4" />
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+      </div>
 
-          {/* Mobile cards */}
-          <div className="md:hidden space-y-3">
-            {rates.map((r) => (
-              <div key={r.id} className="bg-card border border-border rounded-lg p-4">
-                <div className="flex items-start justify-between mb-2">
-                  <div>
-                    <p className="font-semibold">{r.name}</p>
-                    {r.notes && <p className="text-xs text-muted-foreground">{r.notes}</p>}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <button onClick={() => toggleActive(r)} className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium cursor-pointer ${r.active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'}`}>
-                      {r.active ? 'Active' : 'Inactive'}
-                    </button>
-                    <button onClick={() => openEdit(r)} className="p-1.5 hover:bg-accent rounded-md text-muted-foreground cursor-pointer">
-                      <Edit className="w-4 h-4" />
-                    </button>
-                  </div>
-                </div>
-                <p className="text-lg font-bold">{Number(r.value).toFixed(2)} <span className="text-sm font-normal text-muted-foreground">{r.unit}</span></p>
+      {/* Mobile cards */}
+      <div className="md:hidden space-y-3">
+        {rates?.map((r) => (
+          <div key={r.id} className="rounded-md border border-border bg-card p-4">
+            <div className="mb-2 flex items-start justify-between">
+              <div>
+                <p className="font-semibold">{r.name}</p>
+                {r.notes && <p className="text-xs text-muted-foreground">{r.notes}</p>}
               </div>
-            ))}
+              <div className="flex items-center gap-2">
+                <button type="button" onClick={() => toggleActive(r)}>
+                  <StatusBadge tone={r.active ? 'success' : 'destructive'}>{r.active ? 'Active' : 'Inactive'}</StatusBadge>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => openEdit(r)}
+                  aria-label={`Edit ${r.name}`}
+                  className="rounded-md p-1.5 text-muted-foreground hover:bg-muted"
+                >
+                  <Edit className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+            <p className="text-lg font-semibold tabular-nums">
+              {Number(r.value).toFixed(2)}
+              <span className="ml-1 text-sm font-normal text-muted-foreground">{r.unit}</span>
+            </p>
           </div>
-        </>
-      )}
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/SalesPage.tsx
+++ b/frontend/src/pages/SalesPage.tsx
@@ -1,35 +1,84 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Link } from 'react-router-dom';
-import { Plus, Eye } from 'lucide-react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Download, Plus } from 'lucide-react';
 import api from '@/api/client';
-import { formatCurrency } from '@/lib/utils';
-import { SkeletonTable } from '@/components/ui/Skeleton';
-import EmptyState from '@/components/ui/EmptyState';
+import { cn, formatCurrency } from '@/lib/utils';
 import PageHeader from '@/components/layout/PageHeader';
-import type { PaginatedSales, SalesChannel } from '@/types';
+import DataTable, { type Column, type SortDir } from '@/components/data/DataTable';
+import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
+import TableToolbar from '@/components/data/TableToolbar';
+import SearchInput from '@/components/data/SearchInput';
+import Select from '@/components/data/Select';
+import Pagination from '@/components/data/Pagination';
+import type { PaginatedSales, SaleListItem, SalesChannel } from '@/types';
 
-const statusColors: Record<string, string> = {
-  pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
-  paid: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  shipped: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-  delivered: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400',
-  refunded: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-  cancelled: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400',
-};
+const STATUS_OPTIONS = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'paid', label: 'Paid' },
+  { value: 'shipped', label: 'Shipped' },
+  { value: 'delivered', label: 'Delivered' },
+  { value: 'refunded', label: 'Refunded' },
+  { value: 'cancelled', label: 'Cancelled' },
+];
 
-const defaultPaymentMethods = ['cash', 'card', 'other'];
+const DEFAULT_PAYMENT_METHODS = ['cash', 'card', 'other'];
+
+/** Build a CSV from the selected sale rows. */
+function buildSelectedSalesCsv(rows: SaleListItem[]): string {
+  const header = [
+    'sale_number',
+    'date',
+    'customer_name',
+    'channel_name',
+    'payment_method',
+    'status',
+    'total',
+    'gross_profit',
+    'contribution_margin',
+    'item_count',
+  ];
+  const escape = (value: string | number | null | undefined) => {
+    if (value == null) return '';
+    const s = String(value);
+    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  const lines = [
+    header.join(','),
+    ...rows.map((r) =>
+      [
+        r.sale_number,
+        r.date,
+        r.customer_name ?? '',
+        r.channel_name ?? 'Direct',
+        r.payment_method ?? '',
+        r.status,
+        r.total,
+        r.gross_profit,
+        r.contribution_margin,
+        r.item_count,
+      ]
+        .map(escape)
+        .join(','),
+    ),
+  ];
+  return lines.join('\n');
+}
 
 export default function SalesPage() {
+  const navigate = useNavigate();
   const [search, setSearch] = useState('');
   const [status, setStatus] = useState('');
   const [channelId, setChannelId] = useState('');
   const [paymentMethod, setPaymentMethod] = useState('');
+  const [sortKey, setSortKey] = useState<string>('date');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [page, setPage] = useState(0);
-  const limit = 25;
+  const [pageSize, setPageSize] = useState(25);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
 
   const { data, isLoading } = useQuery<PaginatedSales>({
-    queryKey: ['sales', search, status, channelId, paymentMethod, page],
+    queryKey: ['sales', search, status, channelId, paymentMethod, sortKey, sortDir, page, pageSize],
     queryFn: () =>
       api
         .get('/sales', {
@@ -38,25 +87,113 @@ export default function SalesPage() {
             status: status || undefined,
             channel_id: channelId || undefined,
             payment_method: paymentMethod || undefined,
-            skip: page * limit,
-            limit,
+            sort_by: sortKey || undefined,
+            sort_dir: sortDir,
+            skip: page * pageSize,
+            limit: pageSize,
           },
         })
         .then((r) => r.data),
   });
+
   const { data: channels } = useQuery<SalesChannel[]>({
     queryKey: ['sales-channels'],
     queryFn: () => api.get('/sales/channels').then((r) => r.data),
   });
+
   const sales = data?.items || [];
   const total = data?.total || 0;
-  const totalPages = Math.ceil(total / limit);
   const paymentMethods = Array.from(
-    new Set([
-      ...defaultPaymentMethods,
-      ...sales.map((sale) => sale.payment_method).filter(Boolean),
-    ])
+    new Set([...DEFAULT_PAYMENT_METHODS, ...sales.map((s) => s.payment_method).filter(Boolean)]),
   ) as string[];
+
+  const activeFilters = [search, status, channelId, paymentMethod].filter(Boolean).length;
+
+  const clearFilters = () => {
+    setSearch('');
+    setStatus('');
+    setChannelId('');
+    setPaymentMethod('');
+    setPage(0);
+  };
+
+  const handleSortChange = (key: string, dir: SortDir | null) => {
+    if (!key || !dir) {
+      setSortKey('date');
+      setSortDir('desc');
+    } else {
+      setSortKey(key);
+      setSortDir(dir);
+    }
+    setPage(0);
+  };
+
+  const exportSelected = () => {
+    const chosen = sales.filter((s) => selected.has(s.id));
+    if (!chosen.length) return;
+    const csv = buildSelectedSalesCsv(chosen);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `sales-${new Date().toISOString().slice(0, 10)}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const columns: Column<SaleListItem>[] = [
+    {
+      key: 'sale_number',
+      header: 'Sale #',
+      sortable: true,
+      cell: (s) => <span className="font-mono text-xs tabular-nums">{s.sale_number}</span>,
+    },
+    { key: 'date', header: 'Date', sortable: true, cell: (s) => s.date },
+    {
+      key: 'customer_name',
+      header: 'Customer',
+      cell: (s) => s.customer_name || <span className="text-muted-foreground">—</span>,
+    },
+    {
+      key: 'channel_name',
+      header: 'Channel',
+      colClassName: 'hidden lg:table-cell',
+      cell: (s) => s.channel_name || 'Direct',
+    },
+    {
+      key: 'payment_method',
+      header: 'Payment',
+      sortable: true,
+      colClassName: 'hidden lg:table-cell',
+      cell: (s) => (
+        <span className="capitalize">{s.payment_method || <span className="text-muted-foreground">—</span>}</span>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      sortable: true,
+      cell: (s) => <StatusBadge tone={defaultStatusTone(s.status)}>{s.status}</StatusBadge>,
+    },
+    {
+      key: 'total',
+      header: 'Total',
+      sortable: true,
+      numeric: true,
+      cell: (s) => formatCurrency(s.total),
+    },
+    {
+      key: 'contribution_margin',
+      header: 'Margin',
+      numeric: true,
+      colClassName: 'hidden md:table-cell',
+      cell: (s) => (
+        <span className={Number(s.contribution_margin) >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}>
+          {formatCurrency(s.contribution_margin)}
+        </span>
+      ),
+    },
+  ];
 
   return (
     <div className="space-y-6">
@@ -73,183 +210,145 @@ export default function SalesPage() {
         }
       />
 
-      {/* Filters */}
-      <div className="flex flex-wrap gap-3 mb-4">
-        <input
-          placeholder="Search by sale # or customer..."
-          value={search}
-          onChange={(e) => {
-            setSearch(e.target.value);
-            setPage(0);
-          }}
-          className="w-full max-w-xs px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
-        />
-        <select
-          value={status}
-          onChange={(e) => {
-            setStatus(e.target.value);
-            setPage(0);
-          }}
-          className="px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
-        >
-          <option value="">All statuses</option>
-          {['pending', 'paid', 'shipped', 'delivered', 'refunded', 'cancelled'].map((s) => (
-            <option key={s} value={s}>
-              {s.charAt(0).toUpperCase() + s.slice(1)}
-            </option>
-          ))}
-        </select>
-        <select
-          value={channelId}
-          onChange={(e) => {
-            setChannelId(e.target.value);
-            setPage(0);
-          }}
-          className="px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
-        >
-          <option value="">All channels</option>
-          {channels?.map((channel) => (
-            <option key={channel.id} value={channel.id}>
-              {channel.name}
-            </option>
-          ))}
-        </select>
-        <select
-          value={paymentMethod}
-          onChange={(e) => {
-            setPaymentMethod(e.target.value);
-            setPage(0);
-          }}
-          className="px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
-        >
-          <option value="">All payment methods</option>
-          {paymentMethods.map((method) => (
-            <option key={method} value={method}>
-              {method}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {isLoading ? (
-        <SkeletonTable rows={5} cols={7} />
-      ) : !sales.length ? (
-        <EmptyState
-          icon="default"
-          title="No sales yet"
-          description="Record your first sale to start tracking revenue."
-          action={
-            <Link
-              to="/sell/sales/new"
-              className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 no-underline"
+      {/* Desktop: DataTable with integrated toolbar + pagination */}
+      <div className="hidden md:block">
+        <DataTable<SaleListItem>
+          data={sales}
+          columns={columns}
+          rowKey={(s) => s.id}
+          onRowClick={(s) => navigate(`/sell/sales/${s.id}`)}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSortChange={handleSortChange}
+          selectable
+          selected={selected}
+          onSelectedChange={setSelected}
+          loading={isLoading}
+          emptyState={
+            activeFilters > 0
+              ? 'No sales match the current filters.'
+              : 'No sales recorded yet.'
+          }
+          toolbar={
+            <TableToolbar
+              total={total}
+              activeFilters={activeFilters}
+              onClearFilters={clearFilters}
+              actions={
+                selected.size > 0 ? (
+                  <button
+                    type="button"
+                    onClick={exportSelected}
+                    className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-xs font-medium hover:bg-muted transition-colors"
+                  >
+                    <Download className="h-3.5 w-3.5" />
+                    Export {selected.size} selected
+                  </button>
+                ) : null
+              }
             >
-              <Plus className="w-4 h-4" /> New Sale
-            </Link>
+              <SearchInput
+                value={search}
+                onChange={(v) => {
+                  setSearch(v);
+                  setPage(0);
+                }}
+                placeholder="Search by sale # or customer…"
+              />
+              <Select
+                value={status}
+                onChange={(v) => {
+                  setStatus(v);
+                  setPage(0);
+                }}
+                options={STATUS_OPTIONS}
+                placeholder="All statuses"
+                aria-label="Filter by status"
+              />
+              <Select
+                value={channelId}
+                onChange={(v) => {
+                  setChannelId(v);
+                  setPage(0);
+                }}
+                options={(channels || []).map((c) => ({ value: c.id, label: c.name }))}
+                placeholder="All channels"
+                aria-label="Filter by channel"
+              />
+              <Select
+                value={paymentMethod}
+                onChange={(v) => {
+                  setPaymentMethod(v);
+                  setPage(0);
+                }}
+                options={paymentMethods.map((m) => ({ value: m, label: m }))}
+                placeholder="All payment methods"
+                aria-label="Filter by payment method"
+              />
+            </TableToolbar>
+          }
+          footer={
+            <Pagination
+              page={page}
+              pageSize={pageSize}
+              total={total}
+              onPageChange={setPage}
+              onPageSizeChange={(n) => {
+                setPageSize(n);
+                setPage(0);
+              }}
+            />
           }
         />
-      ) : (
-        <>
-          {/* Desktop table */}
-          <div className="hidden md:block overflow-x-auto bg-card border border-border rounded-lg">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border text-left text-muted-foreground">
-                  <th className="px-4 py-3 font-medium">Sale #</th>
-                  <th className="px-4 py-3 font-medium">Date</th>
-                  <th className="px-4 py-3 font-medium">Customer</th>
-                  <th className="px-4 py-3 font-medium">Channel</th>
-                  <th className="px-4 py-3 font-medium">Payment</th>
-                  <th className="px-4 py-3 font-medium">Status</th>
-                  <th className="px-4 py-3 font-medium text-right">Total</th>
-                  <th className="px-4 py-3 font-medium text-right">Contribution Margin</th>
-                  <th className="px-4 py-3 font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {sales.map((s) => (
-                  <tr key={s.id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                    <td className="px-4 py-3 font-mono text-xs">{s.sale_number}</td>
-                    <td className="px-4 py-3">{s.date}</td>
-                    <td className="px-4 py-3">{s.customer_name || '—'}</td>
-                    <td className="px-4 py-3">{s.channel_name || 'Direct'}</td>
-                    <td className="px-4 py-3 capitalize">{s.payment_method || '—'}</td>
-                    <td className="px-4 py-3">
-                      <span
-                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${statusColors[s.status] || statusColors.pending}`}
-                      >
-                        {s.status}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-right">{formatCurrency(s.total)}</td>
-                    <td className="px-4 py-3 text-right">
-                      <span className={Number(s.contribution_margin) >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}>
-                        {formatCurrency(s.contribution_margin)}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <Link to={`/sell/sales/${s.id}`} className="p-1.5 hover:bg-accent rounded-md text-muted-foreground inline-block" title="View">
-                        <Eye className="w-4 h-4" />
-                      </Link>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+      </div>
 
-          {/* Mobile cards */}
-          <div className="md:hidden space-y-3">
-            {sales.map((s) => (
-              <Link key={s.id} to={`/sell/sales/${s.id}`} className="block bg-card border border-border rounded-lg p-4 no-underline">
-                <div className="flex items-start justify-between mb-2">
-                  <div>
-                    <p className="font-semibold">{s.sale_number}</p>
-                    <p className="text-xs text-muted-foreground">{s.date} &middot; {s.customer_name || 'No customer'}</p>
-                  </div>
-                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${statusColors[s.status] || statusColors.pending}`}>
-                    {s.status}
-                  </span>
-                </div>
-                <div className="grid grid-cols-3 gap-2 text-sm">
-                  <div>
-                    <p className="text-xs text-muted-foreground">Total</p>
-                    <p>{formatCurrency(s.total)}</p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Contribution</p>
-                    <p className={Number(s.contribution_margin) >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}>
-                      {formatCurrency(s.contribution_margin)}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Payment</p>
-                    <p className="capitalize">{s.payment_method || '—'}</p>
-                  </div>
-                </div>
-                <p className="text-xs text-muted-foreground mt-3">{s.channel_name || 'Direct'} &middot; {s.item_count} items</p>
-              </Link>
-            ))}
-          </div>
-
-          {/* Pagination */}
-          {totalPages > 1 && (
-            <div className="flex items-center justify-between mt-4">
-              <p className="text-sm text-muted-foreground">{total} sales</p>
-              <div className="flex gap-2">
-                <button disabled={page === 0} onClick={() => setPage(page - 1)} className="px-3 py-1 border border-border rounded-md text-sm hover:bg-accent disabled:opacity-50 cursor-pointer">
-                  Prev
-                </button>
-                <span className="px-3 py-1 text-sm">
-                  {page + 1} / {totalPages}
-                </span>
-                <button disabled={page >= totalPages - 1} onClick={() => setPage(page + 1)} className="px-3 py-1 border border-border rounded-md text-sm hover:bg-accent disabled:opacity-50 cursor-pointer">
-                  Next
-                </button>
+      {/* Mobile: card list, unchanged */}
+      <div className="md:hidden space-y-3">
+        {sales.map((s) => (
+          <Link
+            key={s.id}
+            to={`/sell/sales/${s.id}`}
+            className="block bg-card border border-border rounded-md p-4 no-underline"
+          >
+            <div className="flex items-start justify-between mb-2">
+              <div>
+                <p className="font-semibold">{s.sale_number}</p>
+                <p className="text-xs text-muted-foreground">
+                  {s.date} &middot; {s.customer_name || 'No customer'}
+                </p>
+              </div>
+              <StatusBadge tone={defaultStatusTone(s.status)}>{s.status}</StatusBadge>
+            </div>
+            <div className="grid grid-cols-3 gap-2 text-sm">
+              <div>
+                <p className="text-xs text-muted-foreground">Total</p>
+                <p className="tabular-nums">{formatCurrency(s.total)}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Margin</p>
+                <p
+                  className={cn(
+                    'tabular-nums',
+                    Number(s.contribution_margin) >= 0
+                      ? 'text-emerald-600 dark:text-emerald-400'
+                      : 'text-red-600 dark:text-red-400',
+                  )}
+                >
+                  {formatCurrency(s.contribution_margin)}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Payment</p>
+                <p className="capitalize">{s.payment_method || '—'}</p>
               </div>
             </div>
-          )}
-        </>
-      )}
+            <p className="text-xs text-muted-foreground mt-3">
+              {s.channel_name || 'Direct'} &middot; {s.item_count} items
+            </p>
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }
+


### PR DESCRIPTION
Closes #160 (phase 3 of epic #157).

## Summary

The single biggest day-to-day UX improvement in the business-UI epic. Introduces a shared `DataTable` system and applies it to every true-table page. Adds backend sort with allowlisted columns.

## New primitives (`frontend/src/components/data/`)

| Component | Purpose |
|-----------|---------|
| **`DataTable`** | Sticky `<thead>` (`position: sticky`), 32px compact rows (40px normal), controlled sort (asc → desc → unsorted), row selection with indeterminate header checkbox, loading skeleton, empty-state slot, toolbar + pagination footer slots, `onRowClick` with child-interactive guard. |
| **`StatusBadge`** | 5-tone (success/warning/destructive/info/neutral) dot + label pattern. Replaces pastel `rounded-full` pills. Exports `defaultStatusTone()` for string-to-tone mapping. |
| **`Pagination`** | "Showing N–M of T" + rows-per-page select + first/prev/next/last with `aria-label`s and `tabular-nums`. |
| **`SearchInput`** | Debounced text input with search/clear icons. |
| **`Select`** | Styled native `<select>` wrapper. |
| **`TableToolbar`** | In-card toolbar: search/filter slot + result count + "Clear filters (N)" + right-aligned actions slot. |

## Unit tests (19 new, **29/29 total**)

- `DataTable`: render, empty state, sort cycling, single-row selection, select-all indeterminate, `rowClick` vs checkbox isolation, loading skeleton.
- `StatusBadge`: dot toggle, case-insensitive tone mapping.
- `Pagination`: boundary disabled states, page math, `pageSize` callback.

## Backend sort support

- `sales.py` / `products.py` / `inventory.py` — `sort_by` and `sort_dir` query params, enforced via `Query(pattern=...)` so unknown columns return 422 **before** hitting the ORM (injection-safe).
- **4 new backend tests** verify allowlist enforcement and actual sort ordering. Full suite: **260/260 pass** (was 256).

## Page retrofits (7 true-table pages)

| Page | Sortable columns | Bulk action |
|------|-----------------|-------------|
| **SalesPage** | Sale # / Date / Status / Payment / Total | **CSV export of selected rows** (acceptance criterion) |
| **ProductsPage** | SKU / Name / Price / Cost / Stock | — |
| **JobsPage** | Job # / Date / Revenue / Profit / Status | Row-action "Copy" |
| **CustomersPage** | — | Edit / Delete |
| **MaterialsPage** | — | Active toggle via `StatusBadge` |
| **RatesPage** | — | Active toggle via `StatusBadge` |
| **InventoryPage** ledger | Date / Type / Quantity / Unit cost | — |

Mobile card fallbacks at `md:hidden` preserved everywhere.

## Deliberately kept as card layouts

- **`PrintersPage`** — printer wall is intentionally card-based (established in issue #140).
- **`OrdersPage`** — production queue uses rich cards with missing-printer warnings; fulfillment sales list is also cards. Converting to tables would regress the queue UX.

## Acceptance criteria (from #160)

- [x] DataTable, StatusBadge, Pagination, SearchInput primitives exist + smoke tests
- [x] SalesPage, ProductsPage, InventoryPage, CustomersPage, JobsPage use DataTable (plus MaterialsPage + RatesPage)
- [x] Row height ≤ 40px (compact density = 32px, normal = 40px)
- [x] `tabular-nums` on every numeric column
- [x] Sortable columns show caret; click cycles asc → desc → unsorted; wired to backend
- [x] `<thead>` `position: sticky; top: 0`
- [x] Status columns use `StatusBadge` (no more pastel pills on the retrofitted pages)
- [x] Filter toolbar integrated into the table card
- [x] Pagination shows "Showing X–Y of Z" + page-size + first/prev/next/last
- [x] Bulk action: CSV export of selected rows on SalesPage
- [x] Row action buttons ≥ 32×32px hit area with `aria-label`
- [x] Row hover = `hover:bg-muted/60`
- [x] Sales / Products / Inventory endpoints accept `sort_by` / `sort_dir`
- [x] Mobile card layouts preserved (`md:hidden`)
- [x] Build and tests pass

## Validation

- `cd frontend && npm run build` → clean
- `cd frontend && npm test` → **29/29 pass**
- `python3 -m pytest backend/tests -q` → **260/260 pass** (188s)
- `rg "bg-yellow-100 rounded-full|hover:bg-accent/50" on retrofitted pages` → 0 matches

## Notes for phase 4 (#161)

Hand-rolled modals, buttons, and inputs in ProductEditor, PrinterForm, reconcile modal, etc. will be replaced by shared Radix-based primitives when phase 4 lands. Scope in this PR intentionally focused on tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)