### PR TITLE
feat(ui): typography cleanup sweep (#180)

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -3,7 +3,7 @@ export default function Footer() {
     <footer className="mt-auto border-t border-border bg-card/30 py-6 backdrop-blur">
       <div className="mx-auto flex max-w-[96rem] flex-col gap-2 px-4 text-center text-sm text-muted-foreground sm:px-6 lg:px-8 lg:flex-row lg:items-center lg:justify-between">
         <p>&copy; {new Date().getFullYear()} 3D Print Sales.</p>
-        <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground/90">
+        <p className="text-xs text-muted-foreground/90">
           Control Center • Print Floor • Sell • Stock • Product Studio
         </p>
       </div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -41,7 +41,7 @@ export default function Header({ onOpenMobileNav }: HeaderProps) {
                 <span className="block truncate font-display text-lg font-semibold text-foreground">
                   3D Print Sales
                 </span>
-                <span className="block truncate text-xs uppercase tracking-[0.22em] text-muted-foreground">
+                <span className="block truncate text-xs text-muted-foreground">
                   {workspace.label}
                 </span>
               </div>
@@ -64,7 +64,7 @@ export default function Header({ onOpenMobileNav }: HeaderProps) {
                 </div>
                 <div className="min-w-0">
                   <span className="block truncate font-medium text-foreground">{user.full_name}</span>
-                  <span className="block truncate text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                  <span className="block truncate text-xs text-muted-foreground">
                     {user.role}
                   </span>
                 </div>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -23,7 +23,7 @@ function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
               <PanelsTopLeft className="h-5 w-5" />
             </div>
             <div>
-              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+              <p className="text-xs font-medium text-muted-foreground">
                 Active Workspace
               </p>
               <p className="mt-1 font-display text-base font-semibold text-foreground">
@@ -38,7 +38,7 @@ function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
       </div>
 
       <div className="px-3 pb-2">
-        <p className="px-3 text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+        <p className="px-3 text-xs font-medium text-muted-foreground">
           Workspaces
         </p>
       </div>

--- a/frontend/src/components/layout/WorkspaceLocalNav.tsx
+++ b/frontend/src/components/layout/WorkspaceLocalNav.tsx
@@ -10,7 +10,7 @@ export default function WorkspaceLocalNav() {
     <section className="rounded-lg border border-border bg-card/80 p-4 shadow-md backdrop-blur">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
         <div className="min-w-0">
-          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.26em] text-muted-foreground">
+          <p className="text-xs font-medium text-muted-foreground">
             Workspace
           </p>
           <h2 className="mt-1 font-display text-xl font-semibold text-foreground">

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -70,7 +70,7 @@ export default function JobDetailPage() {
             <ArrowLeft className="w-5 h-5" />
           </Link>
           <div>
-            <h1 className="text-2xl font-bold">{job.job_number}</h1>
+            <h1 className="text-2xl font-semibold">{job.job_number}</h1>
             <p className="text-muted-foreground text-sm">{job.product_name}</p>
           </div>
           <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary">
@@ -132,7 +132,7 @@ export default function JobDetailPage() {
           <CostRow label="Shipping" value={job.shipping_cost} />
           <CostRow label="Failure Buffer" value={job.failure_buffer} />
           <CostRow label="Overhead" value={job.overhead} />
-          <div className="flex justify-between py-2 mt-2 border-t-2 border-border font-bold">
+          <div className="flex justify-between py-2 mt-2 border-t-2 border-border font-semibold">
             <span>Total Cost</span>
             <span>{formatCurrency(job.total_cost)}</span>
           </div>
@@ -155,15 +155,15 @@ export default function JobDetailPage() {
             </div>
             <div className="flex justify-between py-2 border-b border-border">
               <span className="text-muted-foreground">Total Revenue</span>
-              <span className="font-bold text-lg">{formatCurrency(job.total_revenue)}</span>
+              <span className="font-semibold text-lg">{formatCurrency(job.total_revenue)}</span>
             </div>
             <div className="flex justify-between py-2 border-b border-border">
               <span className="text-muted-foreground">Platform Fees</span>
               <span className="font-medium text-destructive">-{formatCurrency(job.platform_fees)}</span>
             </div>
             <div className="flex justify-between py-2 mt-2 border-t-2 border-border">
-              <span className="font-bold">Net Profit</span>
-              <span className={`font-bold text-lg ${job.net_profit >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'}`}>
+              <span className="font-semibold">Net Profit</span>
+              <span className={`font-semibold text-lg ${job.net_profit >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'}`}>
                 {formatCurrency(job.net_profit)}
               </span>
             </div>

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
 import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
+import PageHeader from '@/components/layout/PageHeader';
 import { formatCurrency } from '@/lib/utils';
 import type { Material, Job, CalculateResponse, PaginatedProducts, PaginatedPrinters, Product } from '@/types';
 
@@ -277,8 +278,11 @@ export default function JobFormPage() {
   };
 
   return (
-    <div className="max-w-5xl mx-auto">
-      <h1 className="text-3xl font-bold mb-8">{isEdit ? 'Edit Job' : 'New Job'}</h1>
+    <div className="max-w-5xl mx-auto space-y-6">
+      <PageHeader
+        title={isEdit ? 'Edit Job' : 'New Job'}
+        description="Configure materials, labor, and pricing. Live cost preview updates as you type."
+      />
 
       <Dialog open={showCreateProduct} onOpenChange={(open) => !open && setShowCreateProduct(false)}>
         <DialogContent className="max-w-md">
@@ -503,22 +507,22 @@ export default function JobFormPage() {
                 <div className="flex justify-between"><span className="text-muted-foreground">Packaging</span><span>{formatCurrency(preview.packaging_cost)}</span></div>
                 <div className="flex justify-between"><span className="text-muted-foreground">Failure Buffer</span><span>{formatCurrency(preview.failure_buffer)}</span></div>
                 <div className="flex justify-between"><span className="text-muted-foreground">Overhead</span><span>{formatCurrency(preview.overhead)}</span></div>
-                <div className="border-t border-border pt-2 mt-2 flex justify-between font-bold">
+                <div className="border-t border-border pt-2 mt-2 flex justify-between font-semibold">
                   <span>Total Cost</span><span>{formatCurrency(preview.total_cost)}</span>
                 </div>
                 <div className="flex justify-between text-xs text-muted-foreground">
                   <span>Cost/piece</span><span>{formatCurrency(preview.cost_per_piece)}</span>
                 </div>
                 <div className="border-t border-border pt-2 mt-2 flex justify-between">
-                  <span className="text-muted-foreground">Price/piece</span><span className="font-bold">{formatCurrency(preview.price_per_piece)}</span>
+                  <span className="text-muted-foreground">Price/piece</span><span className="font-semibold">{formatCurrency(preview.price_per_piece)}</span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-muted-foreground">Revenue</span><span className="font-bold">{formatCurrency(preview.total_revenue)}</span>
+                  <span className="text-muted-foreground">Revenue</span><span className="font-semibold">{formatCurrency(preview.total_revenue)}</span>
                 </div>
                 <div className="flex justify-between text-xs text-muted-foreground">
                   <span>Platform fees</span><span>-{formatCurrency(preview.platform_fees)}</span>
                 </div>
-                <div className="border-t-2 border-border pt-2 mt-2 flex justify-between font-bold text-lg">
+                <div className="border-t-2 border-border pt-2 mt-2 flex justify-between font-semibold text-lg">
                   <span>Net Profit</span>
                   <span className={preview.net_profit >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'}>
                     {formatCurrency(preview.net_profit)}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -76,10 +76,10 @@ export default function LoginPage() {
       <div className="w-full max-w-md">
         <div className="flex items-center justify-center gap-2 text-primary mb-8">
           <Printer className="w-10 h-10" />
-          <span className="text-2xl font-bold">3D Print Sales</span>
+          <span className="text-2xl font-semibold">3D Print Sales</span>
         </div>
         <div className="bg-card border border-border rounded-lg p-8 shadow-sm">
-          <h2 className="text-xl font-bold mb-6 text-center">Sign In</h2>
+          <h2 className="text-xl font-semibold mb-6 text-center">Sign In</h2>
           {errors.form && (
             <div className="bg-destructive/10 text-destructive text-sm rounded-lg p-3 mb-4">
               {errors.form}

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -74,7 +74,7 @@ function ConsoleStat({
     <div className="rounded-md border border-border bg-card/85 p-4 shadow-sm">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">{label}</p>
+          <p className="text-xs font-medium text-muted-foreground">{label}</p>
           <p
             className={cn(
               'mt-3 text-2xl font-semibold',
@@ -323,19 +323,19 @@ export default function PrinterDetailPage() {
             <div className="space-y-4">
               <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                 <div className="rounded-md border border-border bg-background/60 p-4">
-                  <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Provider</p>
+                  <p className="text-xs text-muted-foreground">Provider</p>
                   <p className="mt-2 font-semibold capitalize text-foreground">{printer.monitor_provider || '—'}</p>
                   <p className="mt-1 text-sm text-muted-foreground">{printer.monitor_poll_interval_seconds}s poll interval</p>
                 </div>
                 <div className="rounded-md border border-border bg-background/60 p-4">
-                  <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Last event</p>
+                  <p className="text-xs text-muted-foreground">Last event</p>
                   <p className="mt-2 font-semibold text-foreground">
                     {printer.monitor_last_event_type ? printer.monitor_last_event_type.replace('notify_', '').replaceAll('_', ' ') : '—'}
                   </p>
                   <p className="mt-1 text-sm text-muted-foreground">{formatDateTime(printer.monitor_last_event_at)}</p>
                 </div>
                 <div className="rounded-md border border-border bg-background/60 p-4">
-                  <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Last seen</p>
+                  <p className="text-xs text-muted-foreground">Last seen</p>
                   <p className="mt-2 font-semibold text-foreground">{formatDateTime(printer.monitor_last_seen_at)}</p>
                   <p className="mt-1 text-sm text-muted-foreground">
                     {printer.monitor_provider === 'moonraker'
@@ -348,7 +348,7 @@ export default function PrinterDetailPage() {
               </div>
 
               <div className="rounded-md border border-border bg-background/60 p-4">
-                <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Provider message</p>
+                <p className="text-xs text-muted-foreground">Provider message</p>
                 <p className="mt-2 text-sm text-foreground">{printer.monitor_last_message || '—'}</p>
               </div>
 
@@ -357,7 +357,7 @@ export default function PrinterDetailPage() {
                   <div className="flex items-start gap-3">
                     <AlertTriangle className="mt-0.5 h-4 w-4 text-red-600 dark:text-red-300" />
                     <div>
-                      <p className="text-xs uppercase tracking-[0.16em] text-red-700 dark:text-red-200">Last monitor error</p>
+                      <p className="text-xs text-red-700 dark:text-red-200">Last monitor error</p>
                       <p className="mt-2 text-sm text-red-700 dark:text-red-100">{printer.monitor_last_error}</p>
                     </div>
                   </div>
@@ -404,12 +404,12 @@ export default function PrinterDetailPage() {
 
           <div className="mt-4 grid gap-3 sm:grid-cols-2">
             <div className="rounded-md border border-border bg-background/60 p-4">
-              <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Machine identity</p>
+              <p className="text-xs text-muted-foreground">Machine identity</p>
               <p className="mt-2 font-semibold text-foreground">{printer.manufacturer || '—'} {printer.model || ''}</p>
               <p className="mt-1 text-sm text-muted-foreground">{printer.serial_number || 'No serial number'}</p>
             </div>
             <div className="rounded-md border border-border bg-background/60 p-4">
-              <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Current assignment</p>
+              <p className="text-xs text-muted-foreground">Current assignment</p>
               {activeJob ? (
                 <>
                   <Link to={`/orders/jobs/${activeJob.id}`} className="mt-2 block font-semibold text-primary no-underline hover:underline">
@@ -425,7 +425,7 @@ export default function PrinterDetailPage() {
 
           {printer.notes ? (
             <div className="mt-4 rounded-md border border-border bg-background/60 p-4">
-              <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Notes</p>
+              <p className="text-xs text-muted-foreground">Notes</p>
               <p className="mt-2 whitespace-pre-wrap text-sm text-foreground">{printer.notes}</p>
             </div>
           ) : null}

--- a/frontend/src/pages/PrinterFormPage.tsx
+++ b/frontend/src/pages/PrinterFormPage.tsx
@@ -196,7 +196,7 @@ export default function PrinterFormPage() {
 
       <div className="rounded-lg border border-border bg-card p-6">
         <div className="mb-6">
-          <h1 className="text-2xl font-bold">{title}</h1>
+          <h1 className="text-2xl font-semibold">{title}</h1>
           <p className="mt-1 text-sm text-muted-foreground">Track machine details, availability, and where this printer lives.</p>
         </div>
 

--- a/frontend/src/pages/PrinterMonitorPage.tsx
+++ b/frontend/src/pages/PrinterMonitorPage.tsx
@@ -100,7 +100,7 @@ export default function PrinterMonitorPage() {
         <div className="flex items-center justify-between gap-6 max-w-7xl mx-auto">
           {/* Printer identity */}
           <div className="min-w-0">
-            <h1 className="text-white text-lg font-display font-bold truncate">{printer.name}</h1>
+            <h1 className="text-white text-lg font-display font-semibold truncate">{printer.name}</h1>
             <div className="flex items-center gap-2 mt-0.5">
               <span className={`text-sm font-medium capitalize ${statusColor}`}>{status}</span>
               {printer.current_print_name && (

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -141,7 +141,7 @@ export default function ProductDetailPage() {
       <div className="bg-card border border-border rounded-lg p-6 mb-6">
         <div className="flex items-start justify-between gap-4 mb-4">
           <div>
-            <h1 className="text-2xl font-bold">{currentProduct.name}</h1>
+            <h1 className="text-2xl font-semibold">{currentProduct.name}</h1>
             <p className="text-sm text-muted-foreground font-mono">{currentProduct.sku}</p>
             {currentProduct.upc && <p className="text-xs text-muted-foreground mt-1">UPC: {currentProduct.upc}</p>}
             {!currentProduct.is_active && <p className="text-sm text-muted-foreground mt-2">This product is archived. Historical records and inventory history are preserved.</p>}
@@ -171,21 +171,21 @@ export default function ProductDetailPage() {
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           <div>
             <p className="text-xs text-muted-foreground">Unit Price</p>
-            <p className="text-lg font-bold">{formatCurrency(product.unit_price)}</p>
+            <p className="text-lg font-semibold">{formatCurrency(product.unit_price)}</p>
           </div>
           <div>
             <p className="text-xs text-muted-foreground">Unit Cost</p>
-            <p className="text-lg font-bold">{formatCurrency(product.unit_cost)}</p>
+            <p className="text-lg font-semibold">{formatCurrency(product.unit_cost)}</p>
           </div>
           <div>
             <p className="text-xs text-muted-foreground">Stock on Hand</p>
-            <p className={`text-lg font-bold ${product.stock_qty <= product.reorder_point ? 'text-amber-600 dark:text-amber-400' : ''}`}>
+            <p className={`text-lg font-semibold ${product.stock_qty <= product.reorder_point ? 'text-amber-600 dark:text-amber-400' : ''}`}>
               {product.stock_qty}
             </p>
           </div>
           <div>
             <p className="text-xs text-muted-foreground">Reorder Point</p>
-            <p className="text-lg font-bold">{product.reorder_point}</p>
+            <p className="text-lg font-semibold">{product.reorder_point}</p>
           </div>
         </div>
         {Number(product.unit_price) > 0 && Number(product.unit_cost) > 0 && (
@@ -200,7 +200,7 @@ export default function ProductDetailPage() {
 
       {/* Adjust Stock */}
       <div className="flex items-center justify-between mb-4 gap-3">
-        <h2 className="text-xl font-bold">Transaction History</h2>
+        <h2 className="text-xl font-semibold">Transaction History</h2>
         <div className="flex gap-2">
           <button
             onClick={() => {

--- a/frontend/src/pages/ProductEditorPage.tsx
+++ b/frontend/src/pages/ProductEditorPage.tsx
@@ -433,16 +433,16 @@ export default function ProductEditorPage() {
             {selectedMaterial ? (
               <div className="mt-4 space-y-3 text-sm">
                 <div className="rounded-md bg-background px-4 py-3">
-                  <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Material</p>
+                  <p className="text-xs text-muted-foreground">Material</p>
                   <p className="mt-2 font-semibold">{selectedMaterial.name}</p>
                   <p className="mt-1 text-muted-foreground">{selectedMaterial.brand}</p>
                 </div>
                 <div className="rounded-md bg-background px-4 py-3">
-                  <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Cost per gram</p>
+                  <p className="text-xs text-muted-foreground">Cost per gram</p>
                   <p className="mt-2 font-semibold">${Number(selectedMaterial.cost_per_g).toFixed(4)}</p>
                 </div>
                 <div className="rounded-md bg-background px-4 py-3">
-                  <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Material stock</p>
+                  <p className="text-xs text-muted-foreground">Material stock</p>
                   <p className="mt-2 font-semibold">{selectedMaterial.spools_in_stock} spools</p>
                   <p className="mt-1 text-muted-foreground">Reorder at {selectedMaterial.reorder_point}</p>
                 </div>

--- a/frontend/src/pages/SaleDetailPage.tsx
+++ b/frontend/src/pages/SaleDetailPage.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
+import PageHeader from '@/components/layout/PageHeader';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import { getShippingLabelActionLabel, getShippingLabelMissingFields } from '@/lib/shippingLabels';
 import { formatCurrency } from '@/lib/utils';
@@ -192,19 +193,24 @@ export default function SaleDetailPage() {
     shipmentForm.tracking_number !== (sale.tracking_number || '');
 
   return (
-    <div>
-      <div className="flex items-center gap-4 mb-8">
-        <Link to="/sales" className="p-2 hover:bg-accent rounded-md text-muted-foreground">
-          <ArrowLeft className="w-5 h-5" />
-        </Link>
-        <div className="flex-1">
-          <h1 className="text-3xl font-bold">{sale.sale_number}</h1>
-          <p className="text-muted-foreground">{sale.date} &middot; {sale.customer_name || 'No customer'}</p>
-        </div>
-        <StatusBadge tone={defaultStatusTone(sale.status)} className="text-sm">
-          <span className="capitalize">{sale.status}</span>
-        </StatusBadge>
-      </div>
+    <div className="space-y-6">
+      <PageHeader
+        title={sale.sale_number}
+        description={`${sale.date} · ${sale.customer_name || 'No customer'}`}
+        actions={
+          <div className="flex items-center gap-2">
+            <Link
+              to="/sales"
+              className="inline-flex items-center gap-1 rounded-md border border-border px-3 py-2 text-sm text-muted-foreground hover:bg-accent no-underline"
+            >
+              <ArrowLeft className="w-4 h-4" /> Back
+            </Link>
+            <StatusBadge tone={defaultStatusTone(sale.status)} className="text-sm">
+              <span className="capitalize">{sale.status}</span>
+            </StatusBadge>
+          </div>
+        }
+      />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2 bg-card border border-border rounded-lg p-6">

--- a/frontend/src/pages/SaleFormPage.tsx
+++ b/frontend/src/pages/SaleFormPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
+import PageHeader from '@/components/layout/PageHeader';
 import { formatCurrency } from '@/lib/utils';
 import type { SalesChannel, PaginatedProducts, Customer } from '@/types';
 
@@ -135,13 +136,20 @@ export default function SaleFormPage() {
     'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring';
 
   return (
-    <div>
-      <div className="flex items-center gap-4 mb-8">
-        <button onClick={() => navigate('/sales')} className="p-2 hover:bg-accent rounded-md text-muted-foreground cursor-pointer">
-          <ArrowLeft className="w-5 h-5" />
-        </button>
-        <h1 className="text-3xl font-bold">New Sale</h1>
-      </div>
+    <div className="space-y-6">
+      <PageHeader
+        title="New Sale"
+        description="Record a sale, its line items, shipment destination, and totals."
+        actions={
+          <button
+            type="button"
+            onClick={() => navigate('/sales')}
+            className="inline-flex items-center gap-1 rounded-md border border-border px-3 py-2 text-sm text-muted-foreground hover:bg-accent"
+          >
+            <ArrowLeft className="w-4 h-4" /> Back to sales
+          </button>
+        }
+      />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Sale details */}

--- a/frontend/src/pages/SalesChannelsPage.tsx
+++ b/frontend/src/pages/SalesChannelsPage.tsx
@@ -6,6 +6,7 @@ import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
+import PageHeader from '@/components/layout/PageHeader';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
 import StatusBadge from '@/components/data/StatusBadge';
 import DataTable, { type Column } from '@/components/data/DataTable';
@@ -72,13 +73,16 @@ export default function SalesChannelsPage() {
   };
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-8">
-        <h1 className="text-3xl font-bold">Sales Channels</h1>
-        <Button onClick={openNew}>
-          <Plus className="h-4 w-4" /> Add Channel
-        </Button>
-      </div>
+    <div className="space-y-6">
+      <PageHeader
+        title="Sales Channels"
+        description="Manage platforms, fees, and active status for every place you sell."
+        actions={
+          <Button onClick={openNew}>
+            <Plus className="h-4 w-4" /> Add channel
+          </Button>
+        }
+      />
 
       <Dialog open={editing !== null} onOpenChange={(o) => !o && close()}>
         <DialogContent className="max-w-md">
@@ -151,13 +155,13 @@ function SalesChannelsTable({ channels, isLoading, onEdit, onToggleActive }: Sal
       key: 'platform_fee_pct',
       header: 'Platform Fee %',
       numeric: true,
-      cell: (ch) => `${Number(ch.platform_fee_pct).toFixed(1)}%`,
+      cell: (ch) => <span className="tabular-nums">{Number(ch.platform_fee_pct).toFixed(1)}%</span>,
     },
     {
       key: 'fixed_fee',
       header: 'Fixed Fee',
       numeric: true,
-      cell: (ch) => `$${Number(ch.fixed_fee).toFixed(2)}`,
+      cell: (ch) => <span className="tabular-nums">${Number(ch.fixed_fee).toFixed(2)}</span>,
     },
     {
       key: 'status',

--- a/frontend/src/pages/admin/CamerasPage.tsx
+++ b/frontend/src/pages/admin/CamerasPage.tsx
@@ -186,7 +186,7 @@ export default function CamerasPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-display font-bold">Cameras</h1>
+          <h1 className="text-2xl font-display font-semibold">Cameras</h1>
           <p className="text-sm text-muted-foreground mt-1">
             Manage camera feeds and assign them to printers for live monitoring.
           </p>

--- a/frontend/src/pages/admin/DataPage.tsx
+++ b/frontend/src/pages/admin/DataPage.tsx
@@ -58,7 +58,7 @@ export default function DataPage() {
       <div className="flex items-center gap-3 mb-8">
         <Download className="w-8 h-8 text-primary" />
         <div>
-          <h1 className="text-2xl font-bold">Data Export</h1>
+          <h1 className="text-2xl font-semibold">Data Export</h1>
           <p className="text-sm text-muted-foreground">Export your data as CSV files</p>
         </div>
       </div>

--- a/frontend/src/pages/admin/SettingsPage.tsx
+++ b/frontend/src/pages/admin/SettingsPage.tsx
@@ -106,7 +106,7 @@ export default function SettingsPage() {
         <div className="flex items-center gap-3">
           <Settings className="w-8 h-8 text-primary" />
           <div>
-            <h1 className="text-2xl font-bold">Settings</h1>
+            <h1 className="text-2xl font-semibold">Settings</h1>
             <p className="text-sm text-muted-foreground">Configure business parameters</p>
           </div>
         </div>

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -93,7 +93,7 @@ export default function UsersPage() {
         <div className="flex items-center gap-3">
           <Users className="w-8 h-8 text-primary" />
           <div>
-            <h1 className="text-2xl font-bold">User Management</h1>
+            <h1 className="text-2xl font-semibold">User Management</h1>
             <p className="text-sm text-muted-foreground">Manage user accounts and roles</p>
           </div>
         </div>

--- a/frontend/src/pages/reports/InventoryReportPage.tsx
+++ b/frontend/src/pages/reports/InventoryReportPage.tsx
@@ -6,6 +6,7 @@ import { formatCurrency } from '@/lib/utils';
 import ReportControls from '@/components/ui/ReportControls';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import DataTable from '@/components/data/DataTable';
+import { KPIStrip, KPI } from '@/components/layout/KPIStrip';
 import type { InventoryReport, StockLevelRow } from '@/types';
 
 const COLORS = ['#6366f1', '#8b5cf6', '#a78bfa', '#c4b5fd', '#ddd6fe', '#e0e7ff'];
@@ -33,7 +34,7 @@ export default function InventoryReportPage() {
 
   return (
     <div>
-      <h2 className="text-2xl font-bold mb-6">Inventory Report</h2>
+      <h2 className="text-xl font-semibold mb-6">Inventory Report</h2>
 
       <ReportControls
         dateFrom={dateFrom}
@@ -49,22 +50,15 @@ export default function InventoryReportPage() {
       ) : !data ? null : (
         <div className="space-y-8">
           {/* Summary cards */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Total Products</p>
-              <p className="text-3xl font-bold mt-1">{data.total_products}</p>
-            </div>
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Stock Value</p>
-              <p className="text-3xl font-bold mt-1">{formatCurrency(data.total_stock_value)}</p>
-            </div>
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Low Stock Items</p>
-              <p className={`text-3xl font-bold mt-1 ${data.low_stock_count > 0 ? 'text-amber-600 dark:text-amber-400' : ''}`}>
-                {data.low_stock_count}
-              </p>
-            </div>
-          </div>
+          <KPIStrip columns={3}>
+            <KPI label="Total products" value={data.total_products.toLocaleString()} />
+            <KPI label="Stock value" value={formatCurrency(data.total_stock_value)} />
+            <KPI
+              label="Low stock"
+              value={data.low_stock_count}
+              tone={data.low_stock_count > 0 ? 'warning' : 'default'}
+            />
+          </KPIStrip>
 
           {/* Stock levels table */}
           {data.stock_levels.length > 0 && (
@@ -87,7 +81,7 @@ export default function InventoryReportPage() {
                     cell: (row) => (
                       <span
                         className={
-                          row.is_low_stock ? 'text-amber-600 dark:text-amber-400 font-bold' : ''
+                          row.is_low_stock ? 'text-amber-600 dark:text-amber-400 font-semibold' : ''
                         }
                       >
                         {row.stock_qty}

--- a/frontend/src/pages/reports/PLReportPage.tsx
+++ b/frontend/src/pages/reports/PLReportPage.tsx
@@ -6,6 +6,7 @@ import { formatCurrency, formatPercent } from '@/lib/utils';
 import ReportControls from '@/components/ui/ReportControls';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import DataTable from '@/components/data/DataTable';
+import { KPIStrip, KPI } from '@/components/layout/KPIStrip';
 import type { PLReport, PLRow } from '@/types';
 
 const formatTooltipCurrency = (value: string | number | readonly (string | number)[] | undefined) => {
@@ -36,7 +37,7 @@ export default function PLReportPage() {
 
   return (
     <div>
-      <h2 className="text-2xl font-bold mb-6">Profit & Loss</h2>
+      <h2 className="text-xl font-semibold mb-6">Profit & Loss</h2>
 
       <ReportControls
         dateFrom={dateFrom}
@@ -53,31 +54,24 @@ export default function PLReportPage() {
       ) : !data || !s ? null : (
         <div className="space-y-8">
           {/* Summary cards */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Realized Sales Revenue</p>
-              <p className="text-2xl font-bold mt-1">{formatCurrency(s.total_revenue)}</p>
-              <p className="text-xs text-muted-foreground mt-1">
-                Sales basis only: {formatCurrency(s.sales_revenue)}
-              </p>
-            </div>
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Total Costs</p>
-              <p className="text-2xl font-bold mt-1">{formatCurrency(s.total_costs)}</p>
-            </div>
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Gross Profit</p>
-              <p className={`text-2xl font-bold mt-1 ${s.gross_profit >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                {formatCurrency(s.gross_profit)}
-              </p>
-            </div>
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Profit Margin</p>
-              <p className={`text-2xl font-bold mt-1 ${s.profit_margin_pct >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                {formatPercent(s.profit_margin_pct)}
-              </p>
-            </div>
-          </div>
+          <KPIStrip columns={4}>
+            <KPI
+              label="Realized sales revenue"
+              value={formatCurrency(s.total_revenue)}
+              sub={`Sales basis only: ${formatCurrency(s.sales_revenue)}`}
+            />
+            <KPI label="Total costs" value={formatCurrency(s.total_costs)} />
+            <KPI
+              label="Gross profit"
+              value={formatCurrency(s.gross_profit)}
+              tone={s.gross_profit >= 0 ? 'success' : 'destructive'}
+            />
+            <KPI
+              label="Profit margin"
+              value={formatPercent(s.profit_margin_pct)}
+              tone={s.profit_margin_pct >= 0 ? 'success' : 'destructive'}
+            />
+          </KPIStrip>
 
           <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4 text-sm text-amber-900 dark:text-amber-100">
             <p className="font-medium">Reporting basis: sales-realized revenue</p>

--- a/frontend/src/pages/reports/ReportsLayout.tsx
+++ b/frontend/src/pages/reports/ReportsLayout.tsx
@@ -1,4 +1,5 @@
 import { NavLink, Outlet } from 'react-router-dom';
+import PageHeader from '@/components/layout/PageHeader';
 import { cn } from '@/lib/utils';
 
 const tabs = [
@@ -9,11 +10,14 @@ const tabs = [
 
 export default function ReportsLayout() {
   return (
-    <div>
-      <h1 className="text-3xl font-bold mb-6">Reports</h1>
+    <div className="space-y-6">
+      <PageHeader
+        title="Reports"
+        description="Slice sales, inventory, and profitability across periods and channels."
+      />
 
       {/* Sub-navigation tabs */}
-      <div className="border-b border-border mb-6">
+      <div className="border-b border-border">
         <nav className="flex gap-1 -mb-px">
           {tabs.map((tab) => (
             <NavLink

--- a/frontend/src/pages/reports/SalesReportPage.tsx
+++ b/frontend/src/pages/reports/SalesReportPage.tsx
@@ -6,6 +6,7 @@ import { formatCurrency } from '@/lib/utils';
 import ReportControls from '@/components/ui/ReportControls';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import DataTable from '@/components/data/DataTable';
+import { KPIStrip, KPI } from '@/components/layout/KPIStrip';
 import type { SalesReport, ProductRanking, ChannelBreakdown } from '@/types';
 
 const formatTooltipCurrency = (value: string | number | readonly (string | number)[] | undefined) => {
@@ -34,7 +35,7 @@ export default function SalesReportPage() {
 
   return (
     <div>
-      <h2 className="text-2xl font-bold mb-6">Sales Report</h2>
+      <h2 className="text-xl font-semibold mb-6">Sales Report</h2>
 
       <ReportControls
         dateFrom={dateFrom}
@@ -51,36 +52,25 @@ export default function SalesReportPage() {
       ) : !data ? null : (
         <div className="space-y-8">
           {/* Summary cards */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Total Orders</p>
-              <p className="text-3xl font-bold mt-1">{data.total_orders}</p>
-            </div>
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Gross Sales</p>
-              <p className="text-3xl font-bold mt-1">{formatCurrency(data.gross_sales)}</p>
-            </div>
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Item COGS</p>
-              <p className="text-3xl font-bold mt-1">{formatCurrency(data.item_cogs)}</p>
-            </div>
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Gross Profit</p>
-              <p className={`text-3xl font-bold mt-1 ${data.gross_profit >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                {formatCurrency(data.gross_profit)}
-              </p>
-            </div>
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Platform Fees + Shipping</p>
-              <p className="text-3xl font-bold mt-1">{formatCurrency(data.platform_fees + data.shipping_costs)}</p>
-            </div>
-            <div className="bg-card border border-border rounded-lg p-6 text-center">
-              <p className="text-sm text-muted-foreground">Contribution Margin</p>
-              <p className={`text-3xl font-bold mt-1 ${data.contribution_margin >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                {formatCurrency(data.contribution_margin)}
-              </p>
-            </div>
-          </div>
+          <KPIStrip columns={3}>
+            <KPI label="Orders" value={data.total_orders.toLocaleString()} />
+            <KPI label="Gross sales" value={formatCurrency(data.gross_sales)} />
+            <KPI label="Item COGS" value={formatCurrency(data.item_cogs)} />
+            <KPI
+              label="Gross profit"
+              value={formatCurrency(data.gross_profit)}
+              tone={data.gross_profit >= 0 ? 'success' : 'destructive'}
+            />
+            <KPI
+              label="Fees + shipping"
+              value={formatCurrency(data.platform_fees + data.shipping_costs)}
+            />
+            <KPI
+              label="Contribution margin"
+              value={formatCurrency(data.contribution_margin)}
+              tone={data.contribution_margin >= 0 ? 'success' : 'destructive'}
+            />
+          </KPIStrip>
 
           {/* Revenue over time chart */}
           {data.period_data.length > 0 && (


### PR DESCRIPTION
Closes #180. Parent epic: #173 (P1 tier — first cross-cutting pass after the workspace revamps).

## Summary

- **T1** — 5 page titles migrated to `<PageHeader>` (SalesChannels, JobForm, SaleForm, SaleDetail, ReportsLayout)
- **T3** — All 3 report pages' hero KPI blocks rebuilt on `<KPIStrip>` + `<KPI>` with tone (success / destructive / warning) replacing raw `text-green-600` / `text-red-600`
- **T4** — Repo-wide `font-bold` → `font-semibold` sweep (11 files)
- **T6** — `tabular-nums` on numeric cells outside DataTable (SalesChannels fee cells)
- **T7** — `tracking-[0.Nem]` eyebrow removal across ProductEditor, PrinterDetail, and the 4 layout chrome files (Footer, WorkspaceLocalNav, Layout, Header)

## Acceptance

- [x] `rg 'text-3xl font-bold' src` → **0**
- [x] `rg 'text-3xl' src` → **0**
- [x] `rg 'font-bold' src` → **0**
- [x] `rg 'tracking-\[0\.' src` → **0**
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → **44 tests passing**

## Test plan

- [ ] Load `/sell/channels` → "Sales Channels" with PageHeader + Add-channel action
- [ ] Load `/reports/sales` → 6-KPI strip with green/red tones on Gross profit + Contribution margin
- [ ] Load `/reports/inventory` → 3-KPI strip with amber Low-stock tone
- [ ] Load `/reports/pl` → 4-KPI strip
- [ ] Load `/orders/jobs/new` → "New Job" PageHeader
- [ ] Load `/sell/sales/new` → "New Sale" PageHeader with back action
- [ ] Load `/sell/sales/{id}` → sale-number PageHeader with status + actions
- [ ] Verify no headings burst larger than PageHeader's `text-2xl` on any page
- [ ] Confirm sidebar / header eyebrows still read as labels, just tighter

🤖 Generated with [Claude Code](https://claude.com/claude-code)