### PR TITLE
feat(ui): Callout primitive + color & chart-palette tokens (#186)

### DIFF
--- a/frontend/src/components/ui/Callout.tsx
+++ b/frontend/src/components/ui/Callout.tsx
@@ -1,0 +1,71 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export type CalloutTone = 'warning' | 'success' | 'info' | 'danger' | 'neutral';
+
+/**
+ * Shared tone className strings. Pages can import these for card-level
+ * warning tints inside iterators (e.g. a PrinterWallCard signalling a
+ * needs-attention state) without re-declaring the same amber classes.
+ * Prefer the `<Callout>` component for standalone banner/panel surfaces;
+ * reach for these constants when the surface must stay a plain card.
+ */
+export const calloutToneClasses: Record<CalloutTone, string> = {
+  warning:
+    'border-amber-300/60 bg-amber-50/80 text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200',
+  success:
+    'border-emerald-300/60 bg-emerald-50/80 text-emerald-900 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200',
+  info: 'border-sky-300/60 bg-sky-50/80 text-sky-900 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-200',
+  danger:
+    'border-destructive/40 bg-destructive/10 text-destructive dark:border-destructive/30 dark:bg-destructive/15',
+  neutral: 'border-border bg-muted text-foreground',
+};
+
+const toneStyles = calloutToneClasses;
+
+export interface CalloutProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+  tone?: CalloutTone;
+  /** Optional leading icon (Lucide). Rendered at `h-4 w-4` before the children. */
+  icon?: ReactNode;
+  /** Optional title rendered in bold above the body. */
+  title?: ReactNode;
+}
+
+/**
+ * Shared "banner" / "panel" component for inline warnings, confirmations,
+ * and info notes. Replaces hand-rolled `bg-amber-50 border-amber-300/60`
+ * panels. Keep copy short — this is shop-floor chrome, not marketing.
+ *
+ * Usage:
+ * ```tsx
+ * <Callout tone="warning" icon={<TriangleAlert className="h-4 w-4" />}
+ *          title="Printers need attention">
+ *   Two machines are paused. Start from the Print Floor.
+ * </Callout>
+ * ```
+ */
+export const Callout = forwardRef<HTMLDivElement, CalloutProps>(function Callout(
+  { className, tone = 'warning', icon, title, children, ...props },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      role="status"
+      {...props}
+      className={cn(
+        'rounded-md border p-4 text-sm shadow-xs',
+        toneStyles[tone],
+        className,
+      )}
+    >
+      <div className="flex items-start gap-2">
+        {icon ? <span className="mt-0.5 shrink-0">{icon}</span> : null}
+        <div className="min-w-0 flex-1 space-y-1">
+          {title ? <p className="font-semibold">{title}</p> : null}
+          {children ? <div className={cn(title ? 'text-sm opacity-90' : '')}>{children}</div> : null}
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/pages/ControlCenterPage.tsx
+++ b/frontend/src/pages/ControlCenterPage.tsx
@@ -7,6 +7,7 @@ import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import PageHeader from '@/components/layout/PageHeader';
 import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
 import { Button } from '@/components/ui/Button';
+import { Callout, calloutToneClasses } from '@/components/ui/Callout';
 import { useAuthStore } from '@/store/auth';
 import { cn, formatCurrency, formatPercent } from '@/lib/utils';
 import type {
@@ -197,76 +198,76 @@ export default function ControlCenterPage() {
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.75fr)]">
         <div className="space-y-6">
-          {(roleMode === 'floor' || roleMode === 'admin' || roleMode === 'general') && (
-            <section
-              className={cn(
-                'rounded-md border p-5 shadow-xs space-y-4',
-                attentionPrinters.length > 0
-                  ? 'border-amber-300/60 bg-amber-50/80 dark:border-amber-500/30 dark:bg-amber-500/10'
-                  : 'border-border bg-card'
-              )}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <h2 className="text-base font-semibold">Print-floor priorities</h2>
-                <Button asChild variant="outline" size="sm">
-                  <Link to="/print-floor">
-                    Open Print Floor <ArrowRight className="h-3.5 w-3.5" />
-                  </Link>
-                </Button>
-              </div>
-              {!printers.length ? (
-                <p className="text-sm text-muted-foreground">No active printers are available.</p>
-              ) : (
-                <div className="grid gap-3 lg:grid-cols-2">
-                  {printers.slice(0, 4).map((printer) => {
-                    const needsAttention = ATTENTION_STATUSES.has(printer.monitor_status || printer.status);
-                    return (
-                      <Link
-                        key={printer.id}
-                        to={`/print-floor/printers/${printer.id}`}
-                        className={cn(
-                          'grid grid-cols-[88px_minmax(0,1fr)] gap-4 rounded-md border p-3 no-underline transition-colors',
-                          needsAttention
-                            ? 'border-amber-300/70 bg-amber-50/70 dark:border-amber-500/30 dark:bg-amber-500/10'
-                            : 'border-border bg-background hover:bg-muted'
-                        )}
-                      >
-                        <PrinterThumbnail
-                          src={printer.current_print_thumbnail_url}
-                          alt={printer.current_print_name || `${printer.name} thumbnail`}
-                          className="h-[88px] w-[88px] rounded-md"
-                          imgClassName="object-cover"
-                          fallbackLabel="No view"
-                        />
-                        <div className="min-w-0">
-                          <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0">
-                              <p className="truncate font-semibold text-foreground">{printer.name}</p>
-                              <p className="truncate text-xs capitalize text-muted-foreground">
-                                {printer.monitor_status || printer.status}
-                              </p>
-                            </div>
-                            <span className="text-sm font-semibold text-foreground">
-                              {printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}
-                            </span>
-                          </div>
-                          <p className="mt-2 truncate text-sm text-muted-foreground">
-                            {printer.current_print_name || 'No active print'}
-                          </p>
-                          <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
-                            <p>Layer {formatLayer(printer)}</p>
-                            <p>ETA {formatDuration(printer.monitor_remaining_seconds)}</p>
-                            <p>{printer.location || 'No bay assigned'}</p>
-                            <p>{printer.monitor_ws_connected ? 'Socket live' : 'Polling'}</p>
-                          </div>
-                        </div>
-                      </Link>
-                    );
-                  })}
+          {(roleMode === 'floor' || roleMode === 'admin' || roleMode === 'general') && (() => {
+            const content = (
+              <>
+                <div className="flex items-start justify-between gap-3">
+                  <h2 className="text-base font-semibold">Print-floor priorities</h2>
+                  <Button asChild variant="outline" size="sm">
+                    <Link to="/print-floor">
+                      Open Print Floor <ArrowRight className="h-3.5 w-3.5" />
+                    </Link>
+                  </Button>
                 </div>
-              )}
-            </section>
-          )}
+                {!printers.length ? (
+                  <p className="text-sm text-muted-foreground">No active printers are available.</p>
+                ) : (
+                  <div className="grid gap-3 lg:grid-cols-2">
+                    {printers.slice(0, 4).map((printer) => {
+                      const needsAttention = ATTENTION_STATUSES.has(printer.monitor_status || printer.status);
+                      return (
+                        <Link
+                          key={printer.id}
+                          to={`/print-floor/printers/${printer.id}`}
+                          className={cn(
+                            'grid grid-cols-[88px_minmax(0,1fr)] gap-4 rounded-md border p-3 no-underline transition-colors',
+                            needsAttention
+                              ? calloutToneClasses.warning
+                              : 'border-border bg-background hover:bg-muted'
+                          )}
+                        >
+                          <PrinterThumbnail
+                            src={printer.current_print_thumbnail_url}
+                            alt={printer.current_print_name || `${printer.name} thumbnail`}
+                            className="h-[88px] w-[88px] rounded-md"
+                            imgClassName="object-cover"
+                            fallbackLabel="No view"
+                          />
+                          <div className="min-w-0">
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0">
+                                <p className="truncate font-semibold text-foreground">{printer.name}</p>
+                                <p className="truncate text-xs capitalize text-muted-foreground">
+                                  {printer.monitor_status || printer.status}
+                                </p>
+                              </div>
+                              <span className="text-sm font-semibold text-foreground">
+                                {printer.monitor_progress_percent != null ? `${printer.monitor_progress_percent.toFixed(0)}%` : '—'}
+                              </span>
+                            </div>
+                            <p className="mt-2 truncate text-sm text-muted-foreground">
+                              {printer.current_print_name || 'No active print'}
+                            </p>
+                            <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+                              <p>Layer {formatLayer(printer)}</p>
+                              <p>ETA {formatDuration(printer.monitor_remaining_seconds)}</p>
+                              <p>{printer.location || 'No bay assigned'}</p>
+                              <p>{printer.monitor_ws_connected ? 'Socket live' : 'Polling'}</p>
+                            </div>
+                          </div>
+                        </Link>
+                      );
+                    })}
+                  </div>
+                )}
+              </>
+            );
+            return attentionPrinters.length > 0 ? (
+              <Callout tone="warning"><div className="space-y-4">{content}</div></Callout>
+            ) : (
+              <section className="rounded-md border border-border bg-card p-5 shadow-xs space-y-4">{content}</section>
+            );
+          })()}
 
           {(roleMode === 'cashier' || roleMode === 'admin' || roleMode === 'general') && (
             <section className="rounded-md border border-border bg-card p-5 shadow-xs space-y-4">
@@ -311,86 +312,89 @@ export default function ControlCenterPage() {
             </section>
           )}
 
-          {(roleMode === 'inventory' || roleMode === 'admin' || roleMode === 'general') && (
-            <section
-              className={cn(
-                'rounded-md border p-5 shadow-xs space-y-4',
-                blockerAlerts.length > 0
-                  ? 'border-amber-300/60 bg-amber-50/80 dark:border-amber-500/30 dark:bg-amber-500/10'
-                  : 'border-border bg-card'
-              )}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <h2 className="text-base font-semibold">Stock blockers</h2>
-                <Button asChild variant="outline" size="sm">
-                  <Link to="/stock">
-                    Open Stock Workspace <ArrowRight className="h-3.5 w-3.5" />
-                  </Link>
-                </Button>
-              </div>
-              {!blockerAlerts.length ? (
-                <p className="text-sm text-muted-foreground">No low-stock blockers are currently open.</p>
-              ) : (
-                <div className="grid gap-3 md:grid-cols-2">
-                  {blockerAlerts.map((alert) => (
-                    <Link
-                      key={`${alert.type}-${alert.id}`}
-                      to={alert.type === 'product' ? `/product-studio/products/${alert.id}` : '/stock/materials'}
-                      className="flex items-center justify-between rounded-md border border-border bg-background px-4 py-3 text-sm no-underline transition-colors hover:bg-muted"
-                    >
-                      <div className="min-w-0">
-                        <p className="truncate font-medium text-foreground">{alert.name}</p>
-                        <p className="truncate text-xs text-muted-foreground">
-                          {alert.type === 'product' ? alert.sku || 'Product' : 'Material'}
-                        </p>
-                      </div>
-                      <div className="text-right">
-                        <p className="font-semibold text-amber-600 dark:text-amber-300">{alert.current_stock}</p>
-                        <p className="text-xs text-muted-foreground">reorder {alert.reorder_point}</p>
-                      </div>
+          {(roleMode === 'inventory' || roleMode === 'admin' || roleMode === 'general') && (() => {
+            const content = (
+              <>
+                <div className="flex items-start justify-between gap-3">
+                  <h2 className="text-base font-semibold">Stock blockers</h2>
+                  <Button asChild variant="outline" size="sm">
+                    <Link to="/stock">
+                      Open Stock Workspace <ArrowRight className="h-3.5 w-3.5" />
                     </Link>
-                  ))}
+                  </Button>
                 </div>
-              )}
-            </section>
-          )}
+                {!blockerAlerts.length ? (
+                  <p className="text-sm text-muted-foreground">No low-stock blockers are currently open.</p>
+                ) : (
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {blockerAlerts.map((alert) => (
+                      <Link
+                        key={`${alert.type}-${alert.id}`}
+                        to={alert.type === 'product' ? `/product-studio/products/${alert.id}` : '/stock/materials'}
+                        className="flex items-center justify-between rounded-md border border-border bg-background px-4 py-3 text-sm no-underline transition-colors hover:bg-muted"
+                      >
+                        <div className="min-w-0">
+                          <p className="truncate font-medium text-foreground">{alert.name}</p>
+                          <p className="truncate text-xs text-muted-foreground">
+                            {alert.type === 'product' ? alert.sku || 'Product' : 'Material'}
+                          </p>
+                        </div>
+                        <div className="text-right">
+                          <p className="font-semibold text-amber-600 dark:text-amber-300">{alert.current_stock}</p>
+                          <p className="text-xs text-muted-foreground">reorder {alert.reorder_point}</p>
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </>
+            );
+            return blockerAlerts.length > 0 ? (
+              <Callout tone="warning"><div className="space-y-4">{content}</div></Callout>
+            ) : (
+              <section className="rounded-md border border-border bg-card p-5 shadow-xs space-y-4">{content}</section>
+            );
+          })()}
         </div>
 
         <div className="space-y-6">
-          <section
-            className={cn(
-              'rounded-md border p-5 shadow-xs space-y-4',
-              attentionPrinters.length + unassignedDraftJobs.length + blockerAlerts.length > 0
-                ? 'border-amber-300/60 bg-amber-50/80 dark:border-amber-500/30 dark:bg-amber-500/10'
-                : 'border-border bg-card'
-            )}
-          >
-            <h2 className="text-base font-semibold">Needs attention now</h2>
-            <ul className="space-y-3">
-              <li className="flex items-start gap-3">
-                <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
-                <div className="min-w-0">
-                  <p className="font-medium text-foreground">Printers needing attention</p>
-                  <p className="text-sm text-muted-foreground">
-                    {attentionPrinters.length
-                      ? `${attentionPrinters.length} printers are paused, offline, or in error.`
-                      : 'No printer exceptions currently open.'}
-                  </p>
-                </div>
-              </li>
-              <li className="flex items-start gap-3">
-                <Package className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
-                <div className="min-w-0">
-                  <p className="font-medium text-foreground">Draft jobs needing assignment</p>
-                  <p className="text-sm text-muted-foreground">
-                    {unassignedDraftJobs.length
-                      ? `${unassignedDraftJobs.length} draft jobs are still missing a printer.`
-                      : 'No unassigned draft jobs.'}
-                  </p>
-                </div>
-              </li>
-            </ul>
-          </section>
+          {(() => {
+            const hasAttention = attentionPrinters.length + unassignedDraftJobs.length + blockerAlerts.length > 0;
+            const content = (
+              <>
+                <h2 className="text-base font-semibold">Needs attention now</h2>
+                <ul className="space-y-3">
+                  <li className="flex items-start gap-3">
+                    <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+                    <div className="min-w-0">
+                      <p className="font-medium text-foreground">Printers needing attention</p>
+                      <p className="text-sm text-muted-foreground">
+                        {attentionPrinters.length
+                          ? `${attentionPrinters.length} printers are paused, offline, or in error.`
+                          : 'No printer exceptions currently open.'}
+                      </p>
+                    </div>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <Package className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+                    <div className="min-w-0">
+                      <p className="font-medium text-foreground">Draft jobs needing assignment</p>
+                      <p className="text-sm text-muted-foreground">
+                        {unassignedDraftJobs.length
+                          ? `${unassignedDraftJobs.length} draft jobs are still missing a printer.`
+                          : 'No unassigned draft jobs.'}
+                      </p>
+                    </div>
+                  </li>
+                </ul>
+              </>
+            );
+            return hasAttention ? (
+              <Callout tone="warning"><div className="space-y-4">{content}</div></Callout>
+            ) : (
+              <section className="rounded-md border border-border bg-card p-5 shadow-xs space-y-4">{content}</section>
+            );
+          })()}
 
           <section className="rounded-md border border-border bg-card p-5 shadow-xs space-y-4">
             <h2 className="text-base font-semibold">Business pulse</h2>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -28,6 +28,7 @@ import PageHeader from '@/components/layout/PageHeader';
 import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
 import { ChartTooltip, chartCategoricalPalette } from '@/components/charts/ChartTooltip';
 import EmptyState from '@/components/ui/EmptyState';
+import { Callout } from '@/components/ui/Callout';
 import { SkeletonCard } from '@/components/ui/Skeleton';
 import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import { formatCurrency, formatPercent } from '@/lib/utils';
@@ -152,11 +153,11 @@ export default function DashboardPage() {
 
       {/* Inventory Alerts */}
       {alerts && alerts.length > 0 ? (
-        <section className="rounded-md border border-amber-300/60 bg-amber-50/80 p-4 dark:border-amber-500/30 dark:bg-amber-500/10">
-          <div className="mb-3 flex items-center gap-2">
-            <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" aria-hidden="true" />
-            <h2 className="text-sm font-semibold text-amber-800 dark:text-amber-300">Low stock alerts</h2>
-          </div>
+        <Callout
+          tone="warning"
+          icon={<AlertTriangle className="h-4 w-4" aria-hidden="true" />}
+          title="Low stock alerts"
+        >
           <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
             {alerts.map((a) => (
               <Link
@@ -174,7 +175,7 @@ export default function DashboardPage() {
               </Link>
             ))}
           </div>
-        </section>
+        </Callout>
       ) : null}
 
       {printersData?.items?.length ? (

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -17,6 +17,7 @@ import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/Tabs';
+import { Callout } from '@/components/ui/Callout';
 import PageHeader from '@/components/layout/PageHeader';
 import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
 import DataTable, { type Column, type SortDir } from '@/components/data/DataTable';
@@ -694,13 +695,17 @@ export default function InventoryPage() {
             </section>
 
             {materialAlerts.length > 0 ? (
-              <section className="rounded-md border border-amber-300/60 bg-amber-50/80 p-4 dark:border-amber-500/30 dark:bg-amber-500/10">
-                <div className="mb-2 flex items-center justify-between">
-                  <h2 className="text-sm font-semibold text-amber-800 dark:text-amber-300">Material signals</h2>
-                  <Button asChild variant="ghost" size="sm" className="h-6 px-2 text-xs">
-                    <Link to="/stock/materials">Open</Link>
-                  </Button>
-                </div>
+              <Callout
+                tone="warning"
+                title={
+                  <span className="flex items-center justify-between gap-2">
+                    <span>Material signals</span>
+                    <Button asChild variant="ghost" size="sm" className="h-6 px-2 text-xs">
+                      <Link to="/stock/materials">Open</Link>
+                    </Button>
+                  </span>
+                }
+              >
                 <ul className="space-y-1 text-sm">
                   {materialAlerts.slice(0, 6).map((alert) => (
                     <li key={`${alert.type}-${alert.id}`} className="flex items-center justify-between gap-3">
@@ -716,7 +721,7 @@ export default function InventoryPage() {
                     </li>
                   ))}
                 </ul>
-              </section>
+              </Callout>
             ) : null}
           </aside>
         </div>

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -163,7 +163,7 @@ export default function JobDetailPage() {
             </div>
             <div className="flex justify-between py-2 mt-2 border-t-2 border-border">
               <span className="font-semibold">Net Profit</span>
-              <span className={`font-semibold text-lg ${job.net_profit >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'}`}>
+              <span className={`font-semibold text-lg ${job.net_profit >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive'}`}>
                 {formatCurrency(job.net_profit)}
               </span>
             </div>

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -524,7 +524,7 @@ export default function JobFormPage() {
                 </div>
                 <div className="border-t-2 border-border pt-2 mt-2 flex justify-between font-semibold text-lg">
                   <span>Net Profit</span>
-                  <span className={preview.net_profit >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'}>
+                  <span className={preview.net_profit >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive'}>
                     {formatCurrency(preview.net_profit)}
                   </span>
                 </div>

--- a/frontend/src/pages/OrdersPage.tsx
+++ b/frontend/src/pages/OrdersPage.tsx
@@ -10,6 +10,7 @@ import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import TableToolbar from '@/components/data/TableToolbar';
 import { Button } from '@/components/ui/Button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/Tabs';
+import { Callout } from '@/components/ui/Callout';
 import { formatCurrency } from '@/lib/utils';
 import type {
   Customer,
@@ -369,11 +370,11 @@ export default function OrdersPage() {
           </section>
 
           {attentionPrinters.length > 0 ? (
-            <section className="rounded-md border border-amber-300/60 bg-amber-50/80 p-4 dark:border-amber-500/30 dark:bg-amber-500/10">
-              <div className="mb-2 flex items-center gap-2">
-                <TriangleAlert className="h-4 w-4 text-amber-600 dark:text-amber-400" aria-hidden="true" />
-                <h2 className="text-sm font-semibold text-amber-800 dark:text-amber-300">Printers need attention</h2>
-              </div>
+            <Callout
+              tone="warning"
+              icon={<TriangleAlert className="h-4 w-4" aria-hidden="true" />}
+              title="Printers need attention"
+            >
               <ul className="space-y-1 text-sm">
                 {attentionPrinters.slice(0, 6).map((printer) => (
                   <li key={printer.id} className="flex items-center justify-between gap-3">
@@ -389,7 +390,7 @@ export default function OrdersPage() {
                   </li>
                 ))}
               </ul>
-            </section>
+            </Callout>
           ) : null}
         </aside>
       </div>

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -24,6 +24,7 @@ import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/Tabs';
+import { Callout } from '@/components/ui/Callout';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import { cn, formatCurrency } from '@/lib/utils';
 import {
@@ -372,15 +373,13 @@ export default function POSPage() {
       </PageHeader>
 
       {successMessage ? (
-        <div className="rounded-md border border-emerald-300 bg-emerald-50 px-5 py-4 text-emerald-900 shadow-sm" role="status">
-          <div className="flex items-start gap-3">
-            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0" />
-            <div>
-              <p className="font-semibold">Checkout complete</p>
-              <p className="mt-1 text-sm">{successMessage}</p>
-            </div>
-          </div>
-        </div>
+        <Callout
+          tone="success"
+          icon={<CheckCircle2 className="h-5 w-5" />}
+          title="Checkout complete"
+        >
+          {successMessage}
+        </Callout>
       ) : null}
 
       {checkoutError ? (
@@ -429,16 +428,12 @@ export default function POSPage() {
             </form>
 
             {scanStatus ? (
-              <div
-                className={cn(
-                  'mt-4 rounded-md border px-4 py-3 text-sm',
-                  scanStatus.startsWith('Scanned ')
-                    ? 'border-emerald-300 bg-emerald-50 text-emerald-900'
-                    : 'border-amber-300 bg-amber-50 text-amber-900'
-                )}
+              <Callout
+                tone={scanStatus.startsWith('Scanned ') ? 'success' : 'warning'}
+                className="mt-4"
               >
                 {scanStatus}
-              </div>
+              </Callout>
             ) : null}
           </div>
 
@@ -814,12 +809,14 @@ export default function POSPage() {
               </Button>
             ) : null}
 
-            <div className="mt-4 rounded-md border border-amber-300/60 bg-amber-50 p-3 text-sm text-amber-900">
-              <div className="flex items-start gap-2">
-                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-                <p>Checkout blocks oversell when requested quantity exceeds available stock.</p>
-              </div>
-            </div>
+            <Callout
+              tone="warning"
+              icon={<AlertTriangle className="h-4 w-4" />}
+              className="mt-4"
+              role="note"
+            >
+              Checkout blocks oversell when requested quantity exceeds available stock.
+            </Callout>
           </section>
 
           <section className="rounded-lg border border-border bg-card p-5 shadow-sm">

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -355,10 +355,10 @@ export default function PrinterDetailPage() {
               {printer.monitor_last_error ? (
                 <div className="rounded-md border border-red-300/60 bg-red-50/80 p-4 dark:border-red-500/30 dark:bg-red-500/10">
                   <div className="flex items-start gap-3">
-                    <AlertTriangle className="mt-0.5 h-4 w-4 text-red-600 dark:text-red-300" />
+                    <AlertTriangle className="mt-0.5 h-4 w-4 text-destructive" />
                     <div>
-                      <p className="text-xs text-red-700 dark:text-red-200">Last monitor error</p>
-                      <p className="mt-2 text-sm text-red-700 dark:text-red-100">{printer.monitor_last_error}</p>
+                      <p className="text-xs text-destructive">Last monitor error</p>
+                      <p className="mt-2 text-sm text-destructive">{printer.monitor_last_error}</p>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -20,6 +20,7 @@ import CameraFeed from '@/components/cameras/CameraFeed';
 import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import EmptyState from '@/components/ui/EmptyState';
 import { Button } from '@/components/ui/Button';
+import { Callout, calloutToneClasses } from '@/components/ui/Callout';
 import PageHeader from '@/components/layout/PageHeader';
 import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
 import SearchInput from '@/components/data/SearchInput';
@@ -82,7 +83,7 @@ function PrinterWallCard({
         'rounded-md border p-4 shadow-xs',
         !reducedMotion && 'transition-colors',
         needsAttention
-          ? 'border-amber-300/70 bg-amber-50/80 dark:border-amber-500/30 dark:bg-amber-500/10'
+          ? calloutToneClasses.warning
           : wallMode
             ? 'border-slate-700/80 bg-slate-950/85 text-slate-50'
             : 'border-border bg-card'
@@ -332,7 +333,7 @@ export default function PrintersPage() {
         emptyText: 'No printers currently need operator attention.',
         icon: AlertTriangle,
         accentClass: 'text-amber-600 dark:text-amber-300',
-        panelTone: 'border-amber-300/70 bg-amber-50/70 dark:border-amber-500/30 dark:bg-amber-500/8',
+        panelTone: undefined,
         printers: activePrinters.filter((printer) => ATTENTION_STATUSES.has(printer.monitor_status || printer.status)),
       },
       {
@@ -532,12 +533,8 @@ export default function PrintersPage() {
         <div className={cn('grid gap-4', wallMode ? 'xl:grid-cols-2 2xl:grid-cols-3' : 'xl:grid-cols-3')}>
           {wallGroups.map((group) => {
             const Icon = group.icon;
-
-            return (
-              <section
-                key={group.key}
-                className={cn('rounded-lg border p-4 shadow-xs', group.panelTone || 'border-border bg-card')}
-              >
+            const body = (
+              <>
                 <div className="mb-4 flex items-start justify-between gap-3">
                   <div>
                     <div className="flex items-center gap-2">
@@ -569,6 +566,24 @@ export default function PrintersPage() {
                     {group.emptyText}
                   </div>
                 )}
+              </>
+            );
+
+            if (group.key === 'attention' && group.printers.length > 0) {
+              return (
+                <Callout key={group.key} tone="warning">
+                  <div>{body}</div>
+                </Callout>
+              );
+            }
+
+            const defaultTone = group.key === 'attention' ? undefined : group.panelTone;
+            return (
+              <section
+                key={group.key}
+                className={cn('rounded-lg border p-4 shadow-xs', defaultTone || 'border-border bg-card')}
+              >
+                {body}
               </section>
             );
           })}

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -239,7 +239,7 @@ export default function ProductDetailPage() {
               </div>
               <div className="flex items-center justify-between gap-4">
                 <span className="text-muted-foreground">Inventory adjustment</span>
-                <span className="font-semibold text-red-600 dark:text-red-400">-{currentProduct.stock_qty}</span>
+                <span className="font-semibold text-destructive">-{currentProduct.stock_qty}</span>
               </div>
             </div>
             <p className="text-sm text-muted-foreground">
@@ -325,7 +325,7 @@ export default function ProductDetailPage() {
                   <td className="px-4 py-3">
                     <StatusBadge tone={defaultStatusTone(t.type)}>{t.type}</StatusBadge>
                   </td>
-                  <td className={`px-4 py-3 text-right font-medium ${t.quantity > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                  <td className={`px-4 py-3 text-right font-medium ${t.quantity > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive'}`}>
                     {t.quantity > 0 ? '+' : ''}{t.quantity}
                   </td>
                   <td className="px-4 py-3 text-right">{formatCurrency(t.unit_cost)}</td>

--- a/frontend/src/pages/ProductEditorPage.tsx
+++ b/frontend/src/pages/ProductEditorPage.tsx
@@ -19,6 +19,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
+import { Callout, type CalloutTone } from '@/components/ui/Callout';
 import PageHeader from '@/components/layout/PageHeader';
 import { cn, formatCurrency } from '@/lib/utils';
 import type { InventoryTransaction, Material, PaginatedTransactions, Product } from '@/types';
@@ -32,10 +33,10 @@ const emptyForm = {
   reorder_point: 5,
 };
 
-function readinessTone(value: 'ready' | 'warning' | 'draft') {
-  if (value === 'ready') return 'bg-emerald-50 text-emerald-900 border-emerald-300/60';
-  if (value === 'warning') return 'bg-amber-50 text-amber-900 border-amber-300/60';
-  return 'bg-slate-100 text-slate-800 border-slate-300/60';
+function readinessTone(value: 'ready' | 'warning' | 'draft'): CalloutTone {
+  if (value === 'ready') return 'success';
+  if (value === 'warning') return 'warning';
+  return 'neutral';
 }
 
 export default function ProductEditorPage() {
@@ -334,7 +335,7 @@ export default function ProductEditorPage() {
                       <p
                         className={cn(
                           'font-semibold',
-                          transaction.quantity > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                          transaction.quantity > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive'
                         )}
                       >
                         {transaction.quantity > 0 ? '+' : ''}
@@ -357,38 +358,29 @@ export default function ProductEditorPage() {
             </div>
 
             <div className="mt-4 space-y-3">
-              <div className={cn('rounded-md border px-4 py-3', readinessTone(identityReadiness))}>
-                <p className="font-semibold">Identity</p>
-                <p className="mt-1 text-sm">
-                  {identityReadiness === 'ready'
-                    ? 'Name, material, and price are present.'
-                    : identityReadiness === 'warning'
-                      ? 'The product has partial setup but still needs key sellable fields.'
-                      : 'Start with the basic product identity and pricing fields.'}
-                </p>
-              </div>
+              <Callout tone={readinessTone(identityReadiness)} title="Identity">
+                {identityReadiness === 'ready'
+                  ? 'Name, material, and price are present.'
+                  : identityReadiness === 'warning'
+                    ? 'The product has partial setup but still needs key sellable fields.'
+                    : 'Start with the basic product identity and pricing fields.'}
+              </Callout>
 
-              <div className={cn('rounded-md border px-4 py-3', readinessTone(barcodeReadiness))}>
-                <p className="font-semibold">POS readiness</p>
-                <p className="mt-1 text-sm">
-                  {barcodeReadiness === 'ready'
-                    ? 'UPC present. This product can participate in barcode-driven POS flow.'
-                    : 'No UPC yet. Product is still sellable, but manual lookup will be required at the register.'}
-                </p>
-              </div>
+              <Callout tone={readinessTone(barcodeReadiness)} title="POS readiness">
+                {barcodeReadiness === 'ready'
+                  ? 'UPC present. This product can participate in barcode-driven POS flow.'
+                  : 'No UPC yet. Product is still sellable, but manual lookup will be required at the register.'}
+              </Callout>
 
-              <div className={cn('rounded-md border px-4 py-3', readinessTone(stockReadiness))}>
-                <p className="font-semibold">Stock policy</p>
-                <p className="mt-1 text-sm">
-                  {isCreate
-                    ? 'Stock starts after creation. Reorder policy will apply once transactions begin.'
-                    : stockReadiness === 'ready'
-                      ? 'Current stock is above the reorder threshold.'
-                      : stockReadiness === 'warning'
-                        ? 'Current stock is near the reorder point.'
-                        : 'Current stock is at or below zero and needs attention.'}
-                </p>
-              </div>
+              <Callout tone={readinessTone(stockReadiness)} title="Stock policy">
+                {isCreate
+                  ? 'Stock starts after creation. Reorder policy will apply once transactions begin.'
+                  : stockReadiness === 'ready'
+                    ? 'Current stock is above the reorder threshold.'
+                    : stockReadiness === 'warning'
+                      ? 'Current stock is near the reorder point.'
+                      : 'Current stock is at or below zero and needs attention.'}
+              </Callout>
             </div>
 
             <div className="mt-5 space-y-3 rounded-lg bg-background p-4">
@@ -402,13 +394,13 @@ export default function ProductEditorPage() {
               </div>
               <div className="flex items-center justify-between text-sm">
                 <span className="text-muted-foreground">Margin dollars</span>
-                <span className={cn(marginDollars >= 0 ? 'text-emerald-700' : 'text-red-600')}>
+                <span className={cn(marginDollars >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive')}>
                   {formatCurrency(marginDollars)}
                 </span>
               </div>
               <div className="flex items-center justify-between text-sm">
                 <span className="text-muted-foreground">Margin percent</span>
-                <span className={cn(marginPct >= 0 ? 'text-emerald-700' : 'text-red-600')}>
+                <span className={cn(marginPct >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive')}>
                   {Number.isFinite(marginPct) ? `${marginPct.toFixed(1)}%` : '0.0%'}
                 </span>
               </div>

--- a/frontend/src/pages/SaleDetailPage.tsx
+++ b/frontend/src/pages/SaleDetailPage.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
+import { Callout } from '@/components/ui/Callout';
 import PageHeader from '@/components/layout/PageHeader';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import { getShippingLabelActionLabel, getShippingLabelMissingFields } from '@/lib/shippingLabels';
@@ -251,7 +252,7 @@ export default function SaleDetailPage() {
               <div className="flex justify-between"><span className="text-muted-foreground">Gross Profit</span><span>{formatCurrency(sale.gross_profit)}</span></div>
               <div className="flex justify-between text-muted-foreground"><span>Platform fees</span><span>-{formatCurrency(sale.platform_fees)}</span></div>
               <div className="flex justify-between text-muted-foreground"><span>Shipping cost</span><span>-{formatCurrency(sale.shipping_cost)}</span></div>
-              <div className={`flex justify-between font-semibold border-t border-border pt-2 ${Number(sale.contribution_margin) >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+              <div className={`flex justify-between font-semibold border-t border-border pt-2 ${Number(sale.contribution_margin) >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive'}`}>
                 <span>Contribution Margin</span>
                 <span>{formatCurrency(sale.contribution_margin)}</span>
               </div>
@@ -298,13 +299,13 @@ export default function SaleDetailPage() {
             </div>
 
             {shipmentMissingFields.length > 0 ? (
-              <p className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+              <Callout tone="warning">
                 Add {shipmentMissingFields.join(', ')} before printing from this workstation.
-              </p>
+              </Callout>
             ) : (
-              <p className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-900">
+              <Callout tone="success">
                 Label is ready for workstation-local printing. Canceling the browser print dialog does not mark the label printed.
-              </p>
+              </Callout>
             )}
 
             <div className="grid grid-cols-1 gap-2">

--- a/frontend/src/pages/SalesPage.tsx
+++ b/frontend/src/pages/SalesPage.tsx
@@ -189,7 +189,7 @@ export default function SalesPage() {
       numeric: true,
       colClassName: 'hidden md:table-cell',
       cell: (s) => (
-        <span className={Number(s.contribution_margin) >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}>
+        <span className={Number(s.contribution_margin) >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive'}>
           {formatCurrency(s.contribution_margin)}
         </span>
       ),
@@ -331,7 +331,7 @@ export default function SalesPage() {
                     'tabular-nums',
                     Number(s.contribution_margin) >= 0
                       ? 'text-emerald-600 dark:text-emerald-400'
-                      : 'text-red-600 dark:text-red-400',
+                      : 'text-destructive',
                   )}
                 >
                   {formatCurrency(s.contribution_margin)}

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -243,7 +243,7 @@ function UsersTable({ users, isLoading, currentUserId, onEdit, onDeactivate, onR
                 onClick={() => onReactivate(u)}
                 aria-label={`Reactivate ${u.full_name}`}
                 title="Reactivate"
-                className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-green-100 dark:hover:bg-green-900/20 hover:text-green-600 cursor-pointer"
+                className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-emerald-100 dark:hover:bg-emerald-900/20 hover:text-emerald-600 cursor-pointer"
               >
                 <Users className="h-4 w-4" />
               </button>

--- a/frontend/src/pages/reports/InventoryReportPage.tsx
+++ b/frontend/src/pages/reports/InventoryReportPage.tsx
@@ -1,15 +1,16 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, ResponsiveContainer } from 'recharts';
 import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
 import ReportControls from '@/components/ui/ReportControls';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import DataTable from '@/components/data/DataTable';
 import { KPIStrip, KPI } from '@/components/layout/KPIStrip';
+import { ChartTooltip, chartCategoricalPalette } from '@/components/charts/ChartTooltip';
 import type { InventoryReport, StockLevelRow } from '@/types';
 
-const COLORS = ['#6366f1', '#8b5cf6', '#a78bfa', '#c4b5fd', '#ddd6fe', '#e0e7ff'];
+const COLORS = chartCategoricalPalette;
 const formatTooltipCurrency = (value: string | number | readonly (string | number)[] | undefined) => {
   const normalized = Array.isArray(value) ? value[0] : value;
   return formatCurrency(Number(normalized ?? 0));
@@ -123,7 +124,7 @@ export default function InventoryReportPage() {
                     <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
                     <XAxis dataKey="product" tick={{ fontSize: 11 }} stroke="var(--color-muted-foreground)" />
                     <YAxis tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" />
-                    <Tooltip contentStyle={{ backgroundColor: 'var(--color-card)', border: '1px solid var(--color-border)', borderRadius: '8px' }} />
+                    <ChartTooltip />
                     <Bar dataKey="turnover_rate" name="Turnover Rate" fill="var(--color-primary)" radius={[4, 4, 0, 0]} />
                   </BarChart>
                 </ResponsiveContainer>
@@ -149,7 +150,7 @@ export default function InventoryReportPage() {
                         <Cell key={i} fill={COLORS[i % COLORS.length]} />
                       ))}
                     </Pie>
-                    <Tooltip formatter={formatTooltipCurrency} contentStyle={{ backgroundColor: 'var(--color-card)', border: '1px solid var(--color-border)', borderRadius: '8px' }} />
+                    <ChartTooltip formatter={formatTooltipCurrency} />
                   </PieChart>
                 </ResponsiveContainer>
               </div>

--- a/frontend/src/pages/reports/PLReportPage.tsx
+++ b/frontend/src/pages/reports/PLReportPage.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, ResponsiveContainer, Legend } from 'recharts';
 import api from '@/api/client';
 import { formatCurrency, formatPercent } from '@/lib/utils';
 import ReportControls from '@/components/ui/ReportControls';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import DataTable from '@/components/data/DataTable';
 import { KPIStrip, KPI } from '@/components/layout/KPIStrip';
+import { Callout } from '@/components/ui/Callout';
+import { ChartTooltip, chartCategoricalPalette } from '@/components/charts/ChartTooltip';
 import type { PLReport, PLRow } from '@/types';
 
 const formatTooltipCurrency = (value: string | number | readonly (string | number)[] | undefined) => {
@@ -73,11 +75,10 @@ export default function PLReportPage() {
             />
           </KPIStrip>
 
-          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4 text-sm text-amber-900 dark:text-amber-100">
-            <p className="font-medium">Reporting basis: sales-realized revenue</p>
-            <p className="mt-1">{s.production_estimate_note}</p>
+          <Callout tone="warning" title="Reporting basis: sales-realized revenue">
+            <p>{s.production_estimate_note}</p>
             <p className="mt-1">Operational production estimate shown separately: {formatCurrency(s.operational_production_estimate)}</p>
-          </div>
+          </Callout>
 
           {/* Cost breakdown */}
           <div className="bg-card border border-border rounded-lg p-6">
@@ -111,10 +112,10 @@ export default function PLReportPage() {
                   <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
                   <XAxis dataKey="period" tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" />
                   <YAxis tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" tickFormatter={(v) => `$${v}`} />
-                  <Tooltip formatter={formatTooltipCurrency} contentStyle={{ backgroundColor: 'var(--color-card)', border: '1px solid var(--color-border)', borderRadius: '8px' }} />
+                  <ChartTooltip formatter={formatTooltipCurrency} />
                   <Legend />
-                  <Bar dataKey="sales_revenue" name="Sales Revenue" stackId="rev" fill="#8b5cf6" />
-                  <Bar dataKey="operational_production_estimate" name="Operational Production Estimate" fill="#6366f1" />
+                  <Bar dataKey="sales_revenue" name="Sales Revenue" stackId="rev" fill={chartCategoricalPalette[0]} />
+                  <Bar dataKey="operational_production_estimate" name="Operational Production Estimate" fill={chartCategoricalPalette[2]} />
                   <Bar dataKey="material_costs" name="Materials" stackId="cost" fill="#f87171" />
                   <Bar dataKey="labor_costs" name="Labor" stackId="cost" fill="#fb923c" />
                   <Bar dataKey="machine_costs" name="Machine" stackId="cost" fill="#fbbf24" />
@@ -190,8 +191,8 @@ export default function PLReportPage() {
                       <span
                         className={`font-semibold ${
                           row.gross_profit >= 0
-                            ? 'text-green-600 dark:text-green-400'
-                            : 'text-red-600 dark:text-red-400'
+                            ? 'text-emerald-600 dark:text-emerald-400'
+                            : 'text-destructive'
                         }`}
                       >
                         {formatCurrency(row.gross_profit)}

--- a/frontend/src/pages/reports/SalesReportPage.tsx
+++ b/frontend/src/pages/reports/SalesReportPage.tsx
@@ -116,8 +116,8 @@ export default function SalesReportPage() {
                         <span
                           className={
                             p.contribution_margin >= 0
-                              ? 'text-green-600 dark:text-green-400'
-                              : 'text-red-600 dark:text-red-400'
+                              ? 'text-emerald-600 dark:text-emerald-400'
+                              : 'text-destructive'
                           }
                         >
                           {formatCurrency(p.contribution_margin)}


### PR DESCRIPTION
Closes #186. Parent epic: #173 (P1).

## Summary

- **New `<Callout>` primitive** at `frontend/src/components/ui/Callout.tsx` with tones warning / success / info / danger / neutral. Also exports `calloutToneClasses` constant for card-level tints inside iterators where the full component doesn't fit the layout.
- **C2** — 10 files' raw `text-green-600 dark:text-green-400` / `text-red-600 dark:text-red-*` conditionals migrated to `text-emerald-600 dark:text-emerald-400` / `text-destructive` tokens.
- **C3** — ~13 hand-rolled amber panels across 10 pages migrated to `<Callout tone="warning">`. Two inline card-tint spots (PrinterWallCard + ControlCenter printer-preview card) use the shared `calloutToneClasses.warning` constant so the amber class strings are no longer duplicated.
- **C4** — Off-brand purple chart colors replaced with the shared `chartCategoricalPalette` in PLReportPage (`<Bar>` fills) and InventoryReportPage (`COLORS` array). `<Tooltip>` calls swapped to `<ChartTooltip>`.

## Acceptance

- [x] `rg 'text-(red|green)-(600|700)' src --glob '!**/StatusBadge.tsx'` → **0**
- [x] `rg 'bg-amber-50' src/pages` → **0** (remaining `bg-amber-500` are progress-bar fills)
- [x] `rg '#6366f1|#8b5cf6|#a78bfa|#c4b5fd|#ddd6fe' src` → **0**
- [x] `<Callout>` primitive created + used everywhere amber panels were hand-rolled
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Load `/dashboard` → low-stock alerts render in amber Callout with proper contrast (light + dark)
- [ ] Load `/orders` with a paused printer → "Printers need attention" Callout appears
- [ ] Load `/stock` with material alerts → Material signals Callout appears
- [ ] Load `/control-center` as admin with stock blockers → stock-blockers section renders as amber Callout
- [ ] Load `/print-floor` with a paused printer → wall group + card tint correctly warning-colored
- [ ] Load `/sell` → scan an invalid barcode → error Callout appears; complete checkout → success Callout
- [ ] Load `/reports/pl` → revenue / production-estimate bars are blue-derived (not purple)
- [ ] Load `/reports/inventory` → category breakdown pie uses blue/sky/teal/slate palette
- [ ] Spot-check any currency column showing negative value: destructive-red, positive: emerald

🤖 Generated with [Claude Code](https://claude.com/claude-code)