### PR TITLE
feat(ui): nav chrome revamp — Tabs + Breadcrumbs + lighter shell (#185)

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,8 +1,8 @@
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Moon, Sun, Printer, LogOut, Menu, User } from 'lucide-react';
 import { useAuthStore } from '@/store/auth';
 import { useTheme } from '@/hooks/useTheme';
-import { getWorkspaceForPath } from './workspaces';
+import { Button } from '@/components/ui/Button';
 
 interface HeaderProps {
   onOpenMobileNav?: () => void;
@@ -12,8 +12,6 @@ export default function Header({ onOpenMobileNav }: HeaderProps) {
   const { dark, toggle } = useTheme();
   const { user, logout } = useAuthStore();
   const navigate = useNavigate();
-  const location = useLocation();
-  const workspace = getWorkspaceForPath(location.pathname);
 
   const handleLogout = () => {
     logout();
@@ -21,45 +19,43 @@ export default function Header({ onOpenMobileNav }: HeaderProps) {
   };
 
   return (
-    <header className="sticky top-0 z-40 border-b border-border bg-[color:var(--color-shell)] backdrop-blur-xl">
+    <header className="sticky top-0 z-40 border-b border-border bg-card">
       <div className="mx-auto max-w-[96rem] px-4 sm:px-6 lg:px-8">
-        <div className="flex min-h-18 items-center justify-between gap-4 py-3">
+        <div className="flex min-h-14 items-center justify-between gap-4 py-2">
           <div className="flex min-w-0 items-center gap-3">
-            <button
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={onOpenMobileNav}
-              className="rounded-xl border border-border bg-card/70 p-2 text-muted-foreground transition-colors hover:text-foreground md:hidden"
+              className="md:hidden"
               aria-label="Open navigation menu"
             >
               <Menu className="w-5 h-5" />
-            </button>
+            </Button>
 
             <Link to="/control-center" className="flex min-w-0 items-center gap-3 no-underline">
-              <div className="flex h-11 w-11 items-center justify-center rounded-md border border-primary/30 bg-primary text-primary-foreground shadow-sm">
-                <Printer className="h-5 w-5 shrink-0" />
+              <div className="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground">
+                <Printer className="h-4 w-4 shrink-0" />
               </div>
-              <div className="min-w-0">
-                <span className="block truncate font-display text-lg font-semibold text-foreground">
-                  3D Print Sales
-                </span>
-                <span className="block truncate text-xs text-muted-foreground">
-                  {workspace.label}
-                </span>
-              </div>
+              <span className="block truncate font-display text-lg font-semibold text-foreground">
+                3D Print Sales
+              </span>
             </Link>
           </div>
 
           <div className="flex shrink-0 items-center gap-2">
-            <button
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={toggle}
-              className="rounded-xl border border-border bg-card/70 p-2 text-muted-foreground transition-colors hover:text-foreground"
               aria-label="Toggle theme"
             >
               {dark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
-            </button>
+            </Button>
 
             {user && (
-              <div className="hidden min-w-0 max-w-[280px] items-center gap-3 rounded-md border border-border bg-card/70 px-3 py-2 text-sm text-muted-foreground sm:flex">
-                <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-background/80 text-foreground">
+              <div className="hidden min-w-0 max-w-[280px] items-center gap-3 px-2 py-1 text-sm text-muted-foreground sm:flex">
+                <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted/60 text-foreground">
                   <User className="h-4 w-4 shrink-0" />
                 </div>
                 <div className="min-w-0">
@@ -68,26 +64,29 @@ export default function Header({ onOpenMobileNav }: HeaderProps) {
                     {user.role}
                   </span>
                 </div>
-                <button
+                <Button
+                  variant="ghost"
+                  size="icon"
                   onClick={handleLogout}
-                  className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-destructive"
                   aria-label="Logout"
                   title="Sign out"
                 >
                   <LogOut className="w-4 h-4" />
-                </button>
+                </Button>
               </div>
             )}
 
             {user && (
-              <button
+              <Button
+                variant="ghost"
+                size="icon"
                 onClick={handleLogout}
-                className="rounded-xl border border-border bg-card/70 p-2 text-muted-foreground transition-colors hover:text-destructive sm:hidden"
+                className="sm:hidden"
                 aria-label="Logout"
                 title="Sign out"
               >
                 <LogOut className="w-5 h-5" />
-              </button>
+              </Button>
             )}
           </div>
         </div>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,49 +1,21 @@
 import { useState } from 'react';
 import { NavLink, Outlet, useLocation } from 'react-router-dom';
-import { ChevronLeft, PanelsTopLeft, X } from 'lucide-react';
+import { ChevronLeft, X } from 'lucide-react';
 import Header from './Header';
 import Footer from './Footer';
 import { useAuthStore } from '@/store/auth';
 import { cn } from '@/lib/utils';
 import WorkspaceLocalNav from './WorkspaceLocalNav';
-import { getVisibleWorkspaces, getWorkspaceForPath, isWorkspaceLinkActive } from './workspaces';
+import { getVisibleWorkspaces, isWorkspaceLinkActive } from './workspaces';
 
 function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
   const { user } = useAuthStore();
   const location = useLocation();
-  const activeWorkspace = getWorkspaceForPath(location.pathname);
   const visibleWorkspaces = getVisibleWorkspaces(user?.role);
 
   return (
     <div className="flex h-full flex-col">
-      <div className="px-3 pb-4">
-        <div className="rounded-md border border-border bg-background/70 p-4">
-          <div className="flex items-center gap-3">
-            <div className="flex h-11 w-11 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-sm">
-              <PanelsTopLeft className="h-5 w-5" />
-            </div>
-            <div>
-              <p className="text-xs font-medium text-muted-foreground">
-                Active Workspace
-              </p>
-              <p className="mt-1 font-display text-base font-semibold text-foreground">
-                {activeWorkspace.label}
-              </p>
-            </div>
-          </div>
-          <p className="mt-3 text-sm text-muted-foreground">
-            {activeWorkspace.description}
-          </p>
-        </div>
-      </div>
-
-      <div className="px-3 pb-2">
-        <p className="px-3 text-xs font-medium text-muted-foreground">
-          Workspaces
-        </p>
-      </div>
-
-      <nav className="space-y-1 px-3">
+      <nav className="space-y-1 px-1">
         {visibleWorkspaces.map(({ key, to, label, icon: Icon, matchPrefixes }) => (
           <NavLink
             key={key}
@@ -51,23 +23,14 @@ function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
             onClick={onNavigate}
             className={() =>
               cn(
-                'flex items-center gap-3 rounded-md px-3 py-3 text-sm font-medium transition-colors no-underline',
+                'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors no-underline',
                 isWorkspaceLinkActive(location.pathname, matchPrefixes)
-                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  ? 'bg-primary text-primary-foreground'
                   : 'text-muted-foreground hover:bg-accent hover:text-foreground'
               )
             }
           >
-            <span
-              className={cn(
-                'flex h-9 w-9 items-center justify-center rounded-xl border transition-colors',
-                isWorkspaceLinkActive(location.pathname, matchPrefixes)
-                  ? 'border-primary-foreground/15 bg-primary-foreground/10'
-                  : 'border-border bg-background/70'
-              )}
-            >
-              <Icon className="h-4 w-4 shrink-0" />
-            </span>
+            <Icon className="h-4 w-4 shrink-0" />
             <span>{label}</span>
           </NavLink>
         ))}
@@ -86,7 +49,7 @@ export default function Layout() {
       <div className="mx-auto flex-1 w-full max-w-[96rem] px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
         <div className="flex min-h-full gap-6 lg:gap-8">
           <aside className="hidden w-80 shrink-0 xl:block">
-            <div className="sticky top-24 rounded-lg border border-border bg-card/80 p-3 shadow-md backdrop-blur">
+            <div className="sticky top-24 rounded-md border border-border bg-card p-2 shadow-xs">
               <SidebarContent />
             </div>
           </aside>

--- a/frontend/src/components/layout/WorkspaceLocalNav.tsx
+++ b/frontend/src/components/layout/WorkspaceLocalNav.tsx
@@ -1,50 +1,33 @@
-import { NavLink, useLocation } from 'react-router-dom';
-import { cn } from '@/lib/utils';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import { getWorkspaceForPath, isWorkspaceLinkActive } from './workspaces';
 
 export default function WorkspaceLocalNav() {
   const location = useLocation();
+  const navigate = useNavigate();
   const workspace = getWorkspaceForPath(location.pathname);
 
-  return (
-    <section className="rounded-lg border border-border bg-card/80 p-4 shadow-md backdrop-blur">
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-        <div className="min-w-0">
-          <p className="text-xs font-medium text-muted-foreground">
-            Workspace
-          </p>
-          <h2 className="mt-1 font-display text-xl font-semibold text-foreground">
-            {workspace.label}
-          </h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {workspace.description}
-          </p>
-        </div>
+  if (!workspace.localLinks.length) {
+    return null;
+  }
 
-        <nav
-          aria-label={`${workspace.label} navigation`}
-          className="flex flex-wrap gap-2"
-        >
-          {workspace.localLinks.map((link) => {
-            const prefixes = link.matchPrefixes ?? [link.to];
-            const active = isWorkspaceLinkActive(location.pathname, prefixes);
-            return (
-              <NavLink
-                key={link.to}
-                to={link.to}
-                className={cn(
-                  'rounded-full border px-3 py-2 text-sm font-medium no-underline transition-colors',
-                  active
-                    ? 'border-primary/40 bg-primary text-primary-foreground shadow-sm'
-                    : 'border-border bg-background/70 text-muted-foreground hover:border-primary/30 hover:text-foreground'
-                )}
-              >
-                {link.label}
-              </NavLink>
-            );
-          })}
-        </nav>
-      </div>
-    </section>
+  const activeValue =
+    workspace.localLinks.find((link) => {
+      const prefixes = link.matchPrefixes ?? [link.to];
+      return isWorkspaceLinkActive(location.pathname, prefixes);
+    })?.to ?? workspace.localLinks[0]?.to ?? '';
+
+  return (
+    <div aria-label={`${workspace.label} navigation`}>
+      <Tabs value={activeValue} onValueChange={(next) => navigate(next)}>
+        <TabsList>
+          {workspace.localLinks.map((link) => (
+            <TabsTrigger key={link.to} value={link.to}>
+              {link.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+    </div>
   );
 }

--- a/frontend/src/components/ui/Breadcrumbs.tsx
+++ b/frontend/src/components/ui/Breadcrumbs.tsx
@@ -1,0 +1,57 @@
+import { Link } from 'react-router-dom';
+import { ChevronRight } from 'lucide-react';
+import { Fragment, type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface BreadcrumbItem {
+  label: ReactNode;
+  /** Route path. If omitted, the item renders as plain text (usually the current page). */
+  to?: string;
+}
+
+interface BreadcrumbsProps {
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+/**
+ * Compact breadcrumb trail for detail pages. Place inside `<PageHeader
+ * breadcrumbs={<Breadcrumbs items={...} />}>`.
+ *
+ * The final item is typically the current page — pass it without `to` so
+ * it renders as plain muted text.
+ */
+export default function Breadcrumbs({ items, className }: BreadcrumbsProps) {
+  if (!items.length) return null;
+
+  return (
+    <nav aria-label="Breadcrumb" className={cn('text-sm', className)}>
+      <ol className="flex flex-wrap items-center gap-1 text-muted-foreground">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+          return (
+            <Fragment key={`${index}-${String(item.label)}`}>
+              <li>
+                {item.to && !isLast ? (
+                  <Link
+                    to={item.to}
+                    className="text-muted-foreground no-underline hover:text-foreground hover:underline"
+                  >
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span className={cn(isLast && 'text-foreground')}>{item.label}</span>
+                )}
+              </li>
+              {!isLast ? (
+                <li aria-hidden="true">
+                  <ChevronRight className="h-3.5 w-3.5" />
+                </li>
+              ) : null}
+            </Fragment>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -4,6 +4,7 @@ import { useParams, Link, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Edit, Calendar, User, Package, Printer, Copy } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { formatCurrency, formatPercent } from '@/lib/utils';
 import type { Job } from '@/types';
 
@@ -64,6 +65,12 @@ export default function JobDetailPage() {
 
   return (
     <div className="space-y-6">
+      <Breadcrumbs
+        items={[
+          { to: '/orders/jobs', label: 'Jobs' },
+          { label: job.job_number },
+        ]}
+      />
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
           <Link to="/orders/jobs" className="p-2 rounded-md hover:bg-accent text-muted-foreground no-underline">

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -22,6 +22,7 @@ import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import { Button } from '@/components/ui/Button';
 import PageHeader from '@/components/layout/PageHeader';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import type { Job, PaginatedJobs, Printer, PrinterConnectionTestResult } from '@/types';
 
@@ -181,6 +182,14 @@ export default function PrinterDetailPage() {
 
       <PageHeader
         title={printer.name}
+        breadcrumbs={
+          <Breadcrumbs
+            items={[
+              { to: '/print-floor', label: 'Print Floor' },
+              { label: printer.name },
+            ]}
+          />
+        }
         description={
           <span className="flex flex-wrap items-center gap-2">
             <StatusBadge tone={defaultStatusTone(liveStatus)}>

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -12,6 +12,7 @@ import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import type { Product, PaginatedTransactions } from '@/types';
 
 const TXN_TYPES = [
@@ -133,6 +134,13 @@ export default function ProductDetailPage() {
 
   return (
     <div className="max-w-4xl mx-auto">
+      <Breadcrumbs
+        className="mb-4"
+        items={[
+          { to: '/product-studio/products', label: 'Products' },
+          { label: currentProduct.name },
+        ]}
+      />
       <Link to="/product-studio" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-4">
         <ArrowLeft className="w-4 h-4" /> Back to Products
       </Link>

--- a/frontend/src/pages/SaleDetailPage.tsx
+++ b/frontend/src/pages/SaleDetailPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Callout } from '@/components/ui/Callout';
 import PageHeader from '@/components/layout/PageHeader';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import { getShippingLabelActionLabel, getShippingLabelMissingFields } from '@/lib/shippingLabels';
 import { formatCurrency } from '@/lib/utils';
@@ -198,6 +199,14 @@ export default function SaleDetailPage() {
       <PageHeader
         title={sale.sale_number}
         description={`${sale.date} · ${sale.customer_name || 'No customer'}`}
+        breadcrumbs={
+          <Breadcrumbs
+            items={[
+              { to: '/sell/sales', label: 'Sales' },
+              { label: sale.sale_number },
+            ]}
+          />
+        }
         actions={
           <div className="flex items-center gap-2">
             <Link


### PR DESCRIPTION
Closes #185. Parent epic: #173 (P1).

## Summary

Revamps the app shell and detail-page navigation so chrome reads card-on-card (Stripe/Linear convention) and the density matches the rest of the P1 pass.

## Before → After

| # | Area | Before | After |
|---|---|---|---|
| N1 | Local workspace nav | `rounded-full` pills with `shadow-sm` active state (consumer-app feel) | `<Tabs>` primitive — muted square container, `bg-card` active |
| N2 | Header background | dark `var(--color-shell)` navy with `backdrop-blur-xl` over a light body (disjointed) | solid `bg-card` in both modes |
| N3 | Logo tile | `h-11 w-11` solid-blue with border + shadow; workspace label sub-line under wordmark | `h-8 w-8` solid blue, no border/shadow; sub-line removed |
| N4 | Detail-page breadcrumbs | None | `<Breadcrumbs>` on Sale / Printer / Job / Product detail |
| N5 | Sidebar nav items | `h-9 w-9 rounded-xl border` icon tile around each label; bordered "Active Workspace" header card; "Workspaces" eyebrow | Icon + text rows; no decorative tiles; slim sidebar |

## New primitives

- `frontend/src/components/ui/Breadcrumbs.tsx` — compact breadcrumb trail using `<ChevronRight>` separators; plugs into `PageHeader`'s `breadcrumbs` prop.

## Files touched

- `frontend/src/components/layout/Header.tsx`
- `frontend/src/components/layout/Layout.tsx`
- `frontend/src/components/layout/WorkspaceLocalNav.tsx`
- `frontend/src/components/ui/Breadcrumbs.tsx` (new)
- `frontend/src/pages/SaleDetailPage.tsx`
- `frontend/src/pages/PrinterDetailPage.tsx`
- `frontend/src/pages/JobDetailPage.tsx`
- `frontend/src/pages/ProductDetailPage.tsx`

## Acceptance

- [x] Local nav uses `<Tabs>` primitive (no `rounded-full` active pills)
- [x] Header uses `bg-card` (no `var(--color-shell)` reference)
- [x] Logo is `h-8 w-8`
- [x] Sidebar nav items are icon + text rows
- [x] All 4 detail pages render `<Breadcrumbs>`
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Header renders card-color in light + dark modes (no dark navy bar over light body)
- [ ] Logo tile is compact (`h-8`) and wordmark is the visual anchor
- [ ] Sidebar — active workspace is highlighted via `bg-primary text-primary-foreground`; no tile chrome
- [ ] Local nav tabs on `/orders`, `/sell`, `/print-floor`, `/stock` navigate correctly when clicked
- [ ] Breadcrumbs on `/sell/sales/{id}` shows `Sales › SALE-NUMBER`; link to `/sell/sales` works
- [ ] Breadcrumbs on `/orders/jobs/{id}`, `/product-studio/products/{id}`, `/print-floor/printers/{id}` — same pattern
- [ ] Mobile nav drawer still opens, user card + logout still works, theme toggle still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)