### PR TITLE
feat(ui): revamp InsightsPage + CalculatorPage (#209)

### DIFF
--- a/frontend/src/pages/CalculatorPage.tsx
+++ b/frontend/src/pages/CalculatorPage.tsx
@@ -1,35 +1,14 @@
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { Calculator } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
 import { formatCurrency } from '@/lib/utils';
 import type { Material, CalculateResponse } from '@/types';
-
-interface CalcFieldProps {
-  label: string;
-  field: string;
-  value: number;
-  onChange: (field: string, value: number) => void;
-  [k: string]: any;
-}
-
-function CalcField({ label, field, value, onChange, ...rest }: CalcFieldProps) {
-  return (
-    <div>
-      <label className="block text-sm font-medium mb-1.5">{label}</label>
-      <input
-        type="number"
-        value={value}
-        onChange={(e) => onChange(field, Number(e.target.value))}
-        className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-        {...rest}
-      />
-    </div>
-  );
-}
 
 export default function CalculatorPage() {
   const navigate = useNavigate();
@@ -69,7 +48,8 @@ export default function CalculatorPage() {
     return () => clearTimeout(timer);
   }, [form]);
 
-  const update = (field: string, value: number | string) => setForm((f) => ({ ...f, [field]: value }));
+  const update = (field: string, value: number | string) =>
+    setForm((f) => ({ ...f, [field]: value }));
 
   const saveAsJob = () => {
     const params = new URLSearchParams();
@@ -80,46 +60,126 @@ export default function CalculatorPage() {
   };
 
   return (
-    <div className="max-w-5xl mx-auto">
-      <div className="flex items-center gap-3 mb-8">
-        <Calculator className="w-8 h-8 text-primary" />
-        <h1 className="text-3xl font-bold">Cost Calculator</h1>
-      </div>
+    <div className="space-y-6">
+      <PageHeader
+        title="Cost Calculator"
+        description="Estimate material, labor, and machine costs for a print job before committing to production."
+      />
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        <div className="lg:col-span-2 space-y-6">
-          <div className="bg-card border border-border rounded-lg p-6">
-            <h3 className="text-lg font-semibold mb-4">Print Parameters</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium mb-1.5">Material</label>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="space-y-6 lg:col-span-2">
+          {/* Print Parameters */}
+          <section className="rounded-md border border-border bg-card p-5 shadow-xs space-y-4">
+            <h2 className="text-base font-semibold">Print parameters</h2>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="calc-material">Material</Label>
                 <select
+                  id="calc-material"
                   value={form.material_id}
                   onChange={(e) => update('material_id', e.target.value)}
-                  className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                 >
-                  <option value="">Select material...</option>
+                  <option value="">Select material…</option>
                   {materials?.map((m) => (
-                    <option key={m.id} value={m.id}>{m.name} ({m.brand}) — ${Number(m.cost_per_g).toFixed(4)}/g</option>
+                    <option key={m.id} value={m.id}>
+                      {m.name} ({m.brand}) — ${Number(m.cost_per_g).toFixed(4)}/g
+                    </option>
                   ))}
                 </select>
               </div>
-              <CalcField label="Qty per Plate" field="qty_per_plate" value={form.qty_per_plate} onChange={update} min={1} />
-              <CalcField label="Number of Plates" field="num_plates" value={form.num_plates} onChange={update} min={1} />
-              <CalcField label="Material per Plate (g)" field="material_per_plate_g" value={form.material_per_plate_g} onChange={update} min={0} step="0.01" />
-              <CalcField label="Print Time per Plate (hrs)" field="print_time_per_plate_hrs" value={form.print_time_per_plate_hrs} onChange={update} min={0} step="0.01" />
-            </div>
-          </div>
 
-          <div className="bg-card border border-border rounded-lg p-6">
-            <h3 className="text-lg font-semibold mb-4">Labor & Costs</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <CalcField label="Labor Time (mins)" field="labor_mins" value={form.labor_mins} onChange={update} min={0} />
-              <CalcField label="Design Time (hrs)" field="design_time_hrs" value={form.design_time_hrs} onChange={update} min={0} step="0.01" />
-              <CalcField label="Shipping Cost ($)" field="shipping_cost" value={form.shipping_cost} onChange={update} min={0} step="0.01" />
-              <div>
-                <label className="block text-sm font-medium mb-1.5">Target Margin: {form.target_margin_pct}%</label>
+              <div className="space-y-1.5">
+                <Label htmlFor="calc-qty-per-plate">Qty per plate</Label>
+                <Input
+                  id="calc-qty-per-plate"
+                  type="number"
+                  min={1}
+                  value={form.qty_per_plate}
+                  onChange={(e) => update('qty_per_plate', Number(e.target.value))}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="calc-num-plates">Number of plates</Label>
+                <Input
+                  id="calc-num-plates"
+                  type="number"
+                  min={1}
+                  value={form.num_plates}
+                  onChange={(e) => update('num_plates', Number(e.target.value))}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="calc-material-per-plate">Material per plate (g)</Label>
+                <Input
+                  id="calc-material-per-plate"
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={form.material_per_plate_g}
+                  onChange={(e) => update('material_per_plate_g', Number(e.target.value))}
+                />
+              </div>
+
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label htmlFor="calc-print-time">Print time per plate (hrs)</Label>
+                <Input
+                  id="calc-print-time"
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={form.print_time_per_plate_hrs}
+                  onChange={(e) => update('print_time_per_plate_hrs', Number(e.target.value))}
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* Labor & Costs */}
+          <section className="rounded-md border border-border bg-card p-5 shadow-xs space-y-4">
+            <h2 className="text-base font-semibold">Labor &amp; costs</h2>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="calc-labor-mins">Labor time (mins)</Label>
+                <Input
+                  id="calc-labor-mins"
+                  type="number"
+                  min={0}
+                  value={form.labor_mins}
+                  onChange={(e) => update('labor_mins', Number(e.target.value))}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="calc-design-hrs">Design time (hrs)</Label>
+                <Input
+                  id="calc-design-hrs"
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={form.design_time_hrs}
+                  onChange={(e) => update('design_time_hrs', Number(e.target.value))}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="calc-shipping">Shipping cost ($)</Label>
+                <Input
+                  id="calc-shipping"
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={form.shipping_cost}
+                  onChange={(e) => update('shipping_cost', Number(e.target.value))}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="calc-margin">Target margin: {form.target_margin_pct}%</Label>
                 <input
+                  id="calc-margin"
                   type="range"
                   min={0}
                   max={90}
@@ -129,59 +189,97 @@ export default function CalculatorPage() {
                 />
               </div>
             </div>
-          </div>
+          </section>
         </div>
 
         {/* Results */}
         <div className="lg:col-span-1">
-          <div className="bg-card border border-border rounded-lg p-6 sticky top-24">
-            <h3 className="text-lg font-semibold mb-4">Results</h3>
+          <section className="sticky top-24 rounded-md border border-border bg-card p-5 shadow-xs space-y-3">
+            <h2 className="text-base font-semibold">Results</h2>
             {result ? (
               <div className="space-y-2 text-sm">
-                <div className="flex justify-between"><span className="text-muted-foreground">Total Pieces</span><span className="font-medium">{result.total_pieces}</span></div>
-                <div className="border-t border-border pt-2 mt-2" />
-                <div className="flex justify-between"><span className="text-muted-foreground">Material</span><span>{formatCurrency(result.material_cost)}</span></div>
-                <div className="flex justify-between"><span className="text-muted-foreground">Labor</span><span>{formatCurrency(result.labor_cost)}</span></div>
-                <div className="flex justify-between"><span className="text-muted-foreground">Design</span><span>{formatCurrency(result.design_cost)}</span></div>
-                <div className="flex justify-between"><span className="text-muted-foreground">Machine</span><span>{formatCurrency(result.machine_cost)}</span></div>
-                <div className="flex justify-between"><span className="text-muted-foreground">Electricity</span><span>{formatCurrency(result.electricity_cost)}</span></div>
-                <div className="flex justify-between"><span className="text-muted-foreground">Packaging</span><span>{formatCurrency(result.packaging_cost)}</span></div>
-                <div className="flex justify-between"><span className="text-muted-foreground">Failure Buffer</span><span>{formatCurrency(result.failure_buffer)}</span></div>
-                <div className="flex justify-between"><span className="text-muted-foreground">Overhead</span><span>{formatCurrency(result.overhead)}</span></div>
-                <div className="border-t border-border pt-2 mt-2 flex justify-between font-bold">
-                  <span>Total Cost</span><span>{formatCurrency(result.total_cost)}</span>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Total pieces</span>
+                  <span className="font-medium tabular-nums">{result.total_pieces}</span>
                 </div>
-                <div className="flex justify-between text-xs text-muted-foreground">
-                  <span>Cost/piece</span><span>{formatCurrency(result.cost_per_piece)}</span>
-                </div>
-                <div className="border-t border-border pt-2 mt-2 flex justify-between">
-                  <span className="text-muted-foreground">Price/piece</span><span className="font-bold">{formatCurrency(result.price_per_piece)}</span>
+                <div className="border-t border-border pt-2" />
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Material</span>
+                  <span className="tabular-nums">{formatCurrency(result.material_cost)}</span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-muted-foreground">Revenue</span><span className="font-bold">{formatCurrency(result.total_revenue)}</span>
+                  <span className="text-muted-foreground">Labor</span>
+                  <span className="tabular-nums">{formatCurrency(result.labor_cost)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Design</span>
+                  <span className="tabular-nums">{formatCurrency(result.design_cost)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Machine</span>
+                  <span className="tabular-nums">{formatCurrency(result.machine_cost)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Electricity</span>
+                  <span className="tabular-nums">{formatCurrency(result.electricity_cost)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Packaging</span>
+                  <span className="tabular-nums">{formatCurrency(result.packaging_cost)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Failure buffer</span>
+                  <span className="tabular-nums">{formatCurrency(result.failure_buffer)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Overhead</span>
+                  <span className="tabular-nums">{formatCurrency(result.overhead)}</span>
+                </div>
+                <div className="flex justify-between border-t border-border pt-2 font-semibold">
+                  <span>Total cost</span>
+                  <span className="tabular-nums">{formatCurrency(result.total_cost)}</span>
                 </div>
                 <div className="flex justify-between text-xs text-muted-foreground">
-                  <span>Platform fees</span><span>-{formatCurrency(result.platform_fees)}</span>
+                  <span>Cost/piece</span>
+                  <span className="tabular-nums">{formatCurrency(result.cost_per_piece)}</span>
                 </div>
-                <div className="border-t-2 border-border pt-2 mt-2 flex justify-between font-bold text-lg">
-                  <span>Net Profit</span>
-                  <span className={result.net_profit >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'}>
+                <div className="flex justify-between border-t border-border pt-2">
+                  <span className="text-muted-foreground">Price/piece</span>
+                  <span className="font-semibold tabular-nums">{formatCurrency(result.price_per_piece)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Revenue</span>
+                  <span className="font-semibold tabular-nums">{formatCurrency(result.total_revenue)}</span>
+                </div>
+                <div className="flex justify-between text-xs text-muted-foreground">
+                  <span>Platform fees</span>
+                  <span className="tabular-nums">-{formatCurrency(result.platform_fees)}</span>
+                </div>
+                <div className="flex justify-between border-t border-border pt-2 text-base font-semibold">
+                  <span>Net profit</span>
+                  <span
+                    className={
+                      result.net_profit >= 0
+                        ? 'tabular-nums text-emerald-600 dark:text-emerald-400'
+                        : 'tabular-nums text-destructive'
+                    }
+                  >
                     {formatCurrency(result.net_profit)}
                   </span>
                 </div>
-                <div className="text-xs text-muted-foreground text-right">
+                <div className="text-right text-xs text-muted-foreground tabular-nums">
                   {formatCurrency(result.profit_per_piece)} per piece
                 </div>
-                <Button onClick={saveAsJob} className="mt-4 w-full">
-                  Save as Job
+                <Button onClick={saveAsJob} className="mt-2 w-full">
+                  Save as job
                 </Button>
               </div>
             ) : (
-              <p className="text-muted-foreground text-sm py-8 text-center">
-                Fill in parameters to calculate costs
+              <p className="py-6 text-center text-sm text-muted-foreground">
+                Fill in parameters to calculate costs.
               </p>
             )}
-          </div>
+          </section>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/InsightsPage.test.tsx
+++ b/frontend/src/pages/InsightsPage.test.tsx
@@ -68,7 +68,7 @@ describe('InsightsPage', () => {
 
     renderInsightsPage();
 
-    expect(await screen.findByText('Read-only business intelligence')).toBeInTheDocument();
+    expect(await screen.findByText('AI Insights')).toBeInTheDocument();
     expect(screen.getByText(/Configure a provider in/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Admin Settings' })).toHaveAttribute('href', '/admin/settings');
     expect(screen.getByRole('button', { name: 'Generate Insight Summary' })).toBeDisabled();
@@ -113,7 +113,7 @@ describe('InsightsPage', () => {
 
     renderInsightsPage();
 
-    await screen.findByText('Read-only business intelligence');
+    await screen.findByText('AI Insights');
     await user.type(
       screen.getByPlaceholderText('Example: What should I print more of before the next market and what inventory is at risk?'),
       'What should I print more of before the next craft fair?'

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -1,10 +1,14 @@
 import { useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { Bot, BrainCircuit, LoaderCircle, ShieldCheck, Sparkles } from 'lucide-react';
+import { Bot, LoaderCircle, ShieldCheck, Sparkles } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
 import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
 import { Button } from '@/components/ui/Button';
+import { Textarea } from '@/components/ui/Textarea';
+import { Label } from '@/components/ui/Label';
+import StatusBadge, { type StatusTone } from '@/components/data/StatusBadge';
 import { useAuthStore } from '@/store/auth';
 import type { AIInsightStatus, AIInsightSummary } from '@/types';
 
@@ -14,20 +18,11 @@ const presetQuestions = [
   'Where is margin weak or slipping?',
 ];
 
-function PriorityBadge({ value }: { value: 'high' | 'medium' | 'low' }) {
-  const classes =
-    value === 'high'
-      ? 'border-red-300 bg-red-50 text-red-800'
-      : value === 'medium'
-        ? 'border-amber-300 bg-amber-50 text-amber-800'
-        : 'border-emerald-300 bg-emerald-50 text-emerald-800';
-
-  return (
-    <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-wide ${classes}`}>
-      {value}
-    </span>
-  );
-}
+const priorityToTone: Record<'high' | 'medium' | 'low', StatusTone> = {
+  high: 'destructive',
+  medium: 'warning',
+  low: 'success',
+};
 
 export default function InsightsPage() {
   const { user } = useAuthStore();
@@ -59,205 +54,247 @@ export default function InsightsPage() {
   };
 
   if (statusLoading) {
-    return <div className="space-y-6"><div className="h-12 w-72 animate-pulse rounded-md bg-card" /><div className="h-64 animate-pulse rounded-lg bg-card" /></div>;
+    return (
+      <div className="space-y-6">
+        <div className="h-12 w-72 animate-pulse rounded-md bg-card" />
+        <div className="h-64 animate-pulse rounded-md bg-card" />
+      </div>
+    );
   }
 
   return (
-    <div className="space-y-8">
-      <section className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
-        <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
-          <div className="max-w-2xl">
-            <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
-              <BrainCircuit className="h-4 w-4" />
-              AI Insights
-            </div>
-            <h1 className="mt-4 text-3xl font-bold">Read-only business intelligence</h1>
-            <p className="mt-3 text-base text-muted-foreground">
-              Ask for explainable recommendations grounded in your app data. This surface is analysis only: no autonomous writes, no silent pricing changes, and no hidden inventory actions.
-            </p>
-          </div>
-          <div className="rounded-md border border-border bg-background/80 p-4 text-sm">
-            <p className="font-semibold text-foreground">Active provider</p>
-            <p className="mt-2 text-lg font-semibold capitalize">{status?.provider || 'Unavailable'}</p>
-            <p className="text-muted-foreground">{status?.model || 'No model selected'}</p>
-            <div className="mt-3 flex flex-wrap gap-2">
-              {status?.available_providers.map((provider) => {
-                const isActive = provider === status.provider;
-                return (
-                  <span
-                    key={provider}
-                    className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-wide ${
-                      isActive
-                        ? 'border-primary/30 bg-primary/10 text-primary'
-                        : 'border-border bg-card text-muted-foreground'
-                    }`}
-                  >
-                    {provider}
-                  </span>
-                );
-              })}
-            </div>
-            <div className="mt-3 flex items-start gap-2 text-xs text-muted-foreground">
-              <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
-              <span>{status?.note}</span>
-            </div>
-          </div>
-        </div>
-      </section>
+    <div className="space-y-6">
+      <PageHeader
+        title="AI Insights"
+        description="Read-only business intelligence — explainable recommendations grounded in your app data. Analysis only, no autonomous writes."
+      />
 
-      <section className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
-        <div className="flex flex-col gap-4">
+      {/* Provider summary */}
+      <section className="rounded-md border border-border bg-card p-4 shadow-xs">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="text-xl font-semibold">Ask a focused question</h2>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Hick&apos;s Law applies here: start from one clear question instead of dumping every business concern into one prompt.
-            </p>
+            <p className="text-xs text-muted-foreground">Active provider</p>
+            <p className="mt-0.5 text-base font-semibold capitalize">{status?.provider || 'Unavailable'}</p>
+            <p className="text-sm text-muted-foreground">{status?.model || 'No model selected'}</p>
           </div>
-
-          <div className="flex flex-wrap gap-2">
-            {presetQuestions.map((item) => (
-              <button
-                key={item}
-                type="button"
-                onClick={() => {
-                  setQuestion(item);
-                  void handleGenerate(item);
-                }}
-                className="rounded-full border border-border px-4 py-2 text-sm font-medium transition-colors hover:border-primary/35 hover:bg-primary/5"
+          <div className="flex flex-wrap gap-1.5">
+            {status?.available_providers.map((provider) => (
+              <StatusBadge
+                key={provider}
+                tone={provider === status.provider ? 'info' : 'neutral'}
+                hideDot
               >
-                {item}
-              </button>
+                <span className="capitalize">{provider}</span>
+              </StatusBadge>
             ))}
           </div>
+        </div>
+        {status?.note ? (
+          <p className="mt-3 flex items-start gap-2 text-xs text-muted-foreground">
+            <ShieldCheck className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            <span>{status.note}</span>
+          </p>
+        ) : null}
+      </section>
 
-          <textarea
+      {/* Ask question */}
+      <section className="rounded-md border border-border bg-card p-5 shadow-xs space-y-4">
+        <h2 className="text-base font-semibold">Ask a focused question</h2>
+
+        <div className="flex flex-wrap gap-2">
+          {presetQuestions.map((item) => (
+            <Button
+              key={item}
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setQuestion(item);
+                void handleGenerate(item);
+              }}
+              disabled={summaryMutation.isPending}
+            >
+              {item}
+            </Button>
+          ))}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="insights-question" className="sr-only">
+            Your question
+          </Label>
+          <Textarea
+            id="insights-question"
             value={question}
             onChange={(e) => setQuestion(e.target.value)}
             rows={4}
             placeholder="Example: What should I print more of before the next market and what inventory is at risk?"
-            className="w-full rounded-md border border-input bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
           />
+        </div>
 
-          <div className="flex flex-wrap items-center gap-3">
-            <Button
-              type="button"
-              onClick={() => void handleGenerate()}
-              disabled={summaryMutation.isPending || !status?.configured}
-              size="lg"
-              className="min-h-12 font-semibold"
-            >
-              {summaryMutation.isPending ? <LoaderCircle className="h-5 w-5 animate-spin" /> : <Sparkles className="h-5 w-5" />}
-              {summaryMutation.isPending ? 'Generating insights...' : 'Generate Insight Summary'}
-            </Button>
-            {!status?.configured ? (
-              <p className="text-sm text-muted-foreground">
-                {isAdmin ? (
-                  <>
-                    Configure a provider in <Link to="/admin/settings" className="text-primary no-underline hover:underline">Admin Settings</Link> first.
-                  </>
-                ) : (
-                  'An admin must configure an AI provider before this workspace can generate insights.'
-                )}
-              </p>
-            ) : null}
-          </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            onClick={() => void handleGenerate()}
+            disabled={summaryMutation.isPending || !status?.configured}
+          >
+            {summaryMutation.isPending ? (
+              <LoaderCircle className="h-4 w-4 animate-spin" />
+            ) : (
+              <Sparkles className="h-4 w-4" />
+            )}
+            {summaryMutation.isPending ? 'Generating insights…' : 'Generate Insight Summary'}
+          </Button>
+          {!status?.configured ? (
+            <p className="text-sm text-muted-foreground">
+              {isAdmin ? (
+                <>
+                  Configure a provider in{' '}
+                  <Link to="/admin/settings" className="text-primary no-underline hover:underline">
+                    Admin Settings
+                  </Link>{' '}
+                  first.
+                </>
+              ) : (
+                'An admin must configure an AI provider before this workspace can generate insights.'
+              )}
+            </p>
+          ) : null}
         </div>
       </section>
 
       {summary ? (
         <>
-          <section className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
-            <div className="flex items-start gap-4">
-              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-primary/12 text-primary">
-                <Bot className="h-6 w-6" />
-              </div>
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                  {summary.provider} • {summary.model}
+          {/* Summary header */}
+          <section className="rounded-md border border-border bg-card p-5 shadow-xs">
+            <div className="flex items-start gap-3">
+              <Bot className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              <div className="min-w-0">
+                <p className="text-xs text-muted-foreground">
+                  {summary.provider} · {summary.model}
                 </p>
-                <h2 className="mt-2 text-2xl font-semibold">{summary.title}</h2>
-                <p className="mt-3 text-base text-muted-foreground">{summary.summary}</p>
-                <p className="mt-3 text-xs text-muted-foreground">
+                <h2 className="mt-1 text-lg font-semibold">{summary.title}</h2>
+                <p className="mt-2 text-sm text-muted-foreground">{summary.summary}</p>
+                <p className="mt-2 text-xs text-muted-foreground">
                   Generated {new Date(summary.generated_at).toLocaleString()}
                 </p>
                 {summary.question ? (
-                  <p className="mt-4 text-sm text-muted-foreground">Question: {summary.question}</p>
+                  <p className="mt-3 text-sm text-muted-foreground">Question: {summary.question}</p>
                 ) : null}
               </div>
             </div>
           </section>
 
-          <section className="grid gap-6 xl:grid-cols-2">
-            <div className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
-              <h3 className="text-xl font-semibold">Recommendations</h3>
-              <div className="mt-4 space-y-4">
-                {summary.recommendations.length ? summary.recommendations.map((item, index) => (
-                  <article key={`${item.title}-${index}`} className="rounded-md border border-border bg-background/80 p-4">
-                    <div className="flex items-start justify-between gap-3">
-                      <h4 className="font-semibold">{item.title}</h4>
-                      <PriorityBadge value={item.priority} />
-                    </div>
-                    <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
-                    {item.recommended_action ? <p className="mt-3 text-sm font-medium text-foreground">Action: {item.recommended_action}</p> : null}
-                    {item.evidence.length ? <p className="mt-3 text-xs text-muted-foreground">Evidence: {item.evidence.join(' • ')}</p> : null}
-                  </article>
-                )) : <p className="text-sm text-muted-foreground">No recommendations returned.</p>}
-              </div>
-            </div>
+          {/* Recommendations + Risks */}
+          <div className="grid gap-6 xl:grid-cols-2">
+            <section className="rounded-md border border-border bg-card p-5 shadow-xs space-y-4">
+              <h2 className="text-base font-semibold">Recommendations</h2>
+              {summary.recommendations.length ? (
+                <div className="space-y-3">
+                  {summary.recommendations.map((item, index) => (
+                    <article
+                      key={`${item.title}-${index}`}
+                      className="rounded-md border border-border bg-background p-4"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <h3 className="text-sm font-semibold">{item.title}</h3>
+                        <StatusBadge tone={priorityToTone[item.priority]} hideDot>
+                          <span className="capitalize">{item.priority}</span>
+                        </StatusBadge>
+                      </div>
+                      <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
+                      {item.recommended_action ? (
+                        <p className="mt-3 text-sm font-medium">Action: {item.recommended_action}</p>
+                      ) : null}
+                      {item.evidence.length ? (
+                        <p className="mt-3 text-xs text-muted-foreground">
+                          Evidence: {item.evidence.join(' · ')}
+                        </p>
+                      ) : null}
+                    </article>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">No recommendations returned.</p>
+              )}
+            </section>
 
-            <div className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
-              <h3 className="text-xl font-semibold">Risks</h3>
-              <div className="mt-4 space-y-4">
-                {summary.risks.length ? summary.risks.map((item, index) => (
-                  <article key={`${item.title}-${index}`} className="rounded-md border border-border bg-background/80 p-4">
-                    <div className="flex items-start justify-between gap-3">
-                      <h4 className="font-semibold">{item.title}</h4>
-                      <PriorityBadge value={item.priority} />
-                    </div>
-                    <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
-                    {item.recommended_action ? <p className="mt-3 text-sm font-medium text-foreground">Action: {item.recommended_action}</p> : null}
-                    {item.evidence.length ? <p className="mt-3 text-xs text-muted-foreground">Evidence: {item.evidence.join(' • ')}</p> : null}
-                  </article>
-                )) : <p className="text-sm text-muted-foreground">No risks returned.</p>}
-              </div>
-            </div>
-          </section>
+            <section className="rounded-md border border-border bg-card p-5 shadow-xs space-y-4">
+              <h2 className="text-base font-semibold">Risks</h2>
+              {summary.risks.length ? (
+                <div className="space-y-3">
+                  {summary.risks.map((item, index) => (
+                    <article
+                      key={`${item.title}-${index}`}
+                      className="rounded-md border border-border bg-background p-4"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <h3 className="text-sm font-semibold">{item.title}</h3>
+                        <StatusBadge tone={priorityToTone[item.priority]} hideDot>
+                          <span className="capitalize">{item.priority}</span>
+                        </StatusBadge>
+                      </div>
+                      <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
+                      {item.recommended_action ? (
+                        <p className="mt-3 text-sm font-medium">Action: {item.recommended_action}</p>
+                      ) : null}
+                      {item.evidence.length ? (
+                        <p className="mt-3 text-xs text-muted-foreground">
+                          Evidence: {item.evidence.join(' · ')}
+                        </p>
+                      ) : null}
+                    </article>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">No risks returned.</p>
+              )}
+            </section>
+          </div>
 
-          <section className="grid gap-6 xl:grid-cols-[1.4fr_1fr]">
-            <div className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
-              <h3 className="text-xl font-semibold">Evidence metrics</h3>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Jakob&apos;s Law and Common Region: the recommendation copy stays separate from the source-of-truth numbers it references.
-              </p>
-              <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {/* Evidence + follow-ups */}
+          <div className="grid gap-6 xl:grid-cols-[1.4fr_1fr]">
+            <section className="rounded-md border border-border bg-card p-5 shadow-xs space-y-4">
+              <h2 className="text-base font-semibold">Evidence metrics</h2>
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
                 {summary.evidence_metrics.map((metric) => (
-                  <div key={metric.key} className="rounded-md border border-border bg-background/80 p-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">{metric.label}</p>
-                    <p className="mt-2 text-xl font-semibold">{metric.value}</p>
+                  <div
+                    key={metric.key}
+                    className="rounded-md border border-border bg-background p-3"
+                  >
+                    <p className="text-xs text-muted-foreground">{metric.label}</p>
+                    <p className="mt-0.5 text-lg font-semibold tabular-nums">{metric.value}</p>
                   </div>
                 ))}
               </div>
-            </div>
+            </section>
 
-            <div className="rounded-lg border border-border bg-card/90 p-6 shadow-md">
-              <h3 className="text-xl font-semibold">Suggested follow-ups</h3>
-              <div className="mt-4 space-y-3">
-                {summary.suggested_questions.length ? summary.suggested_questions.map((item) => (
-                  <button
-                    key={item}
-                    type="button"
-                    onClick={() => {
-                      setQuestion(item);
-                      void handleGenerate(item);
-                    }}
-                    className="block w-full rounded-md border border-border bg-background/80 px-4 py-3 text-left text-sm font-medium transition-colors hover:border-primary/35 hover:bg-primary/5"
-                  >
-                    {item}
-                  </button>
-                )) : <p className="text-sm text-muted-foreground">No follow-up questions returned.</p>}
-              </div>
-            </div>
-          </section>
+            <section className="rounded-md border border-border bg-card p-5 shadow-xs space-y-3">
+              <h2 className="text-base font-semibold">Suggested follow-ups</h2>
+              {summary.suggested_questions.length ? (
+                <div className="flex flex-col gap-2">
+                  {summary.suggested_questions.map((item) => (
+                    <Button
+                      key={item}
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="w-full justify-start text-left font-normal"
+                      onClick={() => {
+                        setQuestion(item);
+                        void handleGenerate(item);
+                      }}
+                      disabled={summaryMutation.isPending}
+                    >
+                      {item}
+                    </Button>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">No follow-up questions returned.</p>
+              )}
+            </section>
+          </div>
         </>
       ) : null}
     </div>


### PR DESCRIPTION
Closes #209. Parent epic: #173 (P1 tier). Sixth workspace revamp.

## Summary

Both pages migrated off hand-rolled hero cards and tile grids to `<PageHeader>` + primitives.

### InsightsPage
- `<PageHeader>` replaces `text-3xl "Read-only business intelligence"` marketing hero + `tracking-[0.18em]` AI-Insights pill
- Deleted `PriorityBadge` helper → `<StatusBadge tone={destructive|warning|success}>`
- Preset-question + suggested-follow-up pills → `<Button variant="outline" size="sm">`
- Raw `<textarea>` → `<Textarea>` + `<Label>`
- Engineer-speak removed ("Hick's Law applies here", "Jakob's Law and Common Region")
- Updated `InsightsPage.test.tsx` to match new heading
### CalculatorPage
- `<PageHeader>` replaces bespoke header with `w-8 h-8` Calculator icon + `text-3xl font-bold`
- Deleted `CalcField` helper → every field uses `<Input>` + `<Label htmlFor>`
- `text-green-600` raw → `text-emerald-600` token; `text-destructive` for negative profit
- `tabular-nums` on all result numerics
- Dropped `max-w-5xl mx-auto` wrapper; `rounded-lg` → `rounded-md`

## Acceptance

- [x] `rg "text-3xl"` on both pages → 0
- [x] `rg "tracking-\[0\.(14|16|18)em\]"` InsightsPage.tsx → 0
- [x] `rg "PriorityBadge|CalcField"` → 0
- [x] `rg "rounded-full"` InsightsPage.tsx → 0
- [x] `rg "max-w-5xl"` CalculatorPage.tsx → 0
- [x] `rg "text-green-600"` CalculatorPage.tsx → 0
- [x] `npm run build` passes
- [x] `npx vitest run` → 44 tests passing

## Test plan

- [ ] `/insights`: verify "AI Insights" heading, active-provider card, preset-question chips trigger a generate, textarea works, generated summary renders with StatusBadge priorities (destructive/warning/success)
- [ ] Non-admin user: verify "An admin must configure…" message appears in place of the Admin Settings link
- [ ] `/calculator`: verify all fields accept input, debounced calculation fires, net profit shows emerald when positive and destructive when negative, "Save as job" navigates with query params

🤖 Generated with [Claude Code](https://claude.com/claude-code)