### PR TITLE
feat(ui): consolidate status pills behind StatusBadge (#175)

### DIFF
--- a/frontend/src/components/data/StatusBadge.tsx
+++ b/frontend/src/components/data/StatusBadge.tsx
@@ -17,10 +17,10 @@ const toneStyles: Record<StatusTone, { dot: string; text: string; bg: string }> 
  */
 export function defaultStatusTone(status: string): StatusTone {
   const s = (status || '').toLowerCase();
-  if (['paid', 'delivered', 'complete', 'completed', 'printing', 'active', 'healthy', 'ready', 'ok'].includes(s)) return 'success';
-  if (['pending', 'draft', 'in_progress', 'low_stock', 'queued', 'backorder', 'paused'].includes(s)) return 'warning';
-  if (['refunded', 'cancelled', 'error', 'offline', 'critical', 'failed'].includes(s)) return 'destructive';
-  if (['shipped', 'maintenance', 'idle', 'scheduled'].includes(s)) return 'info';
+  if (['paid', 'delivered', 'complete', 'completed', 'printing', 'active', 'healthy', 'ready', 'ok', 'production'].includes(s)) return 'success';
+  if (['pending', 'draft', 'in_progress', 'low_stock', 'queued', 'backorder', 'paused', 'adjustment'].includes(s)) return 'warning';
+  if (['refunded', 'cancelled', 'error', 'offline', 'critical', 'failed', 'waste'].includes(s)) return 'destructive';
+  if (['shipped', 'maintenance', 'idle', 'scheduled', 'sale', 'return'].includes(s)) return 'info';
   return 'neutral';
 }
 

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -19,7 +19,7 @@ import EmptyState from '@/components/ui/EmptyState';
 import PageHeader from '@/components/layout/PageHeader';
 import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
 import DataTable, { type Column, type SortDir } from '@/components/data/DataTable';
-import StatusBadge, { type StatusTone } from '@/components/data/StatusBadge';
+import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import TableToolbar from '@/components/data/TableToolbar';
 import SearchInput from '@/components/data/SearchInput';
 import Select from '@/components/data/Select';
@@ -35,14 +35,6 @@ const TYPE_OPTIONS = [
   { value: 'return', label: 'Return' },
   { value: 'waste', label: 'Waste' },
 ] as const;
-
-const TYPE_COLORS: Record<string, string> = {
-  production: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  sale: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-  adjustment: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
-  return: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
-  waste: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-};
 
 type StockSurface = 'exceptions' | 'ledger';
 
@@ -555,16 +547,9 @@ export default function InventoryPage() {
                           <div>
                             <div className="flex flex-wrap items-center gap-2">
                               <p className="font-semibold">{alert.name}</p>
-                              <span
-                                className={cn(
-                                  'rounded-full px-2.5 py-0.5 text-xs font-semibold',
-                                  isCritical
-                                    ? 'bg-destructive text-destructive-foreground'
-                                    : 'bg-amber-100 text-amber-900'
-                                )}
-                              >
+                              <StatusBadge tone={isCritical ? 'destructive' : 'warning'}>
                                 {isCritical ? 'Stockout' : 'Reorder risk'}
-                              </span>
+                              </StatusBadge>
                             </div>
                             <p className="mt-2 text-sm text-muted-foreground">
                               {(alert.sku || 'No SKU')} • Stock {alert.current_stock} / Reorder {alert.reorder_point}
@@ -641,9 +626,7 @@ export default function InventoryPage() {
                               {transaction.created_at ? new Date(transaction.created_at).toLocaleString() : '-'}
                             </p>
                           </div>
-                          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[transaction.type] || ''}`}>
-                            {transaction.type}
-                          </span>
+                          <StatusBadge tone={defaultStatusTone(transaction.type)}>{transaction.type}</StatusBadge>
                         </div>
                         <div className="mt-3 flex items-center justify-between text-sm">
                           <p className="text-muted-foreground">{transaction.notes || 'No notes provided'}</p>
@@ -720,13 +703,6 @@ export default function InventoryPage() {
         </div>
       ) : (
         (() => {
-          const typeToneMap: Record<string, StatusTone> = {
-            production: 'success',
-            sale: 'info',
-            adjustment: 'warning',
-            return: 'info',
-            waste: 'destructive',
-          };
           const activeFilters = [search, type, dateFrom, dateTo].filter(Boolean).length;
           const clearFilters = () => {
             setSearch('');
@@ -778,7 +754,7 @@ export default function InventoryPage() {
               key: 'type',
               header: 'Type',
               sortable: true,
-              cell: (t) => <StatusBadge tone={typeToneMap[t.type] || 'neutral'}>{t.type}</StatusBadge>,
+              cell: (t) => <StatusBadge tone={defaultStatusTone(t.type)}>{t.type}</StatusBadge>,
             },
             {
               key: 'quantity',

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -22,36 +22,8 @@ import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import { Button } from '@/components/ui/Button';
 import PageHeader from '@/components/layout/PageHeader';
+import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import type { Job, PaginatedJobs, Printer, PrinterConnectionTestResult } from '@/types';
-
-const statusClasses: Record<string, string> = {
-  idle: 'bg-slate-100 text-slate-800 dark:bg-slate-800/60 dark:text-slate-200',
-  printing: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-  paused: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
-  maintenance: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
-  offline: 'bg-zinc-100 text-zinc-800 dark:bg-zinc-900/50 dark:text-zinc-300',
-  error: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-};
-
-const jobStatusClasses: Record<string, string> = {
-  completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  in_progress: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-  draft: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
-  cancelled: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-};
-
-function StatusBadge({ status }: { status: string }) {
-  return (
-    <span
-      className={cn(
-        'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium capitalize',
-        statusClasses[status] || 'bg-primary/10 text-primary'
-      )}
-    >
-      {status.replace('_', ' ')}
-    </span>
-  );
-}
 
 function formatDateTime(value: string | null) {
   if (!value) return '—';
@@ -211,17 +183,12 @@ export default function PrinterDetailPage() {
         title={printer.name}
         description={
           <span className="flex flex-wrap items-center gap-2">
-            <StatusBadge status={liveStatus} />
-            <span
-              className={cn(
-                'inline-flex items-center rounded-sm px-2 py-0.5 text-xs font-medium',
-                printer.is_active
-                  ? 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
-                  : 'bg-amber-500/10 text-amber-700 dark:text-amber-300'
-              )}
-            >
+            <StatusBadge tone={defaultStatusTone(liveStatus)}>
+              <span className="capitalize">{liveStatus.replace('_', ' ')}</span>
+            </StatusBadge>
+            <StatusBadge tone={printer.is_active ? 'success' : 'warning'}>
               {printer.is_active ? 'Active' : 'Inactive'}
-            </span>
+            </StatusBadge>
             <span className="text-muted-foreground">
               {[printer.manufacturer, printer.model, printer.location].filter(Boolean).join(' • ') || printer.slug}
             </span>
@@ -343,7 +310,9 @@ export default function PrinterDetailPage() {
                 A denser, operator-friendly view of the current telemetry from the configured monitoring provider.
               </p>
             </div>
-            {printer.monitor_enabled ? <StatusBadge status={liveStatus} /> : null}
+            {printer.monitor_enabled ? <StatusBadge tone={defaultStatusTone(liveStatus)}>
+              <span className="capitalize">{liveStatus.replace('_', ' ')}</span>
+            </StatusBadge> : null}
           </div>
 
           {!printer.monitor_enabled ? (
@@ -555,14 +524,9 @@ export default function PrinterDetailPage() {
                     <td className="px-4 py-3 text-right">{job.total_pieces}</td>
                     <td className="px-4 py-3 text-right">{formatCurrency(job.total_revenue)}</td>
                     <td className="px-4 py-3">
-                      <span
-                        className={cn(
-                          'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium capitalize',
-                          jobStatusClasses[job.status] || 'bg-primary/10 text-primary'
-                        )}
-                      >
-                        {job.status.replace('_', ' ')}
-                      </span>
+                      <StatusBadge tone={defaultStatusTone(job.status)}>
+                        <span className="capitalize">{job.status.replace('_', ' ')}</span>
+                      </StatusBadge>
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -26,54 +26,13 @@ import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import EmptyState from '@/components/ui/EmptyState';
 import { Button } from '@/components/ui/Button';
 import PageHeader from '@/components/layout/PageHeader';
+import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import { cn } from '@/lib/utils';
 import type { Job, PaginatedJobs, PaginatedPrinters, Printer } from '@/types';
 
 const STATUS_OPTIONS = ['idle', 'printing', 'paused', 'maintenance', 'offline', 'error'] as const;
 const ACTIVE_ASSIGNMENT_STATUSES = new Set(['draft', 'in_progress']);
 const ATTENTION_STATUSES = new Set(['paused', 'maintenance', 'offline', 'error']);
-
-const statusClasses: Record<string, string> = {
-  idle: 'bg-slate-100 text-slate-800 dark:bg-slate-800/60 dark:text-slate-200',
-  printing: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-  paused: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
-  maintenance: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
-  offline: 'bg-zinc-100 text-zinc-800 dark:bg-zinc-900/50 dark:text-zinc-300',
-  error: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-};
-
-const jobStatusClasses: Record<string, string> = {
-  completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  in_progress: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-  draft: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
-  cancelled: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-};
-
-function StatusBadge({ status }: { status: string }) {
-  return (
-    <span
-      className={cn(
-        'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium capitalize',
-        statusClasses[status] || 'bg-primary/10 text-primary'
-      )}
-    >
-      {status.replace('_', ' ')}
-    </span>
-  );
-}
-
-function JobStatusBadge({ status }: { status: string }) {
-  return (
-    <span
-      className={cn(
-        'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium capitalize',
-        jobStatusClasses[status] || 'bg-primary/10 text-primary'
-      )}
-    >
-      {status.replace('_', ' ')}
-    </span>
-  );
-}
 
 function formatDuration(seconds: number | null | undefined) {
   if (seconds == null || Number.isNaN(seconds)) return '—';
@@ -167,8 +126,10 @@ function PrinterWallCard({
             >
               {printer.name}
             </Link>
-            <StatusBadge status={liveStatus} />
-            {!printer.is_active ? <span className="rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">Inactive</span> : null}
+            <StatusBadge tone={defaultStatusTone(liveStatus)}>
+              <span className="capitalize">{liveStatus.replace('_', ' ')}</span>
+            </StatusBadge>
+            {!printer.is_active ? <StatusBadge tone="warning">Inactive</StatusBadge> : null}
           </div>
           <p className="mt-1 text-xs uppercase tracking-[0.16em] text-muted-foreground">
             {[printer.manufacturer, printer.model, printer.location].filter(Boolean).join(' • ') || 'Printer details pending'}
@@ -277,7 +238,11 @@ function PrinterWallCard({
               <p className="mt-1 text-sm text-muted-foreground">No active or draft job is assigned.</p>
             )}
           </div>
-          {currentJob ? <JobStatusBadge status={currentJob.status} /> : null}
+          {currentJob ? (
+            <StatusBadge tone={defaultStatusTone(currentJob.status)}>
+              <span className="capitalize">{currentJob.status.replace('_', ' ')}</span>
+            </StatusBadge>
+          ) : null}
         </div>
       </div>
 

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -8,6 +8,7 @@ import { formatCurrency } from '@/lib/utils';
 import { Button } from '@/components/ui/Button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
 import { SkeletonTable } from '@/components/ui/Skeleton';
+import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import type { Product, PaginatedTransactions } from '@/types';
 
 const TXN_TYPES = [
@@ -17,14 +18,6 @@ const TXN_TYPES = [
   { value: 'return', label: 'Return' },
   { value: 'waste', label: 'Waste' },
 ];
-
-const TYPE_COLORS: Record<string, string> = {
-  production: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  sale: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-  adjustment: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
-  return: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
-  waste: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-};
 
 export default function ProductDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -151,9 +144,9 @@ export default function ProductDetailPage() {
             {!currentProduct.is_active && <p className="text-sm text-muted-foreground mt-2">This product is archived. Historical records and inventory history are preserved.</p>}
           </div>
           <div className="flex flex-col items-end gap-2">
-            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${currentProduct.is_active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400'}`}>
+            <StatusBadge tone={currentProduct.is_active ? 'success' : 'warning'}>
               {currentProduct.is_active ? 'Active' : 'Archived'}
-            </span>
+            </StatusBadge>
             <Link
               to={`/product-studio/products/${currentProduct.id}/edit`}
               className="inline-flex items-center gap-2 px-3 py-2 border border-border rounded-md hover:bg-accent no-underline text-foreground"
@@ -322,9 +315,7 @@ export default function ProductDetailPage() {
                 <tr key={t.id} className="border-b border-border last:border-0 hover:bg-accent/50">
                   <td className="px-4 py-3 text-xs">{t.created_at ? new Date(t.created_at).toLocaleString() : '-'}</td>
                   <td className="px-4 py-3">
-                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${TYPE_COLORS[t.type] || ''}`}>
-                      {t.type}
-                    </span>
+                    <StatusBadge tone={defaultStatusTone(t.type)}>{t.type}</StatusBadge>
                   </td>
                   <td className={`px-4 py-3 text-right font-medium ${t.quantity > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
                     {t.quantity > 0 ? '+' : ''}{t.quantity}

--- a/frontend/src/pages/SaleDetailPage.tsx
+++ b/frontend/src/pages/SaleDetailPage.tsx
@@ -5,18 +5,10 @@ import { ArrowLeft, Printer, RefreshCw, Save } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
+import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import { getShippingLabelActionLabel, getShippingLabelMissingFields } from '@/lib/shippingLabels';
 import { formatCurrency } from '@/lib/utils';
 import type { Sale, SalesChannel } from '@/types';
-
-const statusColors: Record<string, string> = {
-  pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
-  paid: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  shipped: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-  delivered: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400',
-  refunded: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-  cancelled: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400',
-};
 
 export default function SaleDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -208,9 +200,9 @@ export default function SaleDetailPage() {
           <h1 className="text-3xl font-bold">{sale.sale_number}</h1>
           <p className="text-muted-foreground">{sale.date} &middot; {sale.customer_name || 'No customer'}</p>
         </div>
-        <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${statusColors[sale.status] || statusColors.pending}`}>
-          {sale.status}
-        </span>
+        <StatusBadge tone={defaultStatusTone(sale.status)} className="text-sm">
+          <span className="capitalize">{sale.status}</span>
+        </StatusBadge>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/frontend/src/pages/SalesChannelsPage.tsx
+++ b/frontend/src/pages/SalesChannelsPage.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import StatusBadge from '@/components/data/StatusBadge';
 import type { SalesChannel } from '@/types';
 
 const emptyForm = { name: '', platform_fee_pct: 0, fixed_fee: 0, is_active: true };
@@ -155,8 +156,10 @@ export default function SalesChannelsPage() {
                   <td className="px-4 py-3 text-right">{Number(ch.platform_fee_pct).toFixed(1)}%</td>
                   <td className="px-4 py-3 text-right">${Number(ch.fixed_fee).toFixed(2)}</td>
                   <td className="px-4 py-3">
-                    <button onClick={() => toggleActive(ch)} className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium cursor-pointer ${ch.is_active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'}`}>
-                      {ch.is_active ? 'Active' : 'Inactive'}
+                    <button onClick={() => toggleActive(ch)} className="cursor-pointer">
+                      <StatusBadge tone={ch.is_active ? 'success' : 'destructive'}>
+                        {ch.is_active ? 'Active' : 'Inactive'}
+                      </StatusBadge>
                     </button>
                   </td>
                   <td className="px-4 py-3">

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import StatusBadge from '@/components/data/StatusBadge';
 
 interface UserRecord {
   id: string;
@@ -172,14 +173,12 @@ export default function UsersPage() {
                   </td>
                   <td className="px-4 py-3 text-muted-foreground">{u.email}</td>
                   <td className="px-4 py-3">
-                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${u.role === 'admin' ? 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400' : 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400'}`}>
-                      {u.role}
-                    </span>
+                    <StatusBadge tone={u.role === 'admin' ? 'info' : 'neutral'}>{u.role}</StatusBadge>
                   </td>
                   <td className="px-4 py-3">
-                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${u.is_active ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'}`}>
+                    <StatusBadge tone={u.is_active ? 'success' : 'destructive'}>
                       {u.is_active ? 'Active' : 'Inactive'}
-                    </span>
+                    </StatusBadge>
                   </td>
                   <td className="px-4 py-3 text-muted-foreground text-xs">
                     {u.created_at ? new Date(u.created_at).toLocaleDateString() : '—'}


### PR DESCRIPTION
Closes #175.

## Summary

- Replaces 7 local status-color maps and all `bg-*-100 text-*-800` pills with the shared `<StatusBadge>` primitive.
- Extended `defaultStatusTone` with inventory transaction types (production/sale/adjustment/return/waste). Role pills (admin/user) handled inline to keep the shared map status-oriented.

## Files touched

- `frontend/src/components/data/StatusBadge.tsx` — added transaction-type mappings
- `frontend/src/pages/PrintersPage.tsx` — deleted local `StatusBadge` shadow + `STATUS_COLORS`
- `frontend/src/pages/PrinterDetailPage.tsx` — deleted local `JobStatusBadge` shadow + `STATUS_COLORS` / `jobStatusClasses`
- `frontend/src/pages/SaleDetailPage.tsx` — removed `statusColors` map
- `frontend/src/pages/ProductDetailPage.tsx` — removed `TYPE_COLORS`, Active/Archived pill migrated
- `frontend/src/pages/InventoryPage.tsx` — removed `TYPE_COLORS` + redundant local `typeToneMap`; Stockout/Reorder-risk tile migrated
- `frontend/src/pages/admin/UsersPage.tsx` — role + active pills
- `frontend/src/pages/SalesChannelsPage.tsx` — active/inactive pill (preserved `onClick` toggle)

## Acceptance (#175)

- [x] `rg "bg-(green|red|yellow|purple|blue|amber|emerald)-(100|200) text-" frontend/src/pages` returns **0**
- [x] `rg "STATUS_COLORS|TYPE_COLORS|JOB_STATUS_COLORS|statusColors" frontend/src/pages` returns **0**
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Printers list + detail: verify status pills render with correct tones (printing=green, error=red, maintenance=sky, idle=sky)
- [ ] Sale detail: verify pending/paid/shipped/delivered/cancelled pills
- [ ] Product detail transactions: verify production/sale/adjustment/return/waste tones
- [ ] Inventory ledger + risk tile: verify stockout=red, reorder=amber
- [ ] Admin users: verify admin=info/user=neutral role + active/inactive toggle
- [ ] Sales channels: verify active/inactive toggle still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)