### PR TITLE
feat(ui): loading/empty/error state consistency (#182)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
+import { Skeleton, SkeletonCard } from '@/components/ui/Skeleton';
 import Layout from '@/components/layout/Layout';
 import AdminLayout from '@/components/layout/AdminLayout';
 import ProtectedRoute from '@/components/auth/ProtectedRoute';
@@ -50,14 +51,12 @@ const queryClient = new QueryClient({
 function RouteFallback() {
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto flex max-w-6xl items-center justify-center px-6 py-24">
-        <div className="w-full max-w-3xl animate-pulse space-y-4">
-          <div className="h-10 w-56 rounded-md bg-card" />
-          <div className="h-40 rounded-lg bg-card" />
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="h-32 rounded-lg bg-card" />
-            <div className="h-32 rounded-lg bg-card" />
-          </div>
+      <div className="mx-auto max-w-6xl space-y-4 px-6 py-24">
+        <Skeleton className="h-10 w-56" />
+        <SkeletonCard rows={2} />
+        <div className="grid gap-4 md:grid-cols-2">
+          <SkeletonCard rows={1} />
+          <SkeletonCard rows={1} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -6,6 +6,7 @@ import Footer from './Footer';
 import { useAuthStore } from '@/store/auth';
 import { cn } from '@/lib/utils';
 import WorkspaceLocalNav from './WorkspaceLocalNav';
+import QueryErrorBoundary from '@/components/ui/QueryErrorBoundary';
 import { getVisibleWorkspaces, isWorkspaceLinkActive } from './workspaces';
 
 function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
@@ -56,7 +57,9 @@ export default function Layout() {
 
           <main className="min-w-0 flex-1 space-y-5">
             <WorkspaceLocalNav />
-            <Outlet />
+            <QueryErrorBoundary>
+              <Outlet />
+            </QueryErrorBoundary>
           </main>
         </div>
       </div>

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,5 +1,6 @@
-import { Package, Inbox, FileText, Users, Calculator, Settings, Layers, ShoppingCart, BarChart3 } from 'lucide-react';
+import { Package, Inbox, FileText, Users, Calculator, Settings, Layers, ShoppingCart, BarChart3, Printer } from 'lucide-react';
 import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
 
 const icons: Record<string, typeof Package> = {
   jobs: FileText,
@@ -10,26 +11,66 @@ const icons: Record<string, typeof Package> = {
   sales: ShoppingCart,
   reports: BarChart3,
   settings: Settings,
+  printers: Printer,
   default: Inbox,
 };
 
 interface EmptyStateProps {
   icon?: string;
   title: string;
-  description: string;
+  description?: string;
   action?: ReactNode;
   className?: string;
+  /**
+   * When true, renders a denser inline version suitable for embedded
+   * section bodies (side rails, card-body empties). Falls back to the
+   * larger centered layout otherwise — use that for full-page empties.
+   */
+  compact?: boolean;
 }
 
-export default function EmptyState({ icon = 'default', title, description, action, className }: EmptyStateProps) {
+export default function EmptyState({
+  icon = 'default',
+  title,
+  description,
+  action,
+  className,
+  compact = false,
+}: EmptyStateProps) {
   const Icon = icons[icon] || icons.default;
-  return (
-    <div className={`flex flex-col items-center justify-center py-16 px-4 text-center ${className || ''}`}>
-      <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mb-4">
-        <Icon className="w-8 h-8 text-muted-foreground" />
+
+  if (compact) {
+    return (
+      <div
+        className={cn(
+          'flex flex-col items-center justify-center gap-1 rounded-md border border-dashed border-border bg-card px-4 py-8 text-center',
+          className,
+        )}
+      >
+        <Icon className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+        <p className="mt-2 text-sm font-medium text-foreground">{title}</p>
+        {description ? (
+          <p className="max-w-xs text-xs text-muted-foreground">{description}</p>
+        ) : null}
+        {action ? <div className="mt-2">{action}</div> : null}
       </div>
-      <h3 className="text-lg font-semibold mb-1">{title}</h3>
-      <p className="text-sm text-muted-foreground max-w-sm mb-6">{description}</p>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center px-4 py-16 text-center',
+        className,
+      )}
+    >
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+        <Icon className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
+      </div>
+      <h3 className="mb-1 text-lg font-semibold">{title}</h3>
+      {description ? (
+        <p className="mb-6 max-w-sm text-sm text-muted-foreground">{description}</p>
+      ) : null}
       {action}
     </div>
   );

--- a/frontend/src/components/ui/QueryErrorBoundary.tsx
+++ b/frontend/src/components/ui/QueryErrorBoundary.tsx
@@ -1,0 +1,79 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { Button } from '@/components/ui/Button';
+
+interface InnerProps {
+  children: ReactNode;
+  onReset: () => void;
+  fallback?: (args: { error: Error; reset: () => void }) => ReactNode;
+}
+
+interface InnerState {
+  error: Error | null;
+}
+
+class InnerBoundary extends Component<InnerProps, InnerState> {
+  state: InnerState = { error: null };
+
+  static getDerivedStateFromError(error: Error): InnerState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.error('[QueryErrorBoundary]', error, info);
+    }
+  }
+
+  reset = () => {
+    this.props.onReset();
+    this.setState({ error: null });
+  };
+
+  render() {
+    if (this.state.error) {
+      if (this.props.fallback) return this.props.fallback({ error: this.state.error, reset: this.reset });
+      return (
+        <div className="flex flex-col items-center justify-center rounded-md border border-destructive/30 bg-destructive/5 px-4 py-16 text-center">
+          <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
+            <AlertTriangle className="h-7 w-7 text-destructive" aria-hidden="true" />
+          </div>
+          <h3 className="mb-1 text-lg font-semibold">Something went wrong</h3>
+          <p className="mb-6 max-w-md text-sm text-muted-foreground">
+            {this.state.error.message || 'The page could not load its data.'}
+          </p>
+          <Button type="button" variant="outline" onClick={this.reset}>
+            <RefreshCw className="h-4 w-4" /> Try again
+          </Button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+interface QueryErrorBoundaryProps {
+  children: ReactNode;
+  /** Optional custom fallback — receives the caught error + a reset callback. */
+  fallback?: (args: { error: Error; reset: () => void }) => ReactNode;
+}
+
+/**
+ * Error boundary that pairs with react-query's `QueryErrorResetBoundary`
+ * so clicking "Try again" both clears the boundary state AND re-triggers
+ * affected queries. Wrap around any view that consumes `useQuery` without
+ * manual error handling — typically a route's `<Outlet>` or a page body.
+ */
+export default function QueryErrorBoundary({ children, fallback }: QueryErrorBoundaryProps) {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <InnerBoundary onReset={reset} fallback={fallback}>
+          {children}
+        </InnerBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  );
+}

--- a/frontend/src/pages/ControlCenterPage.tsx
+++ b/frontend/src/pages/ControlCenterPage.tsx
@@ -8,6 +8,7 @@ import PageHeader from '@/components/layout/PageHeader';
 import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
 import { Button } from '@/components/ui/Button';
 import { Callout, calloutToneClasses } from '@/components/ui/Callout';
+import EmptyState from '@/components/ui/EmptyState';
 import { useAuthStore } from '@/store/auth';
 import { cn, formatCurrency, formatPercent } from '@/lib/utils';
 import type {
@@ -210,7 +211,7 @@ export default function ControlCenterPage() {
                   </Button>
                 </div>
                 {!printers.length ? (
-                  <p className="text-sm text-muted-foreground">No active printers are available.</p>
+                  <EmptyState compact icon="printers" title="No active printers are available." />
                 ) : (
                   <div className="grid gap-3 lg:grid-cols-2">
                     {printers.slice(0, 4).map((printer) => {

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -9,6 +9,8 @@ import { Button } from '@/components/ui/Button';
 import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
 import StatusBadge, { type StatusTone } from '@/components/data/StatusBadge';
+import { Skeleton, SkeletonCard } from '@/components/ui/Skeleton';
+import EmptyState from '@/components/ui/EmptyState';
 import { useAuthStore } from '@/store/auth';
 import type { AIInsightStatus, AIInsightSummary } from '@/types';
 
@@ -56,8 +58,8 @@ export default function InsightsPage() {
   if (statusLoading) {
     return (
       <div className="space-y-6">
-        <div className="h-12 w-72 animate-pulse rounded-md bg-card" />
-        <div className="h-64 animate-pulse rounded-md bg-card" />
+        <Skeleton className="h-10 w-72" />
+        <SkeletonCard rows={3} />
       </div>
     );
   }
@@ -215,7 +217,7 @@ export default function InsightsPage() {
                   ))}
                 </div>
               ) : (
-                <p className="text-sm text-muted-foreground">No recommendations returned.</p>
+                <EmptyState compact icon="reports" title="No recommendations returned." />
               )}
             </section>
 
@@ -247,7 +249,7 @@ export default function InsightsPage() {
                   ))}
                 </div>
               ) : (
-                <p className="text-sm text-muted-foreground">No risks returned.</p>
+                <EmptyState compact icon="reports" title="No risks returned." />
               )}
             </section>
           </div>

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Edit, Calendar, User, Package, Printer, Copy } from 'lucide-
 import { toast } from 'sonner';
 import api from '@/api/client';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
+import { SkeletonCard } from '@/components/ui/Skeleton';
 import { formatCurrency, formatPercent } from '@/lib/utils';
 import type { Job } from '@/types';
 
@@ -54,9 +55,13 @@ export default function JobDetailPage() {
   };
 
   if (isLoading) {
-    return <div className="space-y-4">{Array.from({ length: 3 }).map((_, i) => (
-      <div key={i} className="bg-card border border-border rounded-lg h-48 animate-pulse" />
-    ))}</div>;
+    return (
+      <div className="space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <SkeletonCard key={i} rows={2} />
+        ))}
+      </div>
+    );
   }
 
   if (!job) return <p className="text-muted-foreground">Job not found</p>;

--- a/frontend/src/pages/OrdersPage.tsx
+++ b/frontend/src/pages/OrdersPage.tsx
@@ -9,6 +9,7 @@ import DataTable, { type Column } from '@/components/data/DataTable';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import TableToolbar from '@/components/data/TableToolbar';
 import { Button } from '@/components/ui/Button';
+import EmptyState from '@/components/ui/EmptyState';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import { Callout } from '@/components/ui/Callout';
 import { formatCurrency } from '@/lib/utils';
@@ -345,7 +346,7 @@ export default function OrdersPage() {
               </Link>
             </div>
             {topCustomers.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No customer activity yet.</p>
+              <EmptyState compact icon="customers" title="No customer activity yet." />
             ) : (
               <ul className="space-y-2">
                 {topCustomers.map((customer) => (

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -19,6 +19,7 @@ import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import EmptyState from '@/components/ui/EmptyState';
+import { SkeletonCard } from '@/components/ui/Skeleton';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
@@ -479,7 +480,7 @@ export default function POSPage() {
           {productsLoading ? (
             <div className="grid gap-3 md:grid-cols-2">
               {Array.from({ length: 6 }).map((_, index) => (
-                <div key={index} className="h-48 animate-pulse rounded-lg border border-border bg-card" />
+                <SkeletonCard key={index} rows={2} />
               ))}
             </div>
           ) : productsError ? (
@@ -836,7 +837,7 @@ export default function POSPage() {
             {salesInboxLoading ? (
               <div className="mt-4 space-y-3">
                 {Array.from({ length: 3 }).map((_, index) => (
-                  <div key={index} className="h-28 animate-pulse rounded-md border border-border bg-background" />
+                  <SkeletonCard key={index} rows={1} />
                 ))}
               </div>
             ) : salesInbox.length ? (

--- a/frontend/src/pages/PrinterMonitorPage.tsx
+++ b/frontend/src/pages/PrinterMonitorPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Thermometer, Clock, Layers, Wifi, WifiOff } from 'lucide-rea
 import api from '@/api/client';
 import type { Printer } from '@/types';
 import CameraFeed from '@/components/cameras/CameraFeed';
+import { Skeleton } from '@/components/ui/Skeleton';
 
 function formatDuration(seconds: number | null | undefined): string {
   if (!seconds || seconds <= 0) return '--';
@@ -31,7 +32,8 @@ export default function PrinterMonitorPage() {
   if (isLoading) {
     return (
       <div className="h-screen w-screen bg-slate-950 flex items-center justify-center">
-        <div className="animate-pulse text-muted-foreground text-sm">Loading printer...</div>
+        <Skeleton className="h-6 w-40" />
+        <span className="sr-only">Loading printer</span>
       </div>
     );
   }

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -11,6 +11,7 @@ import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
 import { SkeletonTable } from '@/components/ui/Skeleton';
+import EmptyState from '@/components/ui/EmptyState';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import type { Product, PaginatedTransactions } from '@/types';
@@ -311,9 +312,7 @@ export default function ProductDetailPage() {
       {txnLoading ? (
         <SkeletonTable rows={5} cols={5} />
       ) : !transactions?.items?.length ? (
-        <div className="bg-card border border-border rounded-lg p-8 text-center text-muted-foreground">
-          No transactions yet
-        </div>
+        <EmptyState compact icon="reports" title="No transactions yet" />
       ) : (
         <div className="overflow-x-auto bg-card border border-border rounded-lg">
           <table className="w-full text-sm">

--- a/frontend/src/pages/ProductEditorPage.tsx
+++ b/frontend/src/pages/ProductEditorPage.tsx
@@ -320,7 +320,13 @@ export default function ProductEditorPage() {
             ) : transactionsLoading ? (
               <SkeletonTable rows={3} cols={4} />
             ) : !recentTransactions.length ? (
-              <p className="mt-4 text-sm text-muted-foreground">No stock activity recorded yet for this product.</p>
+              <EmptyState
+                compact
+                icon="reports"
+                title="No stock activity recorded yet."
+                description="Adjustments and production entries will appear here."
+                className="mt-4"
+              />
             ) : (
               <div className="mt-4 space-y-3">
                 {recentTransactions.map((transaction: InventoryTransaction) => (

--- a/frontend/src/pages/SaleDetailPage.tsx
+++ b/frontend/src/pages/SaleDetailPage.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
+import { Skeleton, SkeletonCard } from '@/components/ui/Skeleton';
 import { Callout } from '@/components/ui/Callout';
 import PageHeader from '@/components/layout/PageHeader';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
@@ -165,7 +166,12 @@ export default function SaleDetailPage() {
   };
 
   if (isLoading) {
-    return <div className="animate-pulse space-y-4"><div className="h-8 bg-muted rounded w-1/3" /><div className="h-64 bg-muted rounded" /></div>;
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-1/3" />
+        <SkeletonCard rows={3} />
+      </div>
+    );
   }
 
   if (!sale) {

--- a/frontend/src/pages/admin/CamerasPage.tsx
+++ b/frontend/src/pages/admin/CamerasPage.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
 import DataTable, { type Column } from '@/components/data/DataTable';
+import { Skeleton } from '@/components/ui/Skeleton';
 import type { Camera, PaginatedCameras, PaginatedPrinters } from '@/types';
 
 type ModalMode = 'create' | 'edit' | null;
@@ -289,7 +290,10 @@ export default function CamerasPage() {
                   </div>
                   <div className="rounded-lg overflow-hidden border border-border bg-black aspect-video flex items-center justify-center">
                     {previewLoading && (
-                      <div className="text-muted-foreground text-sm animate-pulse">Fetching snapshot...</div>
+                      <>
+                        <Skeleton className="h-4 w-28" />
+                        <span className="sr-only">Fetching snapshot</span>
+                      </>
                     )}
                     {!previewLoading && previewError && (
                       <div className="text-center px-4">

--- a/frontend/src/pages/admin/SettingsPage.tsx
+++ b/frontend/src/pages/admin/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { Bot, KeyRound, Settings, Save } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
+import { SkeletonCard } from '@/components/ui/Skeleton';
 import type { Setting } from '@/types';
 
 const groups: Record<string, { keys: string[]; description: string }> = {
@@ -121,7 +122,7 @@ export default function SettingsPage() {
       {isLoading ? (
         <div className="space-y-6">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="bg-card border border-border rounded-lg p-6 h-32 animate-pulse" />
+            <SkeletonCard key={i} rows={2} />
           ))}
         </div>
       ) : (


### PR DESCRIPTION
Closes #182. Parent epic: #173 (P1).

## Summary

Standardizes loading, empty, and error handling across the app via primitives. Every async view now inherits consistent loading skeletons, empty-state chrome, and route-level error recovery for free.

## New primitives

- `components/ui/QueryErrorBoundary.tsx` — pairs a React error boundary with `QueryErrorResetBoundary` from `@tanstack/react-query`. Wrap around `<Outlet>` (or any page body); clicking "Try again" clears boundary state AND re-triggers affected queries.
- `<EmptyState compact>` variant — dense dashed-border card for inline section bodies. Original hero layout still available for full-page empties. Also added `printers` to the icon map.

## Changes

**E1 — Skeleton standardization (9 files):**

| File | Before | After |
|---|---|---|
| `App.tsx` RouteFallback | Bespoke pulse grid | `<Skeleton>` + `<SkeletonCard>` |
| `POSPage.tsx` | Product + inbox pulse blocks | `<SkeletonCard>` |
| `InsightsPage.tsx` | 2 pulse divs | `<Skeleton>` + `<SkeletonCard>` |
| `PrinterMonitorPage.tsx` | Pulse text | Centered `<Skeleton>` + `sr-only` |
| `SaleDetailPage.tsx` | Pulse block | `<Skeleton>` + `<SkeletonCard>` |
| `JobDetailPage.tsx` | 3 pulse cards | 3× `<SkeletonCard>` |
| `admin/CamerasPage.tsx` | Pulse text | `<Skeleton>` + a11y text |
| `admin/SettingsPage.tsx` | 4 pulse cards | 4× `<SkeletonCard>` |

**E2 — EmptyState sweep:**

| Page | Location | Now uses |
|---|---|---|
| OrdersPage | Top customers side rail | `<EmptyState compact icon="customers">` |
| ControlCenterPage | Print-floor priorities | `<EmptyState compact icon="printers">` |
| ProductEditorPage | Stock activity | `<EmptyState compact icon="reports">` |
| InsightsPage | No recommendations/risks | `<EmptyState compact icon="reports">` |
| ProductDetailPage | No transactions yet | `<EmptyState compact icon="reports">` |

**E3 — Route error boundary:**
- `Layout.tsx` wraps `<Outlet>` in `<QueryErrorBoundary>`. Any route's `useQuery` that errors without local handling now surfaces a retry panel at the page level.

## Acceptance

- [x] `rg 'animate-pulse' frontend/src/pages frontend/src/App.tsx` → **0**
- [x] Route-level error boundary catches query errors across all pages
- [x] Every section-body empty state uses `<EmptyState>` (compact variant for inline, hero for full-page)
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Trigger a network failure on any page (e.g. stop backend) → Query error boundary appears with "Try again"; click recovers
- [ ] Navigate to `/insights` while status is loading → Skeleton renders, not pulse blocks
- [ ] Load `/orders` with no customers → compact EmptyState appears in the side rail
- [ ] Load `/control-center` with no active printers → compact EmptyState in print-floor priorities
- [ ] Load `/dashboard` → chart empty states already use hero EmptyState (post-#176, no regression)
- [ ] Load a product with no transactions → compact EmptyState
- [ ] All pages that had bespoke pulse skeletons now show proper Skeleton primitives

🤖 Generated with [Claude Code](https://claude.com/claude-code)