### PR TITLE
feat(ui): migrate list + report pages to DataTable (#179)

### DIFF
--- a/frontend/src/pages/SalesChannelsPage.tsx
+++ b/frontend/src/pages/SalesChannelsPage.tsx
@@ -3,13 +3,12 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Edit, Plus } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
-import { SkeletonTable } from '@/components/ui/Skeleton';
-import EmptyState from '@/components/ui/EmptyState';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
 import StatusBadge from '@/components/data/StatusBadge';
+import DataTable, { type Column } from '@/components/data/DataTable';
 import type { SalesChannel } from '@/types';
 
 const emptyForm = { name: '', platform_fee_pct: 0, fixed_fee: 0, is_active: true };
@@ -124,55 +123,83 @@ export default function SalesChannelsPage() {
         </DialogContent>
       </Dialog>
 
-      {isLoading ? (
-        <SkeletonTable rows={4} cols={5} />
-      ) : !channels?.length ? (
-        <EmptyState
-          icon="default"
-          title="No sales channels"
-          description="Add a sales channel to track platform fees."
-          action={
-            <Button onClick={openNew}>
-              <Plus className="h-4 w-4" /> Add Channel
-            </Button>
-          }
-        />
-      ) : (
-        <div className="overflow-x-auto bg-card border border-border rounded-lg">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border text-left text-muted-foreground">
-                <th className="px-4 py-3 font-medium">Name</th>
-                <th className="px-4 py-3 font-medium text-right">Platform Fee %</th>
-                <th className="px-4 py-3 font-medium text-right">Fixed Fee</th>
-                <th className="px-4 py-3 font-medium">Status</th>
-                <th className="px-4 py-3 font-medium">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {channels.map((ch) => (
-                <tr key={ch.id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                  <td className="px-4 py-3 font-medium">{ch.name}</td>
-                  <td className="px-4 py-3 text-right">{Number(ch.platform_fee_pct).toFixed(1)}%</td>
-                  <td className="px-4 py-3 text-right">${Number(ch.fixed_fee).toFixed(2)}</td>
-                  <td className="px-4 py-3">
-                    <button onClick={() => toggleActive(ch)} className="cursor-pointer">
-                      <StatusBadge tone={ch.is_active ? 'success' : 'destructive'}>
-                        {ch.is_active ? 'Active' : 'Inactive'}
-                      </StatusBadge>
-                    </button>
-                  </td>
-                  <td className="px-4 py-3">
-                    <button onClick={() => openEdit(ch)} className="p-1.5 hover:bg-accent rounded-md text-muted-foreground cursor-pointer" title="Edit">
-                      <Edit className="w-4 h-4" />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <SalesChannelsTable
+        channels={channels || []}
+        isLoading={isLoading}
+        onEdit={openEdit}
+        onToggleActive={toggleActive}
+      />
     </div>
+  );
+}
+
+interface SalesChannelsTableProps {
+  channels: SalesChannel[];
+  isLoading: boolean;
+  onEdit: (ch: SalesChannel) => void;
+  onToggleActive: (ch: SalesChannel) => void;
+}
+
+function SalesChannelsTable({ channels, isLoading, onEdit, onToggleActive }: SalesChannelsTableProps) {
+  const columns: Column<SalesChannel>[] = [
+    {
+      key: 'name',
+      header: 'Name',
+      cell: (ch) => <span className="font-medium">{ch.name}</span>,
+    },
+    {
+      key: 'platform_fee_pct',
+      header: 'Platform Fee %',
+      numeric: true,
+      cell: (ch) => `${Number(ch.platform_fee_pct).toFixed(1)}%`,
+    },
+    {
+      key: 'fixed_fee',
+      header: 'Fixed Fee',
+      numeric: true,
+      cell: (ch) => `$${Number(ch.fixed_fee).toFixed(2)}`,
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      cell: (ch) => (
+        <button
+          type="button"
+          onClick={() => onToggleActive(ch)}
+          aria-label={ch.is_active ? `Deactivate ${ch.name}` : `Activate ${ch.name}`}
+          className="cursor-pointer"
+        >
+          <StatusBadge tone={ch.is_active ? 'success' : 'destructive'}>
+            {ch.is_active ? 'Active' : 'Inactive'}
+          </StatusBadge>
+        </button>
+      ),
+    },
+    {
+      key: 'actions',
+      header: <span className="sr-only">Actions</span>,
+      width: '96px',
+      cell: (ch) => (
+        <button
+          type="button"
+          onClick={() => onEdit(ch)}
+          aria-label={`Edit ${ch.name}`}
+          title="Edit"
+          className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted cursor-pointer"
+        >
+          <Edit className="h-4 w-4" />
+        </button>
+      ),
+    },
+  ];
+
+  return (
+    <DataTable<SalesChannel>
+      data={channels}
+      columns={columns}
+      rowKey={(ch) => ch.id}
+      loading={isLoading}
+      emptyState="No sales channels"
+    />
   );
 }

--- a/frontend/src/pages/admin/CamerasPage.tsx
+++ b/frontend/src/pages/admin/CamerasPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Camera as CameraIcon, Link2, Link2Off, Pencil, Plus, Trash2, Video } from 'lucide-react';
+import { Link2, Link2Off, Pencil, Plus, Trash2, Video } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
@@ -8,6 +8,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
+import DataTable, { type Column } from '@/components/data/DataTable';
 import type { Camera, PaginatedCameras, PaginatedPrinters } from '@/types';
 
 type ModalMode = 'create' | 'edit' | null;
@@ -196,93 +197,12 @@ export default function CamerasPage() {
         </Button>
       </div>
 
-      {/* Table */}
-      {isLoading ? (
-        <div className="animate-pulse space-y-3">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="h-14 bg-muted/50 rounded-lg" />
-          ))}
-        </div>
-      ) : cameras.length === 0 ? (
-        <div className="text-center py-16 text-muted-foreground">
-          <CameraIcon className="h-12 w-12 mx-auto mb-3 opacity-40" />
-          <p className="text-lg font-medium">No cameras yet</p>
-          <p className="text-sm mt-1">Add your first camera to start monitoring printers with live video.</p>
-        </div>
-      ) : (
-        <div className="overflow-x-auto rounded-xl border border-border">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border bg-muted/30">
-                <th className="text-left px-4 py-3 font-medium">Name</th>
-                <th className="text-left px-4 py-3 font-medium hidden md:table-cell">Stream</th>
-                <th className="text-left px-4 py-3 font-medium">Printer</th>
-                <th className="text-left px-4 py-3 font-medium hidden sm:table-cell">Status</th>
-                <th className="text-right px-4 py-3 font-medium">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {cameras.map((cam) => (
-                <tr key={cam.id} className="border-b border-border/50 hover:bg-muted/20 transition-colors">
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2">
-                      <Video className="h-4 w-4 text-info shrink-0" />
-                      <span className="font-medium">{cam.name}</span>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 hidden md:table-cell">
-                    <code className="text-xs bg-muted/50 px-1.5 py-0.5 rounded">{cam.stream_name}</code>
-                  </td>
-                  <td className="px-4 py-3">
-                    {cam.printer_name ? (
-                      <span className="flex items-center gap-1 text-primary">
-                        <Link2 className="h-3 w-3" />
-                        {cam.printer_name}
-                      </span>
-                    ) : (
-                      <span className="flex items-center gap-1 text-muted-foreground">
-                        <Link2Off className="h-3 w-3" />
-                        Unassigned
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-4 py-3 hidden sm:table-cell">
-                    <span
-                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-                        cam.is_active
-                          ? 'bg-primary/10 text-primary'
-                          : 'bg-muted text-muted-foreground'
-                      }`}
-                    >
-                      {cam.is_active ? 'Active' : 'Inactive'}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <div className="flex items-center justify-end gap-1">
-                      <button
-                        type="button"
-                        onClick={() => openEdit(cam)}
-                        className="p-1.5 rounded hover:bg-muted transition-colors"
-                        title="Edit"
-                      >
-                        <Pencil className="h-3.5 w-3.5" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => deleteMutation.mutate(cam.id)}
-                        className="p-1.5 rounded hover:bg-danger/10 text-danger transition-colors"
-                        title="Deactivate"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <CamerasTable
+        cameras={cameras}
+        isLoading={isLoading}
+        onEdit={openEdit}
+        onDeactivate={(id) => deleteMutation.mutate(id)}
+      />
 
       <Dialog open={Boolean(modal)} onOpenChange={(o) => !o && closeModal()}>
         <DialogContent className="max-w-lg">
@@ -448,5 +368,103 @@ export default function CamerasPage() {
         </DialogContent>
       </Dialog>
     </div>
+  );
+}
+
+interface CamerasTableProps {
+  cameras: Camera[];
+  isLoading: boolean;
+  onEdit: (cam: Camera) => void;
+  onDeactivate: (id: string) => void;
+}
+
+function CamerasTable({ cameras, isLoading, onEdit, onDeactivate }: CamerasTableProps) {
+  const columns: Column<Camera>[] = [
+    {
+      key: 'name',
+      header: 'Name',
+      cell: (cam) => (
+        <div className="flex items-center gap-2">
+          <Video className="h-4 w-4 text-info shrink-0" />
+          <span className="font-medium">{cam.name}</span>
+        </div>
+      ),
+    },
+    {
+      key: 'stream',
+      header: 'Stream',
+      colClassName: 'hidden md:table-cell',
+      cell: (cam) => (
+        <code className="text-xs bg-muted/50 px-1.5 py-0.5 rounded">{cam.stream_name}</code>
+      ),
+    },
+    {
+      key: 'printer',
+      header: 'Printer',
+      cell: (cam) =>
+        cam.printer_name ? (
+          <span className="inline-flex items-center gap-1 text-primary">
+            <Link2 className="h-3 w-3" />
+            {cam.printer_name}
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1 text-muted-foreground">
+            <Link2Off className="h-3 w-3" />
+            Unassigned
+          </span>
+        ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      colClassName: 'hidden sm:table-cell',
+      cell: (cam) => (
+        <span
+          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+            cam.is_active ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'
+          }`}
+        >
+          {cam.is_active ? 'Active' : 'Inactive'}
+        </span>
+      ),
+    },
+    {
+      key: 'actions',
+      header: <span className="sr-only">Actions</span>,
+      align: 'right',
+      width: '96px',
+      cell: (cam) => (
+        <div className="flex items-center justify-end gap-1">
+          <button
+            type="button"
+            onClick={() => onEdit(cam)}
+            aria-label={`Edit ${cam.name}`}
+            title="Edit"
+            className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted transition-colors"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => onDeactivate(cam.id)}
+            aria-label={`Deactivate ${cam.name}`}
+            title="Deactivate"
+            className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-danger/10 text-danger transition-colors"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <DataTable<Camera>
+      data={cameras}
+      columns={columns}
+      rowKey={(cam) => cam.id}
+      loading={isLoading}
+      emptyState="No cameras yet — add your first camera to start monitoring printers with live video."
+    />
   );
 }

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
 import StatusBadge from '@/components/data/StatusBadge';
+import DataTable, { type Column } from '@/components/data/DataTable';
 
 interface UserRecord {
   id: string;
@@ -147,66 +148,119 @@ export default function UsersPage() {
         </DialogContent>
       </Dialog>
 
-      {isLoading ? (
-        <div className="bg-card border border-border rounded-lg p-4 h-48 animate-pulse" />
-      ) : (
-        <div className="overflow-x-auto bg-card border border-border rounded-lg">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border text-left text-muted-foreground">
-                <th className="px-4 py-3 font-medium">Name</th>
-                <th className="px-4 py-3 font-medium">Email</th>
-                <th className="px-4 py-3 font-medium">Role</th>
-                <th className="px-4 py-3 font-medium">Status</th>
-                <th className="px-4 py-3 font-medium">Created</th>
-                <th className="px-4 py-3 font-medium">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {users?.map((u) => (
-                <tr key={u.id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                  <td className="px-4 py-3 font-medium">
-                    {u.full_name}
-                    {u.id === currentUser?.id && (
-                      <span className="ml-2 text-xs text-muted-foreground">(you)</span>
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground">{u.email}</td>
-                  <td className="px-4 py-3">
-                    <StatusBadge tone={u.role === 'admin' ? 'info' : 'neutral'}>{u.role}</StatusBadge>
-                  </td>
-                  <td className="px-4 py-3">
-                    <StatusBadge tone={u.is_active ? 'success' : 'destructive'}>
-                      {u.is_active ? 'Active' : 'Inactive'}
-                    </StatusBadge>
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground text-xs">
-                    {u.created_at ? new Date(u.created_at).toLocaleDateString() : '—'}
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex gap-1">
-                      <button onClick={() => openEdit(u)} className="p-1.5 hover:bg-accent rounded-md text-muted-foreground cursor-pointer" title="Edit">
-                        <Edit className="w-4 h-4" />
-                      </button>
-                      {u.id !== currentUser?.id && (
-                        u.is_active ? (
-                          <button onClick={() => deactivate(u)} className="p-1.5 hover:bg-destructive/10 rounded-md text-muted-foreground hover:text-destructive cursor-pointer" title="Deactivate">
-                            <UserX className="w-4 h-4" />
-                          </button>
-                        ) : (
-                          <button onClick={() => reactivate(u)} className="p-1.5 hover:bg-green-100 dark:hover:bg-green-900/20 rounded-md text-muted-foreground hover:text-green-600 cursor-pointer" title="Reactivate">
-                            <Users className="w-4 h-4" />
-                          </button>
-                        )
-                      )}
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <UsersTable
+        users={users || []}
+        isLoading={isLoading}
+        currentUserId={currentUser?.id}
+        onEdit={openEdit}
+        onDeactivate={deactivate}
+        onReactivate={reactivate}
+      />
     </div>
+  );
+}
+
+interface UsersTableProps {
+  users: UserRecord[];
+  isLoading: boolean;
+  currentUserId?: string;
+  onEdit: (u: UserRecord) => void;
+  onDeactivate: (u: UserRecord) => void;
+  onReactivate: (u: UserRecord) => void;
+}
+
+function UsersTable({ users, isLoading, currentUserId, onEdit, onDeactivate, onReactivate }: UsersTableProps) {
+  const columns: Column<UserRecord>[] = [
+    {
+      key: 'full_name',
+      header: 'Name',
+      cell: (u) => (
+        <div className="font-medium">
+          {u.full_name}
+          {u.id === currentUserId && (
+            <span className="ml-2 text-xs text-muted-foreground">(you)</span>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'email',
+      header: 'Email',
+      cell: (u) => <span className="text-muted-foreground">{u.email}</span>,
+    },
+    {
+      key: 'role',
+      header: 'Role',
+      cell: (u) => <StatusBadge tone={u.role === 'admin' ? 'info' : 'neutral'}>{u.role}</StatusBadge>,
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      cell: (u) => (
+        <StatusBadge tone={u.is_active ? 'success' : 'destructive'}>
+          {u.is_active ? 'Active' : 'Inactive'}
+        </StatusBadge>
+      ),
+    },
+    {
+      key: 'created_at',
+      header: 'Created',
+      cell: (u) => (
+        <span className="text-xs text-muted-foreground">
+          {u.created_at ? new Date(u.created_at).toLocaleDateString() : '—'}
+        </span>
+      ),
+    },
+    {
+      key: 'actions',
+      header: <span className="sr-only">Actions</span>,
+      width: '96px',
+      cell: (u) => (
+        <div className="flex gap-1">
+          <button
+            type="button"
+            onClick={() => onEdit(u)}
+            aria-label={`Edit ${u.full_name}`}
+            title="Edit"
+            className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted cursor-pointer"
+          >
+            <Edit className="h-4 w-4" />
+          </button>
+          {u.id !== currentUserId && (
+            u.is_active ? (
+              <button
+                type="button"
+                onClick={() => onDeactivate(u)}
+                aria-label={`Deactivate ${u.full_name}`}
+                title="Deactivate"
+                className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive cursor-pointer"
+              >
+                <UserX className="h-4 w-4" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => onReactivate(u)}
+                aria-label={`Reactivate ${u.full_name}`}
+                title="Reactivate"
+                className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-green-100 dark:hover:bg-green-900/20 hover:text-green-600 cursor-pointer"
+              >
+                <Users className="h-4 w-4" />
+              </button>
+            )
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <DataTable<UserRecord>
+      data={users}
+      columns={columns}
+      rowKey={(u) => u.id}
+      loading={isLoading}
+      emptyState="No users yet."
+    />
   );
 }

--- a/frontend/src/pages/reports/InventoryReportPage.tsx
+++ b/frontend/src/pages/reports/InventoryReportPage.tsx
@@ -5,7 +5,8 @@ import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
 import ReportControls from '@/components/ui/ReportControls';
 import { SkeletonTable } from '@/components/ui/Skeleton';
-import type { InventoryReport } from '@/types';
+import DataTable from '@/components/data/DataTable';
+import type { InventoryReport, StockLevelRow } from '@/types';
 
 const COLORS = ['#6366f1', '#8b5cf6', '#a78bfa', '#c4b5fd', '#ddd6fe', '#e0e7ff'];
 const formatTooltipCurrency = (value: string | number | readonly (string | number)[] | undefined) => {
@@ -67,36 +68,54 @@ export default function InventoryReportPage() {
 
           {/* Stock levels table */}
           {data.stock_levels.length > 0 && (
-            <div className="bg-card border border-border rounded-lg p-6">
-              <h3 className="text-lg font-semibold mb-4">Stock Levels</h3>
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-border text-left text-muted-foreground">
-                      <th className="px-4 py-2 font-medium">SKU</th>
-                      <th className="px-4 py-2 font-medium">Product</th>
-                      <th className="px-4 py-2 font-medium text-right">Stock</th>
-                      <th className="px-4 py-2 font-medium text-right">Unit Cost</th>
-                      <th className="px-4 py-2 font-medium text-right">Value</th>
-                      <th className="px-4 py-2 font-medium text-right">Reorder</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {data.stock_levels.map((row) => (
-                      <tr key={row.product_id} className="border-b border-border last:border-0 hover:bg-accent/50">
-                        <td className="px-4 py-2 font-mono text-xs">{row.sku}</td>
-                        <td className="px-4 py-2">{row.name}</td>
-                        <td className={`px-4 py-2 text-right ${row.is_low_stock ? 'text-amber-600 dark:text-amber-400 font-bold' : ''}`}>
-                          {row.stock_qty}
-                        </td>
-                        <td className="px-4 py-2 text-right">{formatCurrency(row.unit_cost)}</td>
-                        <td className="px-4 py-2 text-right">{formatCurrency(row.stock_value)}</td>
-                        <td className="px-4 py-2 text-right text-muted-foreground">{row.reorder_point}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+            <div className="space-y-3">
+              <h3 className="text-lg font-semibold">Stock Levels</h3>
+              <DataTable<StockLevelRow>
+                data={data.stock_levels}
+                rowKey={(row) => row.product_id}
+                columns={[
+                  {
+                    key: 'sku',
+                    header: 'SKU',
+                    cell: (row) => <span className="font-mono text-xs">{row.sku}</span>,
+                  },
+                  { key: 'name', header: 'Product', cell: (row) => row.name },
+                  {
+                    key: 'stock_qty',
+                    header: 'Stock',
+                    numeric: true,
+                    cell: (row) => (
+                      <span
+                        className={
+                          row.is_low_stock ? 'text-amber-600 dark:text-amber-400 font-bold' : ''
+                        }
+                      >
+                        {row.stock_qty}
+                      </span>
+                    ),
+                  },
+                  {
+                    key: 'unit_cost',
+                    header: 'Unit Cost',
+                    numeric: true,
+                    cell: (row) => formatCurrency(row.unit_cost),
+                  },
+                  {
+                    key: 'stock_value',
+                    header: 'Value',
+                    numeric: true,
+                    cell: (row) => formatCurrency(row.stock_value),
+                  },
+                  {
+                    key: 'reorder_point',
+                    header: 'Reorder',
+                    numeric: true,
+                    cell: (row) => (
+                      <span className="text-muted-foreground">{row.reorder_point}</span>
+                    ),
+                  },
+                ]}
+              />
             </div>
           )}
 

--- a/frontend/src/pages/reports/PLReportPage.tsx
+++ b/frontend/src/pages/reports/PLReportPage.tsx
@@ -5,7 +5,8 @@ import api from '@/api/client';
 import { formatCurrency, formatPercent } from '@/lib/utils';
 import ReportControls from '@/components/ui/ReportControls';
 import { SkeletonTable } from '@/components/ui/Skeleton';
-import type { PLReport } from '@/types';
+import DataTable from '@/components/data/DataTable';
+import type { PLReport, PLRow } from '@/types';
 
 const formatTooltipCurrency = (value: string | number | readonly (string | number)[] | undefined) => {
   const normalized = Array.isArray(value) ? value[0] : value;
@@ -130,42 +131,81 @@ export default function PLReportPage() {
 
           {/* Period table */}
           {data.period_data.length > 0 && (
-            <div className="bg-card border border-border rounded-lg p-6">
-              <h3 className="text-lg font-semibold mb-4">Period Detail</h3>
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-border text-left text-muted-foreground">
-                      <th className="px-3 py-2 font-medium">Period</th>
-                      <th className="px-3 py-2 font-medium text-right">Sales Rev</th>
-                      <th className="px-3 py-2 font-medium text-right">Prod Estimate</th>
-                      <th className="px-3 py-2 font-medium text-right">Materials</th>
-                      <th className="px-3 py-2 font-medium text-right">Labor</th>
-                      <th className="px-3 py-2 font-medium text-right">Machine</th>
-                      <th className="px-3 py-2 font-medium text-right">Overhead</th>
-                      <th className="px-3 py-2 font-medium text-right">Fees</th>
-                      <th className="px-3 py-2 font-medium text-right">Gross Profit</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {data.period_data.map((row) => (
-                      <tr key={row.period} className="border-b border-border last:border-0 hover:bg-accent/50">
-                        <td className="px-3 py-2 font-medium">{row.period}</td>
-                        <td className="px-3 py-2 text-right">{formatCurrency(row.sales_revenue)}</td>
-                        <td className="px-3 py-2 text-right text-muted-foreground">{formatCurrency(row.operational_production_estimate)}</td>
-                        <td className="px-3 py-2 text-right">{formatCurrency(row.material_costs)}</td>
-                        <td className="px-3 py-2 text-right">{formatCurrency(row.labor_costs)}</td>
-                        <td className="px-3 py-2 text-right">{formatCurrency(row.machine_costs)}</td>
-                        <td className="px-3 py-2 text-right">{formatCurrency(row.overhead_costs)}</td>
-                        <td className="px-3 py-2 text-right">{formatCurrency(row.platform_fees)}</td>
-                        <td className={`px-3 py-2 text-right font-semibold ${row.gross_profit >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                          {formatCurrency(row.gross_profit)}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+            <div className="space-y-3">
+              <h3 className="text-lg font-semibold">Period Detail</h3>
+              <DataTable<PLRow>
+                data={data.period_data}
+                rowKey={(row) => row.period}
+                columns={[
+                  {
+                    key: 'period',
+                    header: 'Period',
+                    cell: (row) => <span className="font-medium">{row.period}</span>,
+                  },
+                  {
+                    key: 'sales_revenue',
+                    header: 'Sales Rev',
+                    numeric: true,
+                    cell: (row) => formatCurrency(row.sales_revenue),
+                  },
+                  {
+                    key: 'operational_production_estimate',
+                    header: 'Prod Estimate',
+                    numeric: true,
+                    cell: (row) => (
+                      <span className="text-muted-foreground">
+                        {formatCurrency(row.operational_production_estimate)}
+                      </span>
+                    ),
+                  },
+                  {
+                    key: 'material_costs',
+                    header: 'Materials',
+                    numeric: true,
+                    cell: (row) => formatCurrency(row.material_costs),
+                  },
+                  {
+                    key: 'labor_costs',
+                    header: 'Labor',
+                    numeric: true,
+                    cell: (row) => formatCurrency(row.labor_costs),
+                  },
+                  {
+                    key: 'machine_costs',
+                    header: 'Machine',
+                    numeric: true,
+                    cell: (row) => formatCurrency(row.machine_costs),
+                  },
+                  {
+                    key: 'overhead_costs',
+                    header: 'Overhead',
+                    numeric: true,
+                    cell: (row) => formatCurrency(row.overhead_costs),
+                  },
+                  {
+                    key: 'platform_fees',
+                    header: 'Fees',
+                    numeric: true,
+                    cell: (row) => formatCurrency(row.platform_fees),
+                  },
+                  {
+                    key: 'gross_profit',
+                    header: 'Gross Profit',
+                    numeric: true,
+                    cell: (row) => (
+                      <span
+                        className={`font-semibold ${
+                          row.gross_profit >= 0
+                            ? 'text-green-600 dark:text-green-400'
+                            : 'text-red-600 dark:text-red-400'
+                        }`}
+                      >
+                        {formatCurrency(row.gross_profit)}
+                      </span>
+                    ),
+                  },
+                ]}
+              />
             </div>
           )}
         </div>

--- a/frontend/src/pages/reports/SalesReportPage.tsx
+++ b/frontend/src/pages/reports/SalesReportPage.tsx
@@ -5,7 +5,8 @@ import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
 import ReportControls from '@/components/ui/ReportControls';
 import { SkeletonTable } from '@/components/ui/Skeleton';
-import type { SalesReport } from '@/types';
+import DataTable from '@/components/data/DataTable';
+import type { SalesReport, ProductRanking, ChannelBreakdown } from '@/types';
 
 const formatTooltipCurrency = (value: string | number | readonly (string | number)[] | undefined) => {
   const normalized = Array.isArray(value) ? value[0] : value;
@@ -103,32 +104,38 @@ export default function SalesReportPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             {/* Top products */}
             {data.top_products.length > 0 && (
-              <div className="bg-card border border-border rounded-lg p-6">
-                <h3 className="text-lg font-semibold mb-4">Top Products</h3>
-                <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="border-b border-border text-left text-muted-foreground">
-                        <th className="pb-2 font-medium">Product</th>
-                        <th className="pb-2 font-medium text-right">Units</th>
-                        <th className="pb-2 font-medium text-right">Gross Sales</th>
-                        <th className="pb-2 font-medium text-right">Contribution</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {data.top_products.map((p, i) => (
-                        <tr key={i} className="border-b border-border last:border-0">
-                          <td className="py-2">{p.description}</td>
-                          <td className="py-2 text-right">{p.units_sold}</td>
-                          <td className="py-2 text-right">{formatCurrency(p.gross_sales)}</td>
-                          <td className={`py-2 text-right ${p.contribution_margin >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                            {formatCurrency(p.contribution_margin)}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+              <div className="space-y-3">
+                <h3 className="text-lg font-semibold">Top Products</h3>
+                <DataTable<ProductRanking & { _idx: number }>
+                  data={data.top_products.map((p, i) => ({ ...p, _idx: i }))}
+                  rowKey={(p) => String(p._idx)}
+                  columns={[
+                    { key: 'description', header: 'Product', cell: (p) => p.description },
+                    { key: 'units_sold', header: 'Units', numeric: true, cell: (p) => p.units_sold },
+                    {
+                      key: 'gross_sales',
+                      header: 'Gross Sales',
+                      numeric: true,
+                      cell: (p) => formatCurrency(p.gross_sales),
+                    },
+                    {
+                      key: 'contribution_margin',
+                      header: 'Contribution',
+                      numeric: true,
+                      cell: (p) => (
+                        <span
+                          className={
+                            p.contribution_margin >= 0
+                              ? 'text-green-600 dark:text-green-400'
+                              : 'text-red-600 dark:text-red-400'
+                          }
+                        >
+                          {formatCurrency(p.contribution_margin)}
+                        </span>
+                      ),
+                    },
+                  ]}
+                />
               </div>
             )}
 
@@ -147,33 +154,49 @@ export default function SalesReportPage() {
                     <Bar dataKey="contribution_margin" name="Contribution Margin" fill="#10b981" radius={[4, 4, 0, 0]} />
                   </BarChart>
                 </ResponsiveContainer>
-                <div className="mt-4 overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="border-b border-border text-left text-muted-foreground">
-                        <th className="pb-2 font-medium">Channel</th>
-                        <th className="pb-2 font-medium text-right">Orders</th>
-                        <th className="pb-2 font-medium text-right">Gross Sales</th>
-                        <th className="pb-2 font-medium text-right">Gross Profit</th>
-                        <th className="pb-2 font-medium text-right">Fees</th>
-                        <th className="pb-2 font-medium text-right">Shipping</th>
-                        <th className="pb-2 font-medium text-right">Contribution</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {data.channel_breakdown.map((ch, i) => (
-                        <tr key={i} className="border-b border-border last:border-0">
-                          <td className="py-2">{ch.channel_name}</td>
-                          <td className="py-2 text-right">{ch.order_count}</td>
-                          <td className="py-2 text-right">{formatCurrency(ch.gross_sales)}</td>
-                          <td className="py-2 text-right">{formatCurrency(ch.gross_profit)}</td>
-                          <td className="py-2 text-right text-muted-foreground">{formatCurrency(ch.platform_fees)}</td>
-                          <td className="py-2 text-right text-muted-foreground">{formatCurrency(ch.shipping_costs)}</td>
-                          <td className="py-2 text-right">{formatCurrency(ch.contribution_margin)}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                <div className="mt-4">
+                  <DataTable<ChannelBreakdown & { _idx: number }>
+                    data={data.channel_breakdown.map((ch, i) => ({ ...ch, _idx: i }))}
+                    rowKey={(ch) => String(ch._idx)}
+                    columns={[
+                      { key: 'channel_name', header: 'Channel', cell: (ch) => ch.channel_name },
+                      { key: 'order_count', header: 'Orders', numeric: true, cell: (ch) => ch.order_count },
+                      {
+                        key: 'gross_sales',
+                        header: 'Gross Sales',
+                        numeric: true,
+                        cell: (ch) => formatCurrency(ch.gross_sales),
+                      },
+                      {
+                        key: 'gross_profit',
+                        header: 'Gross Profit',
+                        numeric: true,
+                        cell: (ch) => formatCurrency(ch.gross_profit),
+                      },
+                      {
+                        key: 'platform_fees',
+                        header: 'Fees',
+                        numeric: true,
+                        cell: (ch) => (
+                          <span className="text-muted-foreground">{formatCurrency(ch.platform_fees)}</span>
+                        ),
+                      },
+                      {
+                        key: 'shipping_costs',
+                        header: 'Shipping',
+                        numeric: true,
+                        cell: (ch) => (
+                          <span className="text-muted-foreground">{formatCurrency(ch.shipping_costs)}</span>
+                        ),
+                      },
+                      {
+                        key: 'contribution_margin',
+                        header: 'Contribution',
+                        numeric: true,
+                        cell: (ch) => formatCurrency(ch.contribution_margin),
+                      },
+                    ]}
+                  />
                 </div>
               </div>
             )}


### PR DESCRIPTION
Closes #179.

## Summary

Replaces hand-rolled `<table>` markup on **6 pages** with the shared `<DataTable>` primitive. Every migrated page now gets compact 32px rows, sticky header, built-in loading skeleton, empty state, responsive column hiding, and tabular-nums on numeric columns for free.

## Files touched

| Page | Columns |
| --- | --- |
| `admin/UsersPage` | Name · Email · Role · Status · Created · Actions |
| `SalesChannelsPage` | Name · Fee % · Fixed Fee · Status · Actions |
| `admin/CamerasPage` | Name · Stream · Printer · Status · Actions |
| `reports/SalesReportPage` | Top Products + Channel Breakdown tables |
| `reports/InventoryReportPage` | Stock Levels table |
| `reports/PLReportPage` | Period Detail table |

Detail pages (PrinterDetailPage, SaleDetailPage, ProductDetailPage) keep raw `<table>` per the issue's guidance — they render transaction logs and line items, not lists.

## Acceptance (#179)

- [x] `rg "<table" frontend/src/pages` → only 3 detail pages (whitelisted)
- [x] Row density 32px, sticky header, loading skeleton, empty state on every migrated page
- [x] Numeric columns auto-right-align with `tabular-nums` via `numeric: true`
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Admin users: create + edit + deactivate/reactivate; verify current-user "(you)" marker and gating
- [ ] Sales channels: toggle active state from the clickable status cell
- [ ] Cameras: edit camera, toggle deactivate, verify responsive column hiding at narrow widths
- [ ] Sales report: verify Top Products and Channel Breakdown numbers and green/red contribution coloring
- [ ] Inventory report: verify low-stock amber highlight on Stock column
- [ ] P&L report: verify Gross Profit green/red coloring per period

🤖 Generated with [Claude Code](https://claude.com/claude-code)