### PR TITLE
feat(ui): wire forms to Input/Label/Textarea primitives (#177)

### DIFF
--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -15,6 +15,9 @@ import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { Input } from '@/components/ui/Input';
+import { Textarea } from '@/components/ui/Textarea';
+import { Label } from '@/components/ui/Label';
 import EmptyState from '@/components/ui/EmptyState';
 import PageHeader from '@/components/layout/PageHeader';
 import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
@@ -302,12 +305,13 @@ export default function InventoryPage() {
             <DialogTitle>Stock reconciliation</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
-            <div>
-              <label className="mb-1 block text-sm font-medium">Product</label>
+            <div className="space-y-1.5">
+              <Label htmlFor="reconcile-product">Product</Label>
               <select
+                id="reconcile-product"
                 value={reconcileForm.product_id}
                 onChange={(event) => setReconcileForm((form) => ({ ...form, product_id: event.target.value }))}
-                className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
               >
                 <option value="">Select product...</option>
                 {products.map((product) => (
@@ -340,36 +344,36 @@ export default function InventoryPage() {
               </div>
             ) : null}
 
-            <div>
-              <label className="mb-1 block text-sm font-medium">Counted quantity</label>
-              <input
+            <div className="space-y-1.5">
+              <Label htmlFor="reconcile-counted-qty">Counted quantity</Label>
+              <Input
+                id="reconcile-counted-qty"
                 type="number"
                 min="0"
                 value={reconcileForm.counted_qty}
                 onChange={(event) =>
                   setReconcileForm((form) => ({ ...form, counted_qty: Number(event.target.value) }))
                 }
-                className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
               />
             </div>
 
-            <div>
-              <label className="mb-1 block text-sm font-medium">Reason</label>
-              <input
+            <div className="space-y-1.5">
+              <Label htmlFor="reconcile-reason">Reason</Label>
+              <Input
+                id="reconcile-reason"
                 value={reconcileForm.reason}
                 onChange={(event) => setReconcileForm((form) => ({ ...form, reason: event.target.value }))}
                 placeholder="Cycle count, shelf recount, received correction..."
-                className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
               />
             </div>
 
-            <div>
-              <label className="mb-1 block text-sm font-medium">Notes</label>
-              <textarea
+            <div className="space-y-1.5">
+              <Label htmlFor="reconcile-notes">Notes</Label>
+              <Textarea
+                id="reconcile-notes"
                 value={reconcileForm.notes}
                 onChange={(event) => setReconcileForm((form) => ({ ...form, notes: event.target.value }))}
                 rows={3}
-                className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
               />
             </div>
           </div>
@@ -388,12 +392,13 @@ export default function InventoryPage() {
             <DialogTitle>Quick stock adjustment</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
-            <div>
-              <label className="mb-1 block text-sm font-medium">Product</label>
+            <div className="space-y-1.5">
+              <Label htmlFor="adjust-product">Product</Label>
               <select
+                id="adjust-product"
                 value={adjustForm.product_id}
                 onChange={(event) => setAdjustForm((form) => ({ ...form, product_id: event.target.value }))}
-                className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
               >
                 <option value="">Select product...</option>
                 {products.map((product) => (
@@ -411,12 +416,13 @@ export default function InventoryPage() {
               </div>
             ) : null}
 
-            <div>
-              <label className="mb-1 block text-sm font-medium">Type</label>
+            <div className="space-y-1.5">
+              <Label htmlFor="adjust-type">Type</Label>
               <select
+                id="adjust-type"
                 value={adjustForm.type}
                 onChange={(event) => setAdjustForm((form) => ({ ...form, type: event.target.value }))}
-                className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
               >
                 {TYPE_OPTIONS.filter((option) => option.value).map((option) => (
                   <option key={option.value} value={option.value}>
@@ -426,25 +432,25 @@ export default function InventoryPage() {
               </select>
             </div>
 
-            <div>
-              <label className="mb-1 block text-sm font-medium">Quantity</label>
-              <input
+            <div className="space-y-1.5">
+              <Label htmlFor="adjust-quantity">Quantity</Label>
+              <Input
+                id="adjust-quantity"
                 type="number"
                 value={adjustForm.quantity}
                 onChange={(event) => setAdjustForm((form) => ({ ...form, quantity: Number(event.target.value) }))}
                 placeholder="Positive to add, negative to remove"
-                className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
               />
             </div>
 
-            <div>
-              <label className="mb-1 block text-sm font-medium">Notes</label>
-              <textarea
+            <div className="space-y-1.5">
+              <Label htmlFor="adjust-notes">Notes</Label>
+              <Textarea
+                id="adjust-notes"
                 value={adjustForm.notes}
                 onChange={(event) => setAdjustForm((form) => ({ ...form, notes: event.target.value }))}
                 rows={3}
                 placeholder="Reason for adjustment"
-                className="w-full rounded-xl border border-input bg-background px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-ring"
               />
             </div>
           </div>
@@ -835,24 +841,24 @@ export default function InventoryPage() {
                       placeholder="All types"
                       aria-label="Filter by type"
                     />
-                    <input
+                    <Input
                       type="date"
                       value={dateFrom}
                       onChange={(e) => {
                         setDateFrom(e.target.value);
                         setPage(0);
                       }}
-                      className="rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      className="w-auto"
                       aria-label="From date"
                     />
-                    <input
+                    <Input
                       type="date"
                       value={dateTo}
                       onChange={(e) => {
                         setDateTo(e.target.value);
                         setPage(0);
                       }}
-                      className="rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      className="w-auto"
                       aria-label="To date"
                     />
                   </TableToolbar>

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -6,6 +6,8 @@ import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
 import { formatCurrency } from '@/lib/utils';
 import type { Material, Job, CalculateResponse, PaginatedProducts, PaginatedPrinters, Product } from '@/types';
 
@@ -20,17 +22,19 @@ interface FieldProps {
 }
 
 function Field({ label, field, type = 'text', value, error, onChange, ...rest }: FieldProps) {
+  const id = `job-${field}`;
   return (
-    <div>
-      <label className="block text-sm font-medium mb-1.5">{label}</label>
-      <input
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
         type={type}
         value={value}
         onChange={(e) => onChange(field, type === 'number' ? Number(e.target.value) : e.target.value)}
-        className={`w-full px-3 py-2 border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${error ? 'border-destructive' : 'border-input'}`}
+        invalid={Boolean(error)}
         {...rest}
       />
-      {error && <p className="text-destructive text-xs mt-1">{error}</p>}
+      {error && <p className="text-destructive text-xs">{error}</p>}
     </div>
   );
 }
@@ -282,55 +286,57 @@ export default function JobFormPage() {
             <DialogTitle>Create and link product</DialogTitle>
           </DialogHeader>
           <div className="space-y-3">
-            <div>
-              <label className="block text-sm font-medium mb-1">Name *</label>
-              <input
+            <div className="space-y-1.5">
+              <Label htmlFor="create-product-name">Name *</Label>
+              <Input
+                id="create-product-name"
                 value={productForm.name}
                 onChange={(e) => updateProductForm('name', e.target.value)}
-                className={`w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring ${productErrors.name ? 'border-destructive' : 'border-input'}`}
+                invalid={Boolean(productErrors.name)}
               />
-              {productErrors.name && <p className="text-destructive text-xs mt-1">{productErrors.name}</p>}
+              {productErrors.name && <p className="text-destructive text-xs">{productErrors.name}</p>}
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-1">Description</label>
-              <input
+            <div className="space-y-1.5">
+              <Label htmlFor="create-product-description">Description</Label>
+              <Input
+                id="create-product-description"
                 value={productForm.description}
                 onChange={(e) => updateProductForm('description', e.target.value)}
-                className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
               />
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-1">Material *</label>
+            <div className="space-y-1.5">
+              <Label htmlFor="create-product-material">Material *</Label>
               <select
+                id="create-product-material"
                 value={productForm.material_id}
                 onChange={(e) => updateProductForm('material_id', e.target.value)}
-                className={`w-full px-3 py-2 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring ${productErrors.material_id ? 'border-destructive' : 'border-input'}`}
+                className={`flex h-9 w-full rounded-md border bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring ${productErrors.material_id ? 'border-destructive' : 'border-input'}`}
               >
                 <option value="">Select material...</option>
                 {materials?.map((m) => (
                   <option key={m.id} value={m.id}>{m.name} ({m.brand})</option>
                 ))}
               </select>
-              {productErrors.material_id && <p className="text-destructive text-xs mt-1">{productErrors.material_id}</p>}
+              {productErrors.material_id && <p className="text-destructive text-xs">{productErrors.material_id}</p>}
             </div>
             <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="block text-sm font-medium mb-1">Unit Cost ($)</label>
-                <input type="number" min="0" step="0.01" value={productForm.unit_cost} onChange={(e) => updateProductForm('unit_cost', Number(e.target.value))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+              <div className="space-y-1.5">
+                <Label htmlFor="create-product-unit-cost">Unit Cost ($)</Label>
+                <Input id="create-product-unit-cost" type="number" min="0" step="0.01" value={productForm.unit_cost} onChange={(e) => updateProductForm('unit_cost', Number(e.target.value))} />
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Unit Price ($)</label>
-                <input type="number" min="0" step="0.01" value={productForm.unit_price} onChange={(e) => updateProductForm('unit_price', Number(e.target.value))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+              <div className="space-y-1.5">
+                <Label htmlFor="create-product-unit-price">Unit Price ($)</Label>
+                <Input id="create-product-unit-price" type="number" min="0" step="0.01" value={productForm.unit_price} onChange={(e) => updateProductForm('unit_price', Number(e.target.value))} />
               </div>
             </div>
             <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="block text-sm font-medium mb-1">Reorder Point</label>
-                <input type="number" min="0" value={productForm.reorder_point} onChange={(e) => updateProductForm('reorder_point', Number(e.target.value))} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+              <div className="space-y-1.5">
+                <Label htmlFor="create-product-reorder">Reorder Point</Label>
+                <Input id="create-product-reorder" type="number" min="0" value={productForm.reorder_point} onChange={(e) => updateProductForm('reorder_point', Number(e.target.value))} />
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">UPC/EAN</label>
-                <input value={productForm.upc} onChange={(e) => updateProductForm('upc', e.target.value)} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+              <div className="space-y-1.5">
+                <Label htmlFor="create-product-upc">UPC/EAN</Label>
+                <Input id="create-product-upc" value={productForm.upc} onChange={(e) => updateProductForm('upc', e.target.value)} />
               </div>
             </div>
           </div>
@@ -360,12 +366,13 @@ export default function JobFormPage() {
               <Field label="Date" field="date" type="date" value={form.date} error={errors.date} onChange={update} />
               <Field label="Customer" field="customer_name" value={form.customer_name} error={errors.customer_name} onChange={update} placeholder="Optional" />
               <Field label="Product Name" field="product_name" value={form.product_name} error={errors.product_name} onChange={update} placeholder="Phone Stand" />
-              <div>
-                <label className="block text-sm font-medium mb-1.5">Status</label>
+              <div className="space-y-1.5">
+                <Label htmlFor="job-status">Status</Label>
                 <select
+                  id="job-status"
                   value={form.status}
                   onChange={(e) => update('status', e.target.value)}
-                  className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 >
                   <option value="draft">Draft</option>
                   <option value="in_progress">In Progress</option>
@@ -373,12 +380,13 @@ export default function JobFormPage() {
                   <option value="cancelled">Cancelled</option>
                 </select>
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1.5">Assign Printer (optional)</label>
+              <div className="space-y-1.5">
+                <Label htmlFor="job-printer">Assign Printer (optional)</Label>
                 <select
+                  id="job-printer"
                   value={form.printer_id}
                   onChange={(e) => update('printer_id', e.target.value)}
-                  className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 >
                   <option value="">Unassigned</option>
                   {printersData?.items?.map((printer) => (
@@ -387,11 +395,11 @@ export default function JobFormPage() {
                     </option>
                   ))}
                 </select>
-                <p className="text-xs text-muted-foreground mt-1">Optional printer assignment for the physical machine running this job.</p>
+                <p className="text-xs text-muted-foreground">Optional printer assignment for the physical machine running this job.</p>
               </div>
-              <div>
-                <div className="flex items-center justify-between mb-1.5">
-                  <label className="block text-sm font-medium">Link to Product (optional)</label>
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="job-product">Link to Product (optional)</Label>
                   <button
                     type="button"
                     onClick={openCreateProduct}
@@ -401,9 +409,10 @@ export default function JobFormPage() {
                   </button>
                 </div>
                 <select
+                  id="job-product"
                   value={form.product_id}
                   onChange={(e) => update('product_id', e.target.value)}
-                  className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 >
                   <option value="">None</option>
                   {productsData?.items?.map((p) => (
@@ -411,7 +420,7 @@ export default function JobFormPage() {
                   ))}
                 </select>
                 {form.product_id && form.status === 'completed' && (
-                  <p className="text-xs text-muted-foreground mt-1">Inventory will be auto-updated when job is completed</p>
+                  <p className="text-xs text-muted-foreground">Inventory will be auto-updated when job is completed</p>
                 )}
               </div>
             </div>
@@ -421,19 +430,20 @@ export default function JobFormPage() {
           <div className="bg-card border border-border rounded-lg p-6">
             <h3 className="text-lg font-semibold mb-4">Print Details</h3>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium mb-1.5">Material</label>
+              <div className="space-y-1.5">
+                <Label htmlFor="job-material">Material</Label>
                 <select
+                  id="job-material"
                   value={form.material_id}
                   onChange={(e) => update('material_id', e.target.value)}
-                  className={`w-full px-3 py-2 border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${errors.material_id ? 'border-destructive' : 'border-input'}`}
+                  className={`flex h-9 w-full rounded-md border bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring ${errors.material_id ? 'border-destructive' : 'border-input'}`}
                 >
                   <option value="">Select material...</option>
                   {materials?.map((m) => (
                     <option key={m.id} value={m.id}>{m.name} ({m.brand}) — ${Number(m.cost_per_g).toFixed(4)}/g</option>
                   ))}
                 </select>
-                {errors.material_id && <p className="text-destructive text-xs mt-1">{errors.material_id}</p>}
+                {errors.material_id && <p className="text-destructive text-xs">{errors.material_id}</p>}
               </div>
               <Field label="Qty per Plate" field="qty_per_plate" type="number" value={form.qty_per_plate} error={errors.qty_per_plate} onChange={update} min={1} />
               <Field label="Number of Plates" field="num_plates" type="number" value={form.num_plates} error={errors.num_plates} onChange={update} min={1} />
@@ -449,9 +459,10 @@ export default function JobFormPage() {
               <Field label="Labor Time (mins)" field="labor_mins" type="number" value={form.labor_mins} error={errors.labor_mins} onChange={update} min={0} />
               <Field label="Design Time (hrs)" field="design_time_hrs" type="number" value={form.design_time_hrs} error={errors.design_time_hrs} onChange={update} min={0} step="0.01" />
               <Field label="Shipping Cost ($)" field="shipping_cost" type="number" value={form.shipping_cost} error={errors.shipping_cost} onChange={update} min={0} step="0.01" />
-              <div>
-                <label className="block text-sm font-medium mb-1.5">Target Margin: {form.target_margin_pct}%</label>
+              <div className="space-y-1.5">
+                <Label htmlFor="job-target-margin">Target Margin: {form.target_margin_pct}%</Label>
                 <input
+                  id="job-target-margin"
                   type="range"
                   min={0}
                   max={90}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,6 +5,8 @@ import { z } from 'zod';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
 import { useAuthStore } from '@/store/auth';
 import { useTheme } from '@/hooks/useTheme';
 import { Moon, Sun } from 'lucide-react';
@@ -84,34 +86,32 @@ export default function LoginPage() {
             </div>
           )}
           <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium mb-1.5">Email</label>
-              <input
+            <div className="space-y-1.5">
+              <Label htmlFor="login-email">Email</Label>
+              <Input
+                id="login-email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className={`w-full px-3 py-2 border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${
-                  errors.email ? 'border-destructive' : 'border-input'
-                }`}
                 placeholder="admin@example.com"
+                invalid={Boolean(errors.email)}
               />
               {errors.email && (
-                <p className="text-destructive text-xs mt-1">{errors.email}</p>
+                <p className="text-destructive text-xs">{errors.email}</p>
               )}
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-1.5">Password</label>
-              <input
+            <div className="space-y-1.5">
+              <Label htmlFor="login-password">Password</Label>
+              <Input
+                id="login-password"
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className={`w-full px-3 py-2 border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${
-                  errors.password ? 'border-destructive' : 'border-input'
-                }`}
                 placeholder="Enter your password"
+                invalid={Boolean(errors.password)}
               />
               {errors.password && (
-                <p className="text-destructive text-xs mt-1">{errors.password}</p>
+                <p className="text-destructive text-xs">{errors.password}</p>
               )}
             </div>
             <Button type="submit" disabled={loading} className="w-full">

--- a/frontend/src/pages/PrinterFormPage.tsx
+++ b/frontend/src/pages/PrinterFormPage.tsx
@@ -5,6 +5,9 @@ import { ArrowLeft, PlugZap } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Textarea } from '@/components/ui/Textarea';
+import { Label } from '@/components/ui/Label';
 import type { Printer, PrinterConnectionTestResult } from '@/types';
 
 const STATUS_OPTIONS = ['idle', 'printing', 'paused', 'maintenance', 'offline', 'error'] as const;
@@ -183,7 +186,7 @@ export default function PrinterFormPage() {
     return <p className="py-16 text-center text-muted-foreground">Printer not found</p>;
   }
 
-  const inputClass = (field: string) => `w-full rounded-md border px-3 py-2 bg-background focus:outline-none focus:ring-2 focus:ring-ring ${errors[field] ? 'border-destructive' : 'border-input'}`;
+  const selectClass = (field: string) => `flex h-9 w-full rounded-md border bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring ${errors[field] ? 'border-destructive' : 'border-input'}`;
 
   return (
     <div className="max-w-3xl mx-auto">
@@ -199,43 +202,44 @@ export default function PrinterFormPage() {
 
         <form onSubmit={handleSubmit} className="space-y-6">
           <div className="grid gap-5 sm:grid-cols-2">
-            <div>
-              <label className="block text-sm font-medium mb-1.5">Name *</label>
-              <input value={form.name} onChange={(e) => update('name', e.target.value)} className={inputClass('name')} placeholder="Bambu X1C #1" />
-              {errors.name && <p className="mt-1 text-xs text-destructive">{errors.name}</p>}
+            <div className="space-y-1.5">
+              <Label htmlFor="printer-name">Name *</Label>
+              <Input id="printer-name" value={form.name} onChange={(e) => update('name', e.target.value)} invalid={Boolean(errors.name)} placeholder="Bambu X1C #1" />
+              {errors.name && <p className="text-xs text-destructive">{errors.name}</p>}
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-1.5">Slug *</label>
-              <input
+            <div className="space-y-1.5">
+              <Label htmlFor="printer-slug">Slug *</Label>
+              <Input
+                id="printer-slug"
                 value={form.slug}
                 onChange={(e) => {
                   setSlugTouched(true);
                   update('slug', slugify(e.target.value));
                 }}
-                className={inputClass('slug')}
+                invalid={Boolean(errors.slug)}
                 placeholder="bambu-x1c-1"
               />
-              {errors.slug && <p className="mt-1 text-xs text-destructive">{errors.slug}</p>}
+              {errors.slug && <p className="text-xs text-destructive">{errors.slug}</p>}
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-1.5">Manufacturer</label>
-              <input value={form.manufacturer} onChange={(e) => update('manufacturer', e.target.value)} className={inputClass('manufacturer')} placeholder="Bambu Lab" />
+            <div className="space-y-1.5">
+              <Label htmlFor="printer-manufacturer">Manufacturer</Label>
+              <Input id="printer-manufacturer" value={form.manufacturer} onChange={(e) => update('manufacturer', e.target.value)} placeholder="Bambu Lab" />
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-1.5">Model</label>
-              <input value={form.model} onChange={(e) => update('model', e.target.value)} className={inputClass('model')} placeholder="X1 Carbon" />
+            <div className="space-y-1.5">
+              <Label htmlFor="printer-model">Model</Label>
+              <Input id="printer-model" value={form.model} onChange={(e) => update('model', e.target.value)} placeholder="X1 Carbon" />
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-1.5">Serial Number</label>
-              <input value={form.serial_number} onChange={(e) => update('serial_number', e.target.value)} className={inputClass('serial_number')} placeholder="Optional" />
+            <div className="space-y-1.5">
+              <Label htmlFor="printer-serial">Serial Number</Label>
+              <Input id="printer-serial" value={form.serial_number} onChange={(e) => update('serial_number', e.target.value)} placeholder="Optional" />
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-1.5">Location</label>
-              <input value={form.location} onChange={(e) => update('location', e.target.value)} className={inputClass('location')} placeholder="Print room shelf A" />
+            <div className="space-y-1.5">
+              <Label htmlFor="printer-location">Location</Label>
+              <Input id="printer-location" value={form.location} onChange={(e) => update('location', e.target.value)} placeholder="Print room shelf A" />
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-1.5">Status</label>
-              <select value={form.status} onChange={(e) => update('status', e.target.value)} className={inputClass('status')}>
+            <div className="space-y-1.5">
+              <Label htmlFor="printer-status">Status</Label>
+              <select id="printer-status" value={form.status} onChange={(e) => update('status', e.target.value)} className={selectClass('status')}>
                 {STATUS_OPTIONS.map((option) => (
                   <option key={option} value={option}>{option.replace('_', ' ')}</option>
                 ))}
@@ -267,40 +271,41 @@ export default function PrinterFormPage() {
             {form.monitor_enabled ? (
               <>
                 <div className="grid gap-5 sm:grid-cols-2">
-                  <div>
-                    <label className="block text-sm font-medium mb-1.5">Provider</label>
-                    <select value={form.monitor_provider} onChange={(e) => update('monitor_provider', e.target.value)} className={inputClass('monitor_provider')}>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="printer-monitor-provider">Provider</Label>
+                    <select id="printer-monitor-provider" value={form.monitor_provider} onChange={(e) => update('monitor_provider', e.target.value)} className={selectClass('monitor_provider')}>
                       {MONITOR_PROVIDER_OPTIONS.map((option) => (
                         <option key={option.value} value={option.value}>{option.label}</option>
                       ))}
                     </select>
                   </div>
-                  <div>
-                    <label className="block text-sm font-medium mb-1.5">Poll interval (seconds)</label>
-                    <input type="number" min={5} max={3600} value={form.monitor_poll_interval_seconds} onChange={(e) => update('monitor_poll_interval_seconds', Number(e.target.value) || 30)} className={inputClass('monitor_poll_interval_seconds')} />
-                    {errors.monitor_poll_interval_seconds && <p className="mt-1 text-xs text-destructive">{errors.monitor_poll_interval_seconds}</p>}
+                  <div className="space-y-1.5">
+                    <Label htmlFor="printer-monitor-poll">Poll interval (seconds)</Label>
+                    <Input id="printer-monitor-poll" type="number" min={5} max={3600} value={form.monitor_poll_interval_seconds} onChange={(e) => update('monitor_poll_interval_seconds', Number(e.target.value) || 30)} invalid={Boolean(errors.monitor_poll_interval_seconds)} />
+                    {errors.monitor_poll_interval_seconds && <p className="text-xs text-destructive">{errors.monitor_poll_interval_seconds}</p>}
                   </div>
                 </div>
 
-                <div>
-                  <label className="block text-sm font-medium mb-1.5">Base URL *</label>
-                  <input value={form.monitor_base_url} onChange={(e) => update('monitor_base_url', e.target.value)} className={inputClass('monitor_base_url')} placeholder={selectedProvider.placeholder} />
-                  <p className="mt-1 text-xs text-muted-foreground">
+                <div className="space-y-1.5">
+                  <Label htmlFor="printer-monitor-base-url">Base URL *</Label>
+                  <Input id="printer-monitor-base-url" value={form.monitor_base_url} onChange={(e) => update('monitor_base_url', e.target.value)} invalid={Boolean(errors.monitor_base_url)} placeholder={selectedProvider.placeholder} />
+                  <p className="text-xs text-muted-foreground">
                     {form.monitor_provider === 'moonraker' ? 'Use the Moonraker API URL, typically port 7125.' : 'Use the OctoPrint base URL hosting the API.'}
                   </p>
-                  {errors.monitor_base_url && <p className="mt-1 text-xs text-destructive">{errors.monitor_base_url}</p>}
+                  {errors.monitor_base_url && <p className="text-xs text-destructive">{errors.monitor_base_url}</p>}
                 </div>
 
-                <div>
-                  <label className="block text-sm font-medium mb-1.5">API key / token</label>
-                  <input
+                <div className="space-y-1.5">
+                  <Label htmlFor="printer-monitor-api-key">API key / token</Label>
+                  <Input
+                    id="printer-monitor-api-key"
                     type="password"
                     value={form.monitor_api_key}
                     onChange={(e) => {
                       update('monitor_api_key', e.target.value);
                       if (e.target.value) update('clear_monitor_api_key', false);
                     }}
-                    className={inputClass('monitor_api_key')}
+                    invalid={Boolean(errors.monitor_api_key)}
                     placeholder={isEdit ? 'Enter a new key to replace the saved value' : 'Optional if your provider requires auth'}
                   />
                   <p className="mt-1 text-xs text-muted-foreground">
@@ -334,13 +339,13 @@ export default function PrinterFormPage() {
             ) : null}
           </div>
 
-          <div>
-            <label className="block text-sm font-medium mb-1.5">Notes</label>
-            <textarea
+          <div className="space-y-1.5">
+            <Label htmlFor="printer-notes">Notes</Label>
+            <Textarea
+              id="printer-notes"
               value={form.notes}
               onChange={(e) => update('notes', e.target.value)}
               rows={5}
-              className={inputClass('notes')}
               placeholder="Nozzle size, preferred materials, maintenance notes, quirks, etc."
             />
           </div>

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -7,6 +7,9 @@ import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
 import { Button } from '@/components/ui/Button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { Input } from '@/components/ui/Input';
+import { Textarea } from '@/components/ui/Textarea';
+import { Label } from '@/components/ui/Label';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import type { Product, PaginatedTransactions } from '@/types';
@@ -242,13 +245,13 @@ export default function ProductDetailPage() {
             <p className="text-sm text-muted-foreground">
               This creates an inventory adjustment record and preserves audit history. A reason is required.
             </p>
-            <div>
-              <label className="block text-sm font-medium mb-1">Reason</label>
-              <textarea
+            <div className="space-y-1.5">
+              <Label htmlFor="zero-stock-reason">Reason</Label>
+              <Textarea
+                id="zero-stock-reason"
                 value={zeroReason}
                 onChange={(e) => setZeroReason(e.target.value)}
                 rows={3}
-                className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
                 placeholder="Why is stock being reset to zero?"
               />
             </div>
@@ -269,19 +272,24 @@ export default function ProductDetailPage() {
             <DialogTitle>Adjust stock</DialogTitle>
           </DialogHeader>
           <div className="space-y-3">
-            <div>
-              <label className="block text-sm font-medium mb-1">Type</label>
-              <select value={adjForm.type} onChange={(e) => setAdjForm({ ...adjForm, type: e.target.value })} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring">
+            <div className="space-y-1.5">
+              <Label htmlFor="adjust-type-detail">Type</Label>
+              <select
+                id="adjust-type-detail"
+                value={adjForm.type}
+                onChange={(e) => setAdjForm({ ...adjForm, type: e.target.value })}
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              >
                 {TXN_TYPES.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
               </select>
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-1">Quantity</label>
-              <input type="number" value={adjForm.quantity} onChange={(e) => setAdjForm({ ...adjForm, quantity: Number(e.target.value) })} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" placeholder="Positive to add, negative to remove" />
+            <div className="space-y-1.5">
+              <Label htmlFor="adjust-qty-detail">Quantity</Label>
+              <Input id="adjust-qty-detail" type="number" value={adjForm.quantity} onChange={(e) => setAdjForm({ ...adjForm, quantity: Number(e.target.value) })} placeholder="Positive to add, negative to remove" />
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-1">Notes</label>
-              <input value={adjForm.notes} onChange={(e) => setAdjForm({ ...adjForm, notes: e.target.value })} className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" placeholder="Optional" />
+            <div className="space-y-1.5">
+              <Label htmlFor="adjust-notes-detail">Notes</Label>
+              <Input id="adjust-notes-detail" value={adjForm.notes} onChange={(e) => setAdjForm({ ...adjForm, notes: e.target.value })} placeholder="Optional" />
             </div>
           </div>
           <DialogFooter>

--- a/frontend/src/pages/ProductEditorPage.tsx
+++ b/frontend/src/pages/ProductEditorPage.tsx
@@ -16,6 +16,9 @@ import api from '@/api/client';
 import EmptyState from '@/components/ui/EmptyState';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Textarea } from '@/components/ui/Textarea';
+import { Label } from '@/components/ui/Label';
 import PageHeader from '@/components/layout/PageHeader';
 import { cn, formatCurrency } from '@/lib/utils';
 import type { InventoryTransaction, Material, PaginatedTransactions, Product } from '@/types';
@@ -142,8 +145,8 @@ export default function ProductEditorPage() {
     return <p className="py-16 text-center text-muted-foreground">Product not found</p>;
   }
 
-  const inputClass = (field: string) =>
-    `w-full rounded-md border px-4 py-3 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring ${
+  const selectClass = (field: string) =>
+    `flex h-9 w-full rounded-md border bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring ${
       formErrors[field] ? 'border-destructive' : 'border-input'
     }`;
 
@@ -183,60 +186,63 @@ export default function ProductEditorPage() {
             </div>
 
             <div className="mt-5 grid gap-4 lg:grid-cols-2">
-              <div className="lg:col-span-2">
-                <label className="mb-2 block text-sm font-medium">Product name</label>
-                <input
+              <div className="lg:col-span-2 space-y-1.5">
+                <Label htmlFor="product-name">Product name *</Label>
+                <Input
+                  id="product-name"
                   value={form.name}
                   onChange={(event) => {
                     setForm((current) => ({ ...current, name: event.target.value }));
                     setFormErrors((current) => ({ ...current, name: '' }));
                   }}
-                  className={inputClass('name')}
+                  invalid={Boolean(formErrors.name)}
                   placeholder="Desk Dragon, Tool Holder, Display Plaque..."
                 />
-                {formErrors.name ? <p className="mt-1 text-xs text-destructive">{formErrors.name}</p> : null}
+                {formErrors.name ? <p className="text-xs text-destructive">{formErrors.name}</p> : null}
               </div>
 
-              <div className="lg:col-span-2">
-                <label className="mb-2 block text-sm font-medium">Description</label>
-                <textarea
+              <div className="lg:col-span-2 space-y-1.5">
+                <Label htmlFor="product-description">Description</Label>
+                <Textarea
+                  id="product-description"
                   value={form.description}
                   onChange={(event) => setForm((current) => ({ ...current, description: event.target.value }))}
                   rows={4}
-                  className={inputClass('description')}
                   placeholder="Short operator-facing or storefront-facing summary."
                 />
               </div>
 
-              <div>
-                <label className="mb-2 block text-sm font-medium">SKU</label>
+              <div className="space-y-1.5">
+                <Label>SKU</Label>
                 <div className="rounded-md border border-border bg-background px-4 py-3 text-sm">
                   {product?.sku || 'Generated after first save'}
                 </div>
               </div>
 
-              <div>
-                <label className="mb-2 block text-sm font-medium">UPC / barcode</label>
+              <div className="space-y-1.5">
+                <Label htmlFor="product-upc">UPC / barcode</Label>
                 <div className="relative">
-                  <ScanBarcode className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                  <input
+                  <ScanBarcode className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    id="product-upc"
                     value={form.upc}
                     onChange={(event) => setForm((current) => ({ ...current, upc: event.target.value }))}
-                    className={`${inputClass('upc')} pl-10`}
+                    className="pl-9"
                     placeholder="012345678901"
                   />
                 </div>
               </div>
 
-              <div>
-                <label className="mb-2 block text-sm font-medium">Material</label>
+              <div className="space-y-1.5">
+                <Label htmlFor="product-material">Material *</Label>
                 <select
+                  id="product-material"
                   value={form.material_id}
                   onChange={(event) => {
                     setForm((current) => ({ ...current, material_id: event.target.value }));
                     setFormErrors((current) => ({ ...current, material_id: '' }));
                   }}
-                  className={inputClass('material_id')}
+                  className={selectClass('material_id')}
                 >
                   <option value="">Select material...</option>
                   {materials.map((material) => (
@@ -245,32 +251,34 @@ export default function ProductEditorPage() {
                     </option>
                   ))}
                 </select>
-                {formErrors.material_id ? <p className="mt-1 text-xs text-destructive">{formErrors.material_id}</p> : null}
+                {formErrors.material_id ? <p className="text-xs text-destructive">{formErrors.material_id}</p> : null}
               </div>
 
-              <div>
-                <label className="mb-2 block text-sm font-medium">Unit price</label>
-                <input
+              <div className="space-y-1.5">
+                <Label htmlFor="product-unit-price">Unit price</Label>
+                <Input
+                  id="product-unit-price"
                   type="number"
                   min="0"
                   step="0.01"
                   value={form.unit_price}
                   onChange={(event) => setForm((current) => ({ ...current, unit_price: Number(event.target.value) }))}
-                  className={inputClass('unit_price')}
+                  invalid={Boolean(formErrors.unit_price)}
                 />
-                {formErrors.unit_price ? <p className="mt-1 text-xs text-destructive">{formErrors.unit_price}</p> : null}
+                {formErrors.unit_price ? <p className="text-xs text-destructive">{formErrors.unit_price}</p> : null}
               </div>
 
-              <div>
-                <label className="mb-2 block text-sm font-medium">Reorder point</label>
-                <input
+              <div className="space-y-1.5">
+                <Label htmlFor="product-reorder">Reorder point</Label>
+                <Input
+                  id="product-reorder"
                   type="number"
                   min="0"
                   value={form.reorder_point}
                   onChange={(event) => setForm((current) => ({ ...current, reorder_point: Number(event.target.value) }))}
-                  className={inputClass('reorder_point')}
+                  invalid={Boolean(formErrors.reorder_point)}
                 />
-                {formErrors.reorder_point ? <p className="mt-1 text-xs text-destructive">{formErrors.reorder_point}</p> : null}
+                {formErrors.reorder_point ? <p className="text-xs text-destructive">{formErrors.reorder_point}</p> : null}
               </div>
             </div>
 

--- a/frontend/src/pages/SaleDetailPage.tsx
+++ b/frontend/src/pages/SaleDetailPage.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Printer, RefreshCw, Save } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import { getShippingLabelActionLabel, getShippingLabelMissingFields } from '@/lib/shippingLabels';
 import { formatCurrency } from '@/lib/utils';
@@ -277,17 +278,17 @@ export default function SaleDetailPage() {
             </div>
 
             <div className="grid grid-cols-1 gap-3">
-              <input value={shipmentForm.shipping_recipient_name} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_recipient_name: e.target.value }))} placeholder="Recipient name" className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
-              <input value={shipmentForm.shipping_company} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_company: e.target.value }))} placeholder="Company (optional)" className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
-              <input value={shipmentForm.shipping_address_line1} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_address_line1: e.target.value }))} placeholder="Address line 1" className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
-              <input value={shipmentForm.shipping_address_line2} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_address_line2: e.target.value }))} placeholder="Address line 2" className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+              <Input value={shipmentForm.shipping_recipient_name} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_recipient_name: e.target.value }))} placeholder="Recipient name" />
+              <Input value={shipmentForm.shipping_company} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_company: e.target.value }))} placeholder="Company (optional)" />
+              <Input value={shipmentForm.shipping_address_line1} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_address_line1: e.target.value }))} placeholder="Address line 1" />
+              <Input value={shipmentForm.shipping_address_line2} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_address_line2: e.target.value }))} placeholder="Address line 2" />
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                <input value={shipmentForm.shipping_city} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_city: e.target.value }))} placeholder="City" className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
-                <input value={shipmentForm.shipping_state} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_state: e.target.value }))} placeholder="State" className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
-                <input value={shipmentForm.shipping_postal_code} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_postal_code: e.target.value }))} placeholder="Postal code" className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+                <Input value={shipmentForm.shipping_city} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_city: e.target.value }))} placeholder="City" />
+                <Input value={shipmentForm.shipping_state} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_state: e.target.value }))} placeholder="State" />
+                <Input value={shipmentForm.shipping_postal_code} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_postal_code: e.target.value }))} placeholder="Postal code" />
               </div>
-              <input value={shipmentForm.shipping_country} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_country: e.target.value }))} placeholder="Country" className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
-              <input value={shipmentForm.tracking_number} onChange={(e) => setShipmentForm((prev) => ({ ...prev, tracking_number: e.target.value }))} placeholder="Tracking number" className="w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring" />
+              <Input value={shipmentForm.shipping_country} onChange={(e) => setShipmentForm((prev) => ({ ...prev, shipping_country: e.target.value }))} placeholder="Country" />
+              <Input value={shipmentForm.tracking_number} onChange={(e) => setShipmentForm((prev) => ({ ...prev, tracking_number: e.target.value }))} placeholder="Tracking number" />
             </div>
 
             {shipmentMissingFields.length > 0 ? (

--- a/frontend/src/pages/SaleFormPage.tsx
+++ b/frontend/src/pages/SaleFormPage.tsx
@@ -5,6 +5,9 @@ import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Textarea } from '@/components/ui/Textarea';
+import { Label } from '@/components/ui/Label';
 import { formatCurrency } from '@/lib/utils';
 import type { SalesChannel, PaginatedProducts, Customer } from '@/types';
 
@@ -128,8 +131,8 @@ export default function SaleFormPage() {
     }
   };
 
-  const inputCls =
-    'w-full px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring';
+  const selectCls =
+    'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring';
 
   return (
     <div>
@@ -147,21 +150,22 @@ export default function SaleFormPage() {
           <div className="bg-card border border-border rounded-lg p-6">
             <h2 className="text-lg font-semibold mb-4">Sale Details</h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium mb-1">Date *</label>
-                <input type="date" value={form.date} onChange={(e) => setForm({ ...form, date: e.target.value })} className={inputCls} />
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-date">Date *</Label>
+                <Input id="sale-date" type="date" value={form.date} onChange={(e) => setForm({ ...form, date: e.target.value })} />
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Status</label>
-                <select value={form.status} onChange={(e) => setForm({ ...form, status: e.target.value })} className={inputCls}>
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-status">Status</Label>
+                <select id="sale-status" value={form.status} onChange={(e) => setForm({ ...form, status: e.target.value })} className={selectCls}>
                   {['pending', 'paid', 'shipped', 'delivered'].map((s) => (
                     <option key={s} value={s}>{s.charAt(0).toUpperCase() + s.slice(1)}</option>
                   ))}
                 </select>
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Customer</label>
-                <input
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-customer">Customer</Label>
+                <Input
+                  id="sale-customer"
                   list="customer-list"
                   value={form.customer_name}
                   onChange={(e) =>
@@ -172,7 +176,6 @@ export default function SaleFormPage() {
                     }))
                   }
                   placeholder="Customer name..."
-                  className={inputCls}
                 />
                 <datalist id="customer-list">
                   {customers?.map((c) => (
@@ -180,18 +183,18 @@ export default function SaleFormPage() {
                   ))}
                 </datalist>
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Sales Channel</label>
-                <select value={form.channel_id} onChange={(e) => setForm({ ...form, channel_id: e.target.value })} className={inputCls}>
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-channel">Sales Channel</Label>
+                <select id="sale-channel" value={form.channel_id} onChange={(e) => setForm({ ...form, channel_id: e.target.value })} className={selectCls}>
                   <option value="">Direct Sale</option>
                   {channels?.map((c) => (
                     <option key={c.id} value={c.id}>{c.name}</option>
                   ))}
                 </select>
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Payment Method</label>
-                <select value={form.payment_method} onChange={(e) => setForm({ ...form, payment_method: e.target.value })} className={inputCls}>
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-payment">Payment Method</Label>
+                <select id="sale-payment" value={form.payment_method} onChange={(e) => setForm({ ...form, payment_method: e.target.value })} className={selectCls}>
                   <option value="card">Card</option>
                   <option value="cash">Cash</option>
                   <option value="paypal">PayPal</option>
@@ -199,51 +202,51 @@ export default function SaleFormPage() {
                   <option value="other">Other</option>
                 </select>
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Tracking Number</label>
-                <input value={form.tracking_number} onChange={(e) => setForm({ ...form, tracking_number: e.target.value })} placeholder="Optional" className={inputCls} />
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-tracking">Tracking Number</Label>
+                <Input id="sale-tracking" value={form.tracking_number} onChange={(e) => setForm({ ...form, tracking_number: e.target.value })} placeholder="Optional" />
               </div>
             </div>
-            <div className="mt-4">
-              <label className="block text-sm font-medium mb-1">Notes</label>
-              <textarea value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} rows={2} className={inputCls} />
+            <div className="mt-4 space-y-1.5">
+              <Label htmlFor="sale-notes">Notes</Label>
+              <Textarea id="sale-notes" value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} rows={2} />
             </div>
           </div>
 
           <div className="bg-card border border-border rounded-lg p-6">
             <h2 className="text-lg font-semibold mb-4">Shipment Label</h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium mb-1">Recipient</label>
-                <input value={form.shipping_recipient_name} onChange={(e) => setForm({ ...form, shipping_recipient_name: e.target.value })} placeholder="Customer or recipient name" className={inputCls} />
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-ship-recipient">Recipient</Label>
+                <Input id="sale-ship-recipient" value={form.shipping_recipient_name} onChange={(e) => setForm({ ...form, shipping_recipient_name: e.target.value })} placeholder="Customer or recipient name" />
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Company</label>
-                <input value={form.shipping_company} onChange={(e) => setForm({ ...form, shipping_company: e.target.value })} placeholder="Optional" className={inputCls} />
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-ship-company">Company</Label>
+                <Input id="sale-ship-company" value={form.shipping_company} onChange={(e) => setForm({ ...form, shipping_company: e.target.value })} placeholder="Optional" />
               </div>
-              <div className="sm:col-span-2">
-                <label className="block text-sm font-medium mb-1">Address Line 1</label>
-                <input value={form.shipping_address_line1} onChange={(e) => setForm({ ...form, shipping_address_line1: e.target.value })} placeholder="Street address" className={inputCls} />
+              <div className="sm:col-span-2 space-y-1.5">
+                <Label htmlFor="sale-ship-address1">Address Line 1</Label>
+                <Input id="sale-ship-address1" value={form.shipping_address_line1} onChange={(e) => setForm({ ...form, shipping_address_line1: e.target.value })} placeholder="Street address" />
               </div>
-              <div className="sm:col-span-2">
-                <label className="block text-sm font-medium mb-1">Address Line 2</label>
-                <input value={form.shipping_address_line2} onChange={(e) => setForm({ ...form, shipping_address_line2: e.target.value })} placeholder="Apartment, suite, etc. (optional)" className={inputCls} />
+              <div className="sm:col-span-2 space-y-1.5">
+                <Label htmlFor="sale-ship-address2">Address Line 2</Label>
+                <Input id="sale-ship-address2" value={form.shipping_address_line2} onChange={(e) => setForm({ ...form, shipping_address_line2: e.target.value })} placeholder="Apartment, suite, etc. (optional)" />
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">City</label>
-                <input value={form.shipping_city} onChange={(e) => setForm({ ...form, shipping_city: e.target.value })} className={inputCls} />
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-ship-city">City</Label>
+                <Input id="sale-ship-city" value={form.shipping_city} onChange={(e) => setForm({ ...form, shipping_city: e.target.value })} />
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">State / Region</label>
-                <input value={form.shipping_state} onChange={(e) => setForm({ ...form, shipping_state: e.target.value })} className={inputCls} />
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-ship-state">State / Region</Label>
+                <Input id="sale-ship-state" value={form.shipping_state} onChange={(e) => setForm({ ...form, shipping_state: e.target.value })} />
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Postal Code</label>
-                <input value={form.shipping_postal_code} onChange={(e) => setForm({ ...form, shipping_postal_code: e.target.value })} className={inputCls} />
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-ship-postal">Postal Code</Label>
+                <Input id="sale-ship-postal" value={form.shipping_postal_code} onChange={(e) => setForm({ ...form, shipping_postal_code: e.target.value })} />
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Country</label>
-                <input value={form.shipping_country} onChange={(e) => setForm({ ...form, shipping_country: e.target.value })} className={inputCls} />
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-ship-country">Country</Label>
+                <Input id="sale-ship-country" value={form.shipping_country} onChange={(e) => setForm({ ...form, shipping_country: e.target.value })} />
               </div>
             </div>
             <p className="mt-4 text-sm text-muted-foreground">
@@ -262,12 +265,13 @@ export default function SaleFormPage() {
             <div className="space-y-4">
               {items.map((item, idx) => (
                 <div key={idx} className="grid grid-cols-12 gap-2 items-end">
-                  <div className="col-span-12 sm:col-span-3">
-                    <label className="block text-xs text-muted-foreground mb-1">Product</label>
+                  <div className="col-span-12 sm:col-span-3 space-y-1.5">
+                    <Label htmlFor={`sale-item-${idx}-product`} className="text-xs text-muted-foreground">Product</Label>
                     <select
+                      id={`sale-item-${idx}-product`}
                       value={item.product_id}
                       onChange={(e) => selectProduct(idx, e.target.value)}
-                      className="w-full px-2 py-2 border border-input rounded-md bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      className={selectCls}
                     >
                       <option value="">Custom item...</option>
                       {products.map((p) => (
@@ -275,21 +279,21 @@ export default function SaleFormPage() {
                       ))}
                     </select>
                   </div>
-                  <div className="col-span-12 sm:col-span-3">
-                    <label className="block text-xs text-muted-foreground mb-1">Description *</label>
-                    <input value={item.description} onChange={(e) => updateItem(idx, { description: e.target.value })} className="w-full px-2 py-2 border border-input rounded-md bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring" />
+                  <div className="col-span-12 sm:col-span-3 space-y-1.5">
+                    <Label htmlFor={`sale-item-${idx}-description`} className="text-xs text-muted-foreground">Description *</Label>
+                    <Input id={`sale-item-${idx}-description`} value={item.description} onChange={(e) => updateItem(idx, { description: e.target.value })} />
                   </div>
-                  <div className="col-span-4 sm:col-span-1">
-                    <label className="block text-xs text-muted-foreground mb-1">Qty</label>
-                    <input type="number" min="1" value={item.quantity} onChange={(e) => updateItem(idx, { quantity: Math.max(1, Number(e.target.value)) })} className="w-full px-2 py-2 border border-input rounded-md bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring" />
+                  <div className="col-span-4 sm:col-span-1 space-y-1.5">
+                    <Label htmlFor={`sale-item-${idx}-qty`} className="text-xs text-muted-foreground">Qty</Label>
+                    <Input id={`sale-item-${idx}-qty`} type="number" min="1" value={item.quantity} onChange={(e) => updateItem(idx, { quantity: Math.max(1, Number(e.target.value)) })} />
                   </div>
-                  <div className="col-span-4 sm:col-span-2">
-                    <label className="block text-xs text-muted-foreground mb-1">Price ($)</label>
-                    <input type="number" step="0.01" min="0" value={item.unit_price} onChange={(e) => updateItem(idx, { unit_price: Number(e.target.value) })} className="w-full px-2 py-2 border border-input rounded-md bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring" />
+                  <div className="col-span-4 sm:col-span-2 space-y-1.5">
+                    <Label htmlFor={`sale-item-${idx}-price`} className="text-xs text-muted-foreground">Price ($)</Label>
+                    <Input id={`sale-item-${idx}-price`} type="number" step="0.01" min="0" value={item.unit_price} onChange={(e) => updateItem(idx, { unit_price: Number(e.target.value) })} />
                   </div>
-                  <div className="col-span-3 sm:col-span-2">
-                    <label className="block text-xs text-muted-foreground mb-1">Cost ($)</label>
-                    <input type="number" step="0.01" min="0" value={item.unit_cost} onChange={(e) => updateItem(idx, { unit_cost: Number(e.target.value) })} className="w-full px-2 py-2 border border-input rounded-md bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring" />
+                  <div className="col-span-3 sm:col-span-2 space-y-1.5">
+                    <Label htmlFor={`sale-item-${idx}-cost`} className="text-xs text-muted-foreground">Cost ($)</Label>
+                    <Input id={`sale-item-${idx}-cost`} type="number" step="0.01" min="0" value={item.unit_cost} onChange={(e) => updateItem(idx, { unit_cost: Number(e.target.value) })} />
                   </div>
                   <div className="col-span-1 flex justify-end">
                     <button onClick={() => removeItem(idx)} disabled={items.length === 1} className="p-2 hover:bg-accent rounded-md text-muted-foreground disabled:opacity-30 cursor-pointer">
@@ -308,17 +312,17 @@ export default function SaleFormPage() {
           <div className="bg-card border border-border rounded-lg p-6">
             <h2 className="text-lg font-semibold mb-4">Shipping & Tax</h2>
             <div className="space-y-3">
-              <div>
-                <label className="block text-sm font-medium mb-1">Shipping Charged</label>
-                <input type="number" step="0.01" min="0" value={form.shipping_charged} onChange={(e) => setForm({ ...form, shipping_charged: Number(e.target.value) })} className={inputCls} />
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-shipping-charged">Shipping Charged</Label>
+                <Input id="sale-shipping-charged" type="number" step="0.01" min="0" value={form.shipping_charged} onChange={(e) => setForm({ ...form, shipping_charged: Number(e.target.value) })} />
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Shipping Cost</label>
-                <input type="number" step="0.01" min="0" value={form.shipping_cost} onChange={(e) => setForm({ ...form, shipping_cost: Number(e.target.value) })} className={inputCls} />
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-shipping-cost">Shipping Cost</Label>
+                <Input id="sale-shipping-cost" type="number" step="0.01" min="0" value={form.shipping_cost} onChange={(e) => setForm({ ...form, shipping_cost: Number(e.target.value) })} />
               </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Tax Collected</label>
-                <input type="number" step="0.01" min="0" value={form.tax_collected} onChange={(e) => setForm({ ...form, tax_collected: Number(e.target.value) })} className={inputCls} />
+              <div className="space-y-1.5">
+                <Label htmlFor="sale-tax">Tax Collected</Label>
+                <Input id="sale-tax" type="number" step="0.01" min="0" value={form.tax_collected} onChange={(e) => setForm({ ...form, tax_collected: Number(e.target.value) })} />
               </div>
             </div>
           </div>

--- a/frontend/src/pages/admin/CamerasPage.tsx
+++ b/frontend/src/pages/admin/CamerasPage.tsx
@@ -5,6 +5,9 @@ import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { Input } from '@/components/ui/Input';
+import { Textarea } from '@/components/ui/Textarea';
+import { Label } from '@/components/ui/Label';
 import type { Camera, PaginatedCameras, PaginatedPrinters } from '@/types';
 
 type ModalMode = 'create' | 'edit' | null;
@@ -289,58 +292,64 @@ export default function CamerasPage() {
           <div className="space-y-5">
 
               {/* Name */}
-              <div>
-                <label className="block text-sm font-medium mb-1">Name</label>
-                <input
+              <div className="space-y-1.5">
+                <Label htmlFor="camera-name">Name</Label>
+                <Input
+                  id="camera-name"
                   type="text"
                   value={form.name}
                   onChange={(e) => handleNameChange(e.target.value)}
                   placeholder="Wyze Cam - Bay 1"
-                  className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  invalid={Boolean(errors.name)}
                 />
-                {errors.name && <p className="text-xs text-danger mt-1">{errors.name}</p>}
+                {errors.name && <p className="text-xs text-danger">{errors.name}</p>}
               </div>
 
               {/* Slug */}
-              <div>
-                <label className="block text-sm font-medium mb-1">Slug</label>
-                <input
+              <div className="space-y-1.5">
+                <Label htmlFor="camera-slug">Slug</Label>
+                <Input
+                  id="camera-slug"
                   type="text"
                   value={form.slug}
                   onChange={(e) => setForm((f) => ({ ...f, slug: e.target.value }))}
                   placeholder="wyze-cam-bay-1"
-                  className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  invalid={Boolean(errors.slug)}
                 />
-                {errors.slug && <p className="text-xs text-danger mt-1">{errors.slug}</p>}
+                {errors.slug && <p className="text-xs text-danger">{errors.slug}</p>}
               </div>
 
               {/* go2rtc Base URL */}
-              <div>
-                <label className="block text-sm font-medium mb-1">go2rtc Base URL</label>
-                <input
+              <div className="space-y-1.5">
+                <Label htmlFor="camera-base-url">go2rtc Base URL</Label>
+                <Input
+                  id="camera-base-url"
                   type="text"
                   value={form.go2rtc_base_url}
                   onChange={(e) => setForm((f) => ({ ...f, go2rtc_base_url: e.target.value }))}
                   placeholder="http://192.168.1.50:1984"
-                  className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  className="font-mono"
+                  invalid={Boolean(errors.go2rtc_base_url)}
                 />
                 {errors.go2rtc_base_url && (
-                  <p className="text-xs text-danger mt-1">{errors.go2rtc_base_url}</p>
+                  <p className="text-xs text-danger">{errors.go2rtc_base_url}</p>
                 )}
               </div>
 
               {/* Stream Name */}
-              <div>
-                <label className="block text-sm font-medium mb-1">Stream Name</label>
-                <input
+              <div className="space-y-1.5">
+                <Label htmlFor="camera-stream">Stream Name</Label>
+                <Input
+                  id="camera-stream"
                   type="text"
                   value={form.stream_name}
                   onChange={(e) => setForm((f) => ({ ...f, stream_name: e.target.value }))}
                   placeholder="wyze_printer_1"
-                  className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  className="font-mono"
+                  invalid={Boolean(errors.stream_name)}
                 />
                 {errors.stream_name && (
-                  <p className="text-xs text-danger mt-1">{errors.stream_name}</p>
+                  <p className="text-xs text-danger">{errors.stream_name}</p>
                 )}
               </div>
 
@@ -348,7 +357,7 @@ export default function CamerasPage() {
               {(form.go2rtc_base_url.trim() && form.stream_name.trim()) && (
                 <div>
                   <div className="flex items-center justify-between mb-1">
-                    <label className="block text-sm font-medium">Preview</label>
+                    <Label>Preview</Label>
                     <button
                       type="button"
                       onClick={fetchPreview}
@@ -389,12 +398,13 @@ export default function CamerasPage() {
               )}
 
               {/* Assigned Printer */}
-              <div>
-                <label className="block text-sm font-medium mb-1">Assigned Printer</label>
+              <div className="space-y-1.5">
+                <Label htmlFor="camera-printer">Assigned Printer</Label>
                 <select
+                  id="camera-printer"
                   value={form.printer_id}
                   onChange={(e) => setForm((f) => ({ ...f, printer_id: e.target.value }))}
-                  className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 >
                   <option value="">None (unassigned)</option>
                   {availablePrinters.map((p) => (
@@ -406,13 +416,14 @@ export default function CamerasPage() {
               </div>
 
               {/* Notes */}
-              <div>
-                <label className="block text-sm font-medium mb-1">Notes</label>
-                <textarea
+              <div className="space-y-1.5">
+                <Label htmlFor="camera-notes">Notes</Label>
+                <Textarea
+                  id="camera-notes"
                   value={form.notes}
                   onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))}
                   rows={2}
-                  className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 resize-none"
+                  className="resize-none"
                 />
               </div>
 


### PR DESCRIPTION
Closes #177.

## Summary

Migrates raw `<input>` / `<textarea>` and hand-rolled label markup to the shared `<Input>`, `<Textarea>`, `<Label>` primitives across 9 form-heavy pages. Net +54 lines (mostly from adding `<Label htmlFor>` wrappers).

## Files touched

| Page | Changes |
| --- | --- |
| `LoginPage.tsx` | Email + password → Input/Label |
| `InventoryPage.tsx` | Reconcile + quick-adjust dialogs; ledger date pickers compact |
| `JobFormPage.tsx` | `Field` helper now composes Input/Label; create-and-link-product dialog |
| `SaleFormPage.tsx` | Line-item inputs with per-row IDs; removed `inputCls` |
| `PrinterFormPage.tsx` | Text/number inputs migrated (checkboxes preserved) |
| `ProductDetailPage.tsx` | Set-stock-to-0 + adjust-stock dialogs |
| `ProductEditorPage.tsx` | UPC input with leading icon; removed `inputClass` helper |
| `admin/CamerasPage.tsx` | Camera config form; font-mono preserved on URL/stream |
| `SaleDetailPage.tsx` | Shipment form (9 raw inputs) migrated |

## Standards applied

- `<Label htmlFor={id}>` with matching `id` on every field
- Required indicator `*` in the label text
- Error state: `invalid={Boolean(errors.field)}` + below-field `<p className="text-destructive text-xs">`
- Native `<select>` normalized to Input-matching className (Radix Select migration out of scope)
- Removed legacy helpers: `inputCls`, `inputClass`

## Acceptance (#177)

- [x] `rg '<input\s' frontend/src/pages` returns only accepted exceptions (2 checkboxes in PrinterFormPage, 1 range slider in JobFormPage)
- [x] `rg 'className="[^"]*rounded-xl[^"]*bg-background' frontend/src/pages` → 0
- [x] `rg '<textarea\s' frontend/src/pages` → 0
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Login page: email/password validation, focus rings, disabled state during submit
- [ ] Job form: create a job end-to-end; test the create-and-link-product dialog
- [ ] Sale form: add line items with customer, verify per-row IDs don't conflict
- [ ] Printer form: save with/without monitor, clear API key checkbox still works
- [ ] Inventory: reconcile + quick-adjust dialogs submit correctly
- [ ] Product detail: adjust stock, set stock to 0 dialogs
- [ ] Cameras: create + edit camera, verify font-mono on stream URL
- [ ] Sale detail: fill shipment form, print shipping label

🤖 Generated with [Claude Code](https://claude.com/claude-code)