### PR TITLE
feat(ui): rebuild DashboardPage with PageHeader + KPIStrip (#176)

### DIFF
--- a/frontend/src/components/charts/ChartTooltip.tsx
+++ b/frontend/src/components/charts/ChartTooltip.tsx
@@ -1,0 +1,41 @@
+import { Tooltip } from 'recharts';
+import type { ComponentProps } from 'react';
+
+/**
+ * Shared content style for recharts tooltips. Business-app neutral: card
+ * background, border token, soft corner, compact typography. Re-use via
+ * the `<ChartTooltip>` wrapper or spread into `contentStyle={...}` when a
+ * chart needs additional overrides recharts doesn't pass through.
+ */
+export const chartTooltipContentStyle = {
+  backgroundColor: 'var(--color-card)',
+  border: '1px solid var(--color-border)',
+  borderRadius: '8px',
+  fontSize: '12px',
+  color: 'var(--color-foreground)',
+} as const;
+
+type ChartTooltipProps = ComponentProps<typeof Tooltip>;
+
+/**
+ * Consistent recharts tooltip. Pass the same formatter / labelFormatter you
+ * would pass to recharts' built-in `<Tooltip>`; the content style is applied
+ * automatically so every chart in the app matches.
+ */
+export function ChartTooltip(props: ChartTooltipProps) {
+  return <Tooltip contentStyle={chartTooltipContentStyle} {...props} />;
+}
+
+/**
+ * Palette derived from the trust-blue primary. Use for categorical series
+ * (pie slices, multi-series bars) so charts never drift off-brand. Ordered
+ * for legibility when the first N colors are used.
+ */
+export const chartCategoricalPalette = [
+  '#2563eb', // primary trust-blue
+  '#0ea5e9', // sky-500
+  '#14b8a6', // teal-500
+  '#64748b', // slate-500
+  '#94a3b8', // slate-400
+  '#475569', // slate-600
+] as const;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,13 +1,48 @@
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
-import { BarChart3, Package, DollarSign, TrendingUp, Layers, Award, AlertTriangle, ShoppingCart } from 'lucide-react';
-import { BarChart, Bar, LineChart, Line, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import {
+  AlertTriangle,
+  Award,
+  BarChart3,
+  DollarSign,
+  Layers,
+  Package,
+  ShoppingCart,
+  TrendingUp,
+} from 'lucide-react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from 'recharts';
 import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
+import { ChartTooltip, chartCategoricalPalette } from '@/components/charts/ChartTooltip';
+import EmptyState from '@/components/ui/EmptyState';
+import { SkeletonCard } from '@/components/ui/Skeleton';
 import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import { formatCurrency, formatPercent } from '@/lib/utils';
-import type { DashboardSummary, FinanceDashboardSummary, RevenueDataPoint, MaterialUsageDataPoint, ProfitMarginDataPoint, InventoryAlert, PaginatedPrinters, Printer, SalesMetrics } from '@/types';
+import type {
+  DashboardSummary,
+  FinanceDashboardSummary,
+  InventoryAlert,
+  MaterialUsageDataPoint,
+  PaginatedPrinters,
+  Printer,
+  ProfitMarginDataPoint,
+  RevenueDataPoint,
+  SalesMetrics,
+} from '@/types';
 
-const COLORS = ['#6366f1', '#8b5cf6', '#a78bfa', '#c4b5fd', '#ddd6fe'];
 const formatTooltipCurrency = (value: string | number | readonly (string | number)[] | undefined) => {
   const normalized = Array.isArray(value) ? value[0] : value;
   return formatCurrency(Number(normalized ?? 0));
@@ -26,26 +61,10 @@ const formatDuration = (seconds: number | null | undefined) => {
 };
 const formatLayer = (printer: Printer) => {
   if (printer.monitor_current_layer == null && printer.monitor_total_layers == null) return '—';
-  if (printer.monitor_current_layer != null && printer.monitor_total_layers != null) return `${printer.monitor_current_layer}/${printer.monitor_total_layers}`;
+  if (printer.monitor_current_layer != null && printer.monitor_total_layers != null)
+    return `${printer.monitor_current_layer}/${printer.monitor_total_layers}`;
   return String(printer.monitor_current_layer ?? printer.monitor_total_layers ?? '—');
 };
-
-function StatCard({ icon: Icon, label, value, sub }: {
-  icon: React.ElementType; label: string; value: string; sub?: string;
-}) {
-  return (
-    <div className="bg-card border border-border rounded-lg p-6 flex items-start gap-4">
-      <div className="p-3 rounded-lg bg-primary/10 text-primary">
-        <Icon className="w-6 h-6" />
-      </div>
-      <div>
-        <p className="text-sm text-muted-foreground">{label}</p>
-        <p className="text-2xl font-bold mt-1">{value}</p>
-        {sub && <p className="text-xs text-muted-foreground mt-1">{sub}</p>}
-      </div>
-    </div>
-  );
-}
 
 export default function DashboardPage() {
   const { data, isLoading } = useQuery<DashboardSummary>({
@@ -91,10 +110,11 @@ export default function DashboardPage() {
 
   if (isLoading) {
     return (
-      <div className="space-y-8">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="space-y-6">
+        <PageHeader title="Dashboard" description="Live snapshot of jobs, revenue, inventory, and printers." />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="bg-card border border-border rounded-lg p-6 h-28 animate-pulse" />
+            <SkeletonCard key={i} rows={1} />
           ))}
         </div>
       </div>
@@ -104,57 +124,79 @@ export default function DashboardPage() {
   if (!data) return null;
 
   return (
-    <div className="space-y-8">
-      <h1 className="text-3xl font-bold">Dashboard</h1>
+    <div className="space-y-6">
+      <PageHeader
+        title="Dashboard"
+        description="Live snapshot of jobs, revenue, inventory, and printers."
+      />
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        <StatCard icon={BarChart3} label="Total Jobs" value={String(data.total_jobs)} />
-        <StatCard icon={Package} label="Total Pieces" value={String(data.total_pieces)} />
-        <StatCard icon={DollarSign} label="Total Revenue" value={formatCurrency(data.total_revenue)} />
-        <StatCard icon={Layers} label="Total Costs" value={formatCurrency(data.total_costs)} />
-        <StatCard icon={TrendingUp} label="Net Profit" value={formatCurrency(data.total_net_profit)}
-          sub={`Avg margin: ${formatPercent(data.avg_margin_pct)}`} />
-        <StatCard icon={Award} label="Top Material" value={data.top_material || 'N/A'}
-          sub={`Avg profit/piece: ${formatCurrency(data.avg_profit_per_piece)}`} />
-      </div>
+      <KPIStrip columns={3}>
+        <KPI icon={<BarChart3 className="h-4 w-4" />} label="Total jobs" value={data.total_jobs.toLocaleString()} />
+        <KPI icon={<Package className="h-4 w-4" />} label="Total pieces" value={data.total_pieces.toLocaleString()} />
+        <KPI icon={<DollarSign className="h-4 w-4" />} label="Total revenue" value={formatCurrency(data.total_revenue)} />
+        <KPI icon={<Layers className="h-4 w-4" />} label="Total costs" value={formatCurrency(data.total_costs)} />
+        <KPI
+          icon={<TrendingUp className="h-4 w-4" />}
+          label="Net profit"
+          value={formatCurrency(data.total_net_profit)}
+          sub={`Avg margin ${formatPercent(data.avg_margin_pct)}`}
+          tone={data.total_net_profit >= 0 ? 'success' : 'destructive'}
+        />
+        <KPI
+          icon={<Award className="h-4 w-4" />}
+          label="Top material"
+          value={data.top_material || '—'}
+          sub={`Avg profit/piece ${formatCurrency(data.avg_profit_per_piece)}`}
+        />
+      </KPIStrip>
 
       {/* Inventory Alerts */}
-      {alerts && alerts.length > 0 && (
-        <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
-          <div className="flex items-center gap-2 mb-3">
-            <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400" />
-            <h3 className="font-semibold text-amber-800 dark:text-amber-300">Low Stock Alerts</h3>
+      {alerts && alerts.length > 0 ? (
+        <section className="rounded-md border border-amber-300/60 bg-amber-50/80 p-4 dark:border-amber-500/30 dark:bg-amber-500/10">
+          <div className="mb-3 flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+            <h2 className="text-sm font-semibold text-amber-800 dark:text-amber-300">Low stock alerts</h2>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
             {alerts.map((a) => (
               <Link
                 key={`${a.type}-${a.id}`}
                 to={a.type === 'product' ? `/products/${a.id}` : '/materials'}
-                className="flex items-center justify-between bg-white/60 dark:bg-white/5 rounded-md px-3 py-2 text-sm hover:bg-white/80 dark:hover:bg-white/10 transition-colors"
+                className="flex items-center justify-between rounded-md bg-card px-3 py-2 text-sm no-underline transition-colors hover:bg-muted"
               >
-                <div>
-                  <p className="font-medium">{a.name}</p>
-                  <p className="text-xs text-muted-foreground">{a.type === 'product' ? a.sku : 'Material'}</p>
+                <div className="min-w-0">
+                  <p className="truncate font-medium text-foreground">{a.name}</p>
+                  <p className="truncate text-xs text-muted-foreground">{a.type === 'product' ? a.sku : 'Material'}</p>
                 </div>
-                <span className="text-amber-600 dark:text-amber-400 font-bold">{a.current_stock}</span>
+                <span className="shrink-0 font-semibold tabular-nums text-amber-700 dark:text-amber-300">
+                  {a.current_stock}
+                </span>
               </Link>
             ))}
           </div>
-        </div>
-      )}
+        </section>
+      ) : null}
 
       {printersData?.items?.length ? (
-        <div className="bg-card border border-border rounded-lg p-6">
+        <section className="rounded-md border border-border bg-card p-6 shadow-xs">
           <div className="mb-4 flex items-start justify-between gap-3">
             <div>
-              <h2 className="text-xl font-semibold">Printer live board</h2>
-              <p className="text-sm text-muted-foreground">Quick view of monitored printers, progress, layers, ETA, and Moonraker socket freshness.</p>
+              <h2 className="text-base font-semibold">Printer live board</h2>
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                Monitored printers, progress, layers, ETA, and Moonraker socket freshness.
+              </p>
             </div>
-            <Link to="/printers" className="text-sm text-primary no-underline hover:underline">Open printers</Link>
+            <Link to="/printers" className="text-sm text-primary no-underline hover:underline">
+              Open printers
+            </Link>
           </div>
           <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 xl:grid-cols-3">
             {printersData.items.map((printer) => (
-              <Link key={printer.id} to={`/printers/${printer.id}`} className="rounded-lg border border-border bg-background/40 p-4 no-underline hover:bg-accent/50 transition-colors">
+              <Link
+                key={printer.id}
+                to={`/printers/${printer.id}`}
+                className="rounded-md border border-border bg-background p-4 no-underline transition-colors hover:bg-muted"
+              >
                 <div className="flex gap-3">
                   <PrinterThumbnail
                     src={printer.current_print_thumbnail_url}
@@ -167,122 +209,195 @@ export default function DashboardPage() {
                     <div className="flex items-center justify-between gap-3">
                       <div className="min-w-0">
                         <p className="truncate font-semibold text-foreground">{printer.name}</p>
-                        <p className="truncate text-xs text-muted-foreground" title={`${printer.monitor_provider || 'static'} · ${printer.monitor_status || printer.status}`}>{printer.monitor_provider || 'static'} · {printer.monitor_status || printer.status}</p>
+                        <p
+                          className="truncate text-xs text-muted-foreground"
+                          title={`${printer.monitor_provider || 'static'} · ${printer.monitor_status || printer.status}`}
+                        >
+                          {printer.monitor_provider || 'static'} · {printer.monitor_status || printer.status}
+                        </p>
                       </div>
-                      <span className="text-sm font-semibold text-foreground">{printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}</span>
+                      <span className="text-sm font-semibold tabular-nums text-foreground">
+                        {printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}
+                      </span>
                     </div>
                     <div className="mt-3 space-y-1 text-sm text-muted-foreground">
-                      <p className="truncate" title={printer.current_print_name || 'No active file'}>{printer.current_print_name || 'No active file'}</p>
-                      <p className="truncate" title={`Layer ${formatLayer(printer)} · Remaining ${formatDuration(printer.monitor_remaining_seconds)}`}>Layer {formatLayer(printer)} · Remaining {formatDuration(printer.monitor_remaining_seconds)}</p>
-                      <p className="truncate" title={printer.monitor_provider === 'moonraker' ? (printer.monitor_ws_connected ? 'WebSocket live' : 'Polling fallback') : 'HTTP polling / static'}>{printer.monitor_provider === 'moonraker' ? (printer.monitor_ws_connected ? 'WebSocket live' : 'Polling fallback') : 'HTTP polling / static'}</p>
+                      <p className="truncate" title={printer.current_print_name || 'No active file'}>
+                        {printer.current_print_name || 'No active file'}
+                      </p>
+                      <p
+                        className="truncate"
+                        title={`Layer ${formatLayer(printer)} · Remaining ${formatDuration(printer.monitor_remaining_seconds)}`}
+                      >
+                        Layer {formatLayer(printer)} · Remaining {formatDuration(printer.monitor_remaining_seconds)}
+                      </p>
+                      <p
+                        className="truncate"
+                        title={
+                          printer.monitor_provider === 'moonraker'
+                            ? printer.monitor_ws_connected
+                              ? 'WebSocket live'
+                              : 'Polling fallback'
+                            : 'HTTP polling / static'
+                        }
+                      >
+                        {printer.monitor_provider === 'moonraker'
+                          ? printer.monitor_ws_connected
+                            ? 'WebSocket live'
+                            : 'Polling fallback'
+                          : 'HTTP polling / static'}
+                      </p>
                     </div>
                   </div>
                 </div>
               </Link>
             ))}
           </div>
-        </div>
+        </section>
       ) : null}
 
       {/* Finance Metrics */}
-      {financeData && (
-        <div>
-          <h2 className="text-xl font-semibold mb-4">Finance Overview</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <StatCard icon={DollarSign} label="Cash on Hand" value={formatCurrency(financeData.cash_on_hand)} />
-            <StatCard icon={TrendingUp} label="Current Month Net Income" value={formatCurrency(financeData.current_month_net_income)} />
-            <StatCard icon={BarChart3} label="Unpaid Invoices" value={formatCurrency(financeData.unpaid_invoices)} />
-            <StatCard icon={Layers} label="Unpaid Bills" value={formatCurrency(financeData.unpaid_bills)} />
-            <StatCard icon={Package} label="Inventory Asset Value" value={formatCurrency(financeData.inventory_asset_value)} />
-            <StatCard icon={AlertTriangle} label="Tax Payable" value={formatCurrency(financeData.tax_payable)} />
-            <StatCard icon={ShoppingCart} label="Payouts in Transit" value={formatCurrency(financeData.payouts_in_transit)} />
-          </div>
-        </div>
-      )}
+      {financeData ? (
+        <section>
+          <h2 className="mb-3 text-base font-semibold">Finance overview</h2>
+          <KPIStrip columns={4}>
+            <KPI icon={<DollarSign className="h-4 w-4" />} label="Cash on hand" value={formatCurrency(financeData.cash_on_hand)} />
+            <KPI
+              icon={<TrendingUp className="h-4 w-4" />}
+              label="Month net income"
+              value={formatCurrency(financeData.current_month_net_income)}
+              tone={financeData.current_month_net_income >= 0 ? 'success' : 'destructive'}
+            />
+            <KPI icon={<BarChart3 className="h-4 w-4" />} label="Unpaid invoices" value={formatCurrency(financeData.unpaid_invoices)} />
+            <KPI icon={<Layers className="h-4 w-4" />} label="Unpaid bills" value={formatCurrency(financeData.unpaid_bills)} />
+            <KPI icon={<Package className="h-4 w-4" />} label="Inventory asset value" value={formatCurrency(financeData.inventory_asset_value)} />
+            <KPI
+              icon={<AlertTriangle className="h-4 w-4" />}
+              label="Tax payable"
+              value={formatCurrency(financeData.tax_payable)}
+              tone={financeData.tax_payable > 0 ? 'warning' : 'default'}
+            />
+            <KPI icon={<ShoppingCart className="h-4 w-4" />} label="Payouts in transit" value={formatCurrency(financeData.payouts_in_transit)} />
+          </KPIStrip>
+        </section>
+      ) : null}
 
       {/* Sales Metrics */}
-      {salesMetrics && salesMetrics.total_sales > 0 && (
-        <div>
-          <h2 className="text-xl font-semibold mb-4">Sales Overview</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <StatCard icon={ShoppingCart} label="Total Orders" value={String(salesMetrics.total_sales)} />
-            <StatCard icon={DollarSign} label="Gross Sales" value={formatCurrency(salesMetrics.gross_sales)} />
-            <StatCard icon={Layers} label="Item COGS" value={formatCurrency(salesMetrics.item_cogs)} />
-            <StatCard icon={TrendingUp} label="Gross Profit" value={formatCurrency(salesMetrics.gross_profit)} />
-            <StatCard icon={DollarSign} label="Platform Fees + Shipping" value={formatCurrency(salesMetrics.platform_fees + salesMetrics.shipping_costs)} />
-            <StatCard icon={BarChart3} label="Contribution Margin" value={formatCurrency(salesMetrics.contribution_margin)}
-              sub={salesMetrics.refund_count > 0 ? `${salesMetrics.refund_count} refund(s)` : 'Net profit pending overhead allocation'} />
-          </div>
-          {salesMetrics.revenue_by_channel.length > 1 && (
-            <div className="mt-4 bg-card border border-border rounded-lg p-6">
-              <h3 className="text-lg font-semibold mb-4">Revenue by Channel</h3>
+      {salesMetrics && salesMetrics.total_sales > 0 ? (
+        <section>
+          <h2 className="mb-3 text-base font-semibold">Sales overview</h2>
+          <KPIStrip columns={3}>
+            <KPI icon={<ShoppingCart className="h-4 w-4" />} label="Total orders" value={salesMetrics.total_sales.toLocaleString()} />
+            <KPI icon={<DollarSign className="h-4 w-4" />} label="Gross sales" value={formatCurrency(salesMetrics.gross_sales)} />
+            <KPI icon={<Layers className="h-4 w-4" />} label="Item COGS" value={formatCurrency(salesMetrics.item_cogs)} />
+            <KPI
+              icon={<TrendingUp className="h-4 w-4" />}
+              label="Gross profit"
+              value={formatCurrency(salesMetrics.gross_profit)}
+              tone={salesMetrics.gross_profit >= 0 ? 'success' : 'destructive'}
+            />
+            <KPI
+              icon={<DollarSign className="h-4 w-4" />}
+              label="Platform fees + shipping"
+              value={formatCurrency(salesMetrics.platform_fees + salesMetrics.shipping_costs)}
+            />
+            <KPI
+              icon={<BarChart3 className="h-4 w-4" />}
+              label="Contribution margin"
+              value={formatCurrency(salesMetrics.contribution_margin)}
+              sub={salesMetrics.refund_count > 0 ? `${salesMetrics.refund_count} refund(s)` : 'Net pending overhead allocation'}
+            />
+          </KPIStrip>
+
+          {salesMetrics.revenue_by_channel.length > 1 ? (
+            <div className="mt-4 rounded-md border border-border bg-card p-6 shadow-xs">
+              <h3 className="mb-4 text-base font-semibold">Revenue by channel</h3>
               <ResponsiveContainer width="100%" height={220}>
                 <BarChart data={salesMetrics.revenue_by_channel}>
                   <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
                   <XAxis dataKey="channel_name" tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" />
                   <YAxis tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" tickFormatter={(v) => `$${v}`} />
-                  <Tooltip formatter={formatTooltipCurrency} contentStyle={{ backgroundColor: 'var(--color-card)', border: '1px solid var(--color-border)', borderRadius: '8px' }} />
+                  <ChartTooltip formatter={formatTooltipCurrency} />
                   <Bar dataKey="gross_sales" fill="var(--color-primary)" radius={[4, 4, 0, 0]} />
                 </BarChart>
               </ResponsiveContainer>
             </div>
-          )}
-        </div>
-      )}
+          ) : null}
+        </section>
+      ) : null}
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         {/* Revenue Over Time */}
-        <div className="bg-card border border-border rounded-lg p-6">
-          <h3 className="text-lg font-semibold mb-4">Revenue Over Time</h3>
+        <div className="rounded-md border border-border bg-card p-6 shadow-xs">
+          <h3 className="mb-4 text-base font-semibold">Revenue over time</h3>
           {revenueData && revenueData.length > 0 ? (
             <ResponsiveContainer width="100%" height={280}>
               <LineChart data={revenueData}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
                 <XAxis dataKey="date" tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" />
                 <YAxis tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" tickFormatter={(v) => `$${v}`} />
-                <Tooltip formatter={formatTooltipCurrency} contentStyle={{ backgroundColor: 'var(--color-card)', border: '1px solid var(--color-border)', borderRadius: '8px' }} />
+                <ChartTooltip formatter={formatTooltipCurrency} />
                 <Line type="monotone" dataKey="revenue" stroke="var(--color-primary)" strokeWidth={2} dot={{ r: 4 }} />
               </LineChart>
             </ResponsiveContainer>
           ) : (
-            <p className="text-muted-foreground text-sm py-12 text-center">No revenue data yet</p>
+            <EmptyState
+              icon="reports"
+              title="No revenue data yet"
+              description="Complete a sale to populate this chart."
+            />
           )}
         </div>
 
         {/* Material Usage */}
-        <div className="bg-card border border-border rounded-lg p-6">
-          <h3 className="text-lg font-semibold mb-4">Material Usage</h3>
+        <div className="rounded-md border border-border bg-card p-6 shadow-xs">
+          <h3 className="mb-4 text-base font-semibold">Material usage</h3>
           {materialData && materialData.length > 0 ? (
             <ResponsiveContainer width="100%" height={280}>
               <PieChart>
-                <Pie data={materialData} dataKey="count" nameKey="material" cx="50%" cy="50%" outerRadius={100} label={(props) => `${String(props.name ?? '')} (${String(props.value ?? 0)})`}>
+                <Pie
+                  data={materialData}
+                  dataKey="count"
+                  nameKey="material"
+                  cx="50%"
+                  cy="50%"
+                  outerRadius={100}
+                  label={(props) => `${String(props.name ?? '')} (${String(props.value ?? 0)})`}
+                >
                   {materialData.map((_, i) => (
-                    <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                    <Cell key={i} fill={chartCategoricalPalette[i % chartCategoricalPalette.length]} />
                   ))}
                 </Pie>
-                <Tooltip contentStyle={{ backgroundColor: 'var(--color-card)', border: '1px solid var(--color-border)', borderRadius: '8px' }} />
+                <ChartTooltip />
               </PieChart>
             </ResponsiveContainer>
           ) : (
-            <p className="text-muted-foreground text-sm py-12 text-center">No material data yet</p>
+            <EmptyState
+              icon="materials"
+              title="No material data yet"
+              description="Log a job to see material usage distribution."
+            />
           )}
         </div>
 
         {/* Profit Margins */}
-        <div className="bg-card border border-border rounded-lg p-6 lg:col-span-2">
-          <h3 className="text-lg font-semibold mb-4">Profit Margin by Job</h3>
+        <div className="rounded-md border border-border bg-card p-6 shadow-xs lg:col-span-2">
+          <h3 className="mb-4 text-base font-semibold">Profit margin by job</h3>
           {marginData && marginData.length > 0 ? (
             <ResponsiveContainer width="100%" height={280}>
               <BarChart data={marginData}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
                 <XAxis dataKey="product" tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" />
                 <YAxis tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" tickFormatter={(v) => `${v}%`} />
-                <Tooltip formatter={formatTooltipPercent} contentStyle={{ backgroundColor: 'var(--color-card)', border: '1px solid var(--color-border)', borderRadius: '8px' }} />
+                <ChartTooltip formatter={formatTooltipPercent} />
                 <Bar dataKey="margin" fill="var(--color-primary)" radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           ) : (
-            <p className="text-muted-foreground text-sm py-12 text-center">No margin data yet</p>
+            <EmptyState
+              icon="reports"
+              title="No margin data yet"
+              description="Complete jobs with cost + price data to see per-job profitability."
+            />
           )}
         </div>
       </div>


### PR DESCRIPTION
Closes #176. **Final P0 in epic #173.**

## Summary

- `PageHeader` replaces bespoke `<h1 text-3xl font-bold>Dashboard</h1>`
- `KPIStrip` + `<KPI>` replaces the hobbyist `StatCard` chip-icon grid across 3 sections (summary, Finance, Sales) — 20+ KPIs now dense and tabular-nums-correct
- Extracted shared `<ChartTooltip>` + `chartCategoricalPalette` in `frontend/src/components/charts/ChartTooltip.tsx` — every recharts `<Tooltip>` in Dashboard now flows through it
- Pie chart palette swapped from off-brand purple → blue-derived categorical
- Chart empty states → `<EmptyState>`
- Loading state → `<SkeletonCard>`
- Removed translucent `bg-white/60` / `bg-card/80` — solid surfaces per system
- Tone signals on Net profit / Month net income / Gross profit / Tax payable KPIs so positives are emerald, negatives destructive, warnings amber

## Acceptance (#176)

- [x] Dashboard uses PageHeader + KPIStrip
- [x] Pie palette derived from primary
- [x] All charts share `<ChartTooltip>`
- [x] Chart empty states use `<EmptyState>`
- [x] `rg 'text-3xl font-bold' frontend/src/pages/DashboardPage.tsx` → 0
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Dashboard loads — KPI rows render at correct density (`text-lg` values, no 2xl/3xl bursts)
- [ ] Net profit shows emerald when positive, destructive when negative
- [ ] Revenue Over Time / Material Usage / Profit Margin charts render tooltips with consistent styling
- [ ] Empty data states (fresh install) show the new EmptyState cards, not raw grey text
- [ ] Low-stock alert panel still navigates per-row to product or materials

🤖 Generated with [Claude Code](https://claude.com/claude-code)