### PR TITLE
feat(ui): surface polish sweep — radii, shadows, blur, translucency, cursor (#183)

### DIFF
--- a/frontend/src/components/data/Pagination.tsx
+++ b/frontend/src/components/data/Pagination.tsx
@@ -37,7 +37,7 @@ export default function Pagination({
   return (
     <div
       className={cn(
-        'flex flex-col gap-3 border-t border-border bg-card/50 px-3 py-2 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between',
+        'flex flex-col gap-3 border-t border-border bg-card px-3 py-2 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between',
         className,
       )}
     >

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,6 +1,6 @@
 export default function Footer() {
   return (
-    <footer className="mt-auto border-t border-border bg-card/30 py-6 backdrop-blur">
+    <footer className="mt-auto border-t border-border py-6">
       <div className="mx-auto flex max-w-[96rem] flex-col gap-2 px-4 text-center text-sm text-muted-foreground sm:px-6 lg:px-8 lg:flex-row lg:items-center lg:justify-between">
         <p>&copy; {new Date().getFullYear()} 3D Print Sales.</p>
         <p className="text-xs text-muted-foreground/90">

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -90,7 +90,7 @@ export default function JobDetailPage() {
           </span>
         </div>
         <div className="flex gap-2">
-          <button onClick={handleDuplicate} disabled={duplicating} className="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium hover:bg-accent transition-colors disabled:opacity-50 cursor-pointer">
+          <button onClick={handleDuplicate} disabled={duplicating} className="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium hover:bg-accent transition-colors disabled:opacity-50">
             <Copy className="w-4 h-4" /> {duplicating ? 'Copying...' : 'Copy to New Job'}
           </button>
           <Link to={`/orders/jobs/${id}/edit`} className="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-sm font-medium hover:bg-accent transition-colors no-underline">

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -407,7 +407,7 @@ export default function JobFormPage() {
                   <button
                     type="button"
                     onClick={openCreateProduct}
-                    className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline cursor-pointer"
+                    className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
                   >
                     <Plus className="w-3.5 h-3.5" /> Create product
                   </button>

--- a/frontend/src/pages/MaterialsPage.tsx
+++ b/frontend/src/pages/MaterialsPage.tsx
@@ -115,7 +115,6 @@ export default function MaterialsPage() {
           type="button"
           onClick={() => toggleActive(m)}
           aria-label={m.active ? `Deactivate ${m.name}` : `Activate ${m.name}`}
-          className="cursor-pointer"
         >
           <StatusBadge tone={m.active ? 'success' : 'destructive'}>
             {m.active ? 'Active' : 'Inactive'}

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -92,7 +92,7 @@ function SalesInboxCard({ sale }: { sale: SaleListItem }) {
   return (
     <Link
       to={`/sell/sales/${sale.id}`}
-      className="block rounded-md border border-border bg-background/85 p-4 no-underline transition-colors hover:border-primary/35"
+      className="block rounded-md border border-border bg-background p-4 no-underline transition-colors hover:border-primary/35"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
@@ -572,7 +572,7 @@ export default function POSPage() {
             </div>
 
             {!cart.length ? (
-              <div className="mt-6 rounded-md border border-dashed border-border bg-background/70 p-8 text-center">
+              <div className="mt-6 rounded-md border border-dashed border-border bg-background p-8 text-center">
                 <ShoppingBasket className="mx-auto h-10 w-10 text-muted-foreground" />
                 <p className="mt-4 text-lg font-medium">Cart is empty</p>
                 <p className="mt-2 text-sm text-muted-foreground">
@@ -582,7 +582,7 @@ export default function POSPage() {
             ) : (
               <div className="mt-5 space-y-3">
                 {cart.map((line) => (
-                  <div key={line.product_id} className="rounded-md border border-border bg-background/85 p-4">
+                  <div key={line.product_id} className="rounded-md border border-border bg-background p-4">
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <p className="font-medium">{line.name}</p>
@@ -637,7 +637,7 @@ export default function POSPage() {
               </div>
             )}
 
-            <div className="mt-6 rounded-md border border-border bg-background/70 p-4">
+            <div className="mt-6 rounded-md border border-border bg-background p-4">
               <div className="flex items-center gap-2">
                 <Users className="h-4 w-4 text-muted-foreground" />
                 <h3 className="text-base font-semibold">Customer</h3>
@@ -710,7 +710,7 @@ export default function POSPage() {
               ) : null}
             </div>
 
-            <div className="mt-4 rounded-md border border-border bg-background/70 p-4">
+            <div className="mt-4 rounded-md border border-border bg-background p-4">
               <div className="flex items-center gap-2">
                 <WalletCards className="h-4 w-4 text-muted-foreground" />
                 <h3 className="text-base font-semibold">Payment method</h3>

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -72,7 +72,7 @@ function ConsoleStat({
   emphasis?: 'default' | 'warning' | 'success';
 }) {
   return (
-    <div className="rounded-md border border-border bg-card/85 p-4 shadow-sm">
+    <div className="rounded-md border border-border bg-card p-4 shadow-sm">
       <div className="flex items-start justify-between gap-3">
         <div>
           <p className="text-xs font-medium text-muted-foreground">{label}</p>
@@ -311,7 +311,7 @@ export default function PrinterDetailPage() {
       </div>
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
-        <section className="rounded-lg border border-border bg-card/85 p-5 shadow-md">
+        <section className="rounded-md border border-border bg-card p-5 shadow-xs">
           <div className="mb-4 flex items-start justify-between gap-3">
             <div>
               <h2 className="text-xl font-semibold text-foreground">Live monitoring</h2>
@@ -325,25 +325,25 @@ export default function PrinterDetailPage() {
           </div>
 
           {!printer.monitor_enabled ? (
-            <div className="rounded-md border border-dashed border-border bg-background/60 p-6 text-sm text-muted-foreground">
+            <div className="rounded-md border border-dashed border-border bg-background p-6 text-sm text-muted-foreground">
               Monitoring is not configured for this printer yet. The machine is still available as a static tracked record.
             </div>
           ) : (
             <div className="space-y-4">
               <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                <div className="rounded-md border border-border bg-background/60 p-4">
+                <div className="rounded-md border border-border bg-background p-4">
                   <p className="text-xs text-muted-foreground">Provider</p>
                   <p className="mt-2 font-semibold capitalize text-foreground">{printer.monitor_provider || '—'}</p>
                   <p className="mt-1 text-sm text-muted-foreground">{printer.monitor_poll_interval_seconds}s poll interval</p>
                 </div>
-                <div className="rounded-md border border-border bg-background/60 p-4">
+                <div className="rounded-md border border-border bg-background p-4">
                   <p className="text-xs text-muted-foreground">Last event</p>
                   <p className="mt-2 font-semibold text-foreground">
                     {printer.monitor_last_event_type ? printer.monitor_last_event_type.replace('notify_', '').replaceAll('_', ' ') : '—'}
                   </p>
                   <p className="mt-1 text-sm text-muted-foreground">{formatDateTime(printer.monitor_last_event_at)}</p>
                 </div>
-                <div className="rounded-md border border-border bg-background/60 p-4">
+                <div className="rounded-md border border-border bg-background p-4">
                   <p className="text-xs text-muted-foreground">Last seen</p>
                   <p className="mt-2 font-semibold text-foreground">{formatDateTime(printer.monitor_last_seen_at)}</p>
                   <p className="mt-1 text-sm text-muted-foreground">
@@ -356,7 +356,7 @@ export default function PrinterDetailPage() {
                 </div>
               </div>
 
-              <div className="rounded-md border border-border bg-background/60 p-4">
+              <div className="rounded-md border border-border bg-background p-4">
                 <p className="text-xs text-muted-foreground">Provider message</p>
                 <p className="mt-2 text-sm text-foreground">{printer.monitor_last_message || '—'}</p>
               </div>
@@ -376,7 +376,7 @@ export default function PrinterDetailPage() {
           )}
         </section>
 
-        <section className="rounded-lg border border-border bg-card/85 p-5 shadow-md">
+        <section className="rounded-md border border-border bg-card p-5 shadow-xs">
           <div className="mb-4 flex items-center justify-between">
             <div>
               <h2 className="text-xl font-semibold text-foreground">Visual console</h2>
@@ -412,12 +412,12 @@ export default function PrinterDetailPage() {
           )}
 
           <div className="mt-4 grid gap-3 sm:grid-cols-2">
-            <div className="rounded-md border border-border bg-background/60 p-4">
+            <div className="rounded-md border border-border bg-background p-4">
               <p className="text-xs text-muted-foreground">Machine identity</p>
               <p className="mt-2 font-semibold text-foreground">{printer.manufacturer || '—'} {printer.model || ''}</p>
               <p className="mt-1 text-sm text-muted-foreground">{printer.serial_number || 'No serial number'}</p>
             </div>
-            <div className="rounded-md border border-border bg-background/60 p-4">
+            <div className="rounded-md border border-border bg-background p-4">
               <p className="text-xs text-muted-foreground">Current assignment</p>
               {activeJob ? (
                 <>
@@ -433,7 +433,7 @@ export default function PrinterDetailPage() {
           </div>
 
           {printer.notes ? (
-            <div className="mt-4 rounded-md border border-border bg-background/60 p-4">
+            <div className="mt-4 rounded-md border border-border bg-background p-4">
               <p className="text-xs text-muted-foreground">Notes</p>
               <p className="mt-2 whitespace-pre-wrap text-sm text-foreground">{printer.notes}</p>
             </div>
@@ -441,7 +441,7 @@ export default function PrinterDetailPage() {
         </section>
       </div>
 
-      <section className="rounded-lg border border-border bg-card/85 p-5 shadow-md">
+      <section className="rounded-md border border-border bg-card p-5 shadow-xs">
         <div className="mb-4 flex items-start justify-between gap-3">
           <div>
             <h2 className="text-xl font-semibold text-foreground">Recent floor activity</h2>
@@ -449,13 +449,13 @@ export default function PrinterDetailPage() {
               Status changes and assignment events for this machine.
             </p>
           </div>
-          <span className="rounded-full bg-background/80 px-2.5 py-1 text-xs font-medium text-muted-foreground">
+          <span className="rounded-full bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground">
             {printer.history_events.length} events
           </span>
         </div>
 
         {!printer.history_events.length ? (
-          <div className="rounded-md border border-dashed border-border bg-background/60 p-6 text-sm text-muted-foreground">
+          <div className="rounded-md border border-dashed border-border bg-background p-6 text-sm text-muted-foreground">
             No printer activity has been recorded yet.
           </div>
         ) : (
@@ -467,7 +467,7 @@ export default function PrinterDetailPage() {
               const fromPrinter = formatEventMetaValue(event.metadata?.from_printer_name);
               const toPrinter = formatEventMetaValue(event.metadata?.to_printer_name);
               return (
-                <div key={event.id} className="rounded-md border border-border bg-background/60 p-4">
+                <div key={event.id} className="rounded-md border border-border bg-background p-4">
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                     <div>
                       <p className="font-medium text-foreground">{event.title}</p>
@@ -490,7 +490,7 @@ export default function PrinterDetailPage() {
         )}
       </section>
 
-      <section className="rounded-lg border border-border bg-card/85 p-5 shadow-md">
+      <section className="rounded-md border border-border bg-card p-5 shadow-xs">
         <div className="mb-4 flex items-center justify-between gap-3">
           <div>
             <h2 className="text-xl font-semibold text-foreground">Assigned jobs</h2>
@@ -504,11 +504,11 @@ export default function PrinterDetailPage() {
         {jobsLoading ? (
           <SkeletonTable rows={5} cols={6} />
         ) : !recentJobs.length ? (
-          <div className="rounded-md border border-dashed border-border bg-background/60 p-8 text-center text-muted-foreground">
+          <div className="rounded-md border border-dashed border-border bg-background p-8 text-center text-muted-foreground">
             No jobs assigned to this printer yet.
           </div>
         ) : (
-          <div className="overflow-x-auto rounded-md border border-border bg-background/60">
+          <div className="overflow-x-auto rounded-md border border-border bg-background">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-border text-left text-muted-foreground">

--- a/frontend/src/pages/PrinterFormPage.tsx
+++ b/frontend/src/pages/PrinterFormPage.tsx
@@ -330,7 +330,7 @@ export default function PrinterFormPage() {
                 </div>
 
                 <div className="flex justify-end">
-                  <button type="button" onClick={handleTestConnection} disabled={testingConnection} className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border px-4 py-2 hover:bg-accent disabled:opacity-50">
+                  <button type="button" onClick={handleTestConnection} disabled={testingConnection} className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 hover:bg-accent disabled:opacity-50">
                     <PlugZap className="h-4 w-4" />
                     {testingConnection ? 'Testing...' : 'Test connection'}
                   </button>
@@ -354,7 +354,7 @@ export default function PrinterFormPage() {
             <Button type="submit" disabled={saving}>
               {saving ? 'Saving...' : isEdit ? 'Save Changes' : 'Create Printer'}
             </Button>
-            <button type="button" onClick={() => navigate(isEdit && id ? `/printers/${id}` : '/printers')} className="cursor-pointer rounded-md border border-border px-4 py-2 hover:bg-accent">
+            <button type="button" onClick={() => navigate(isEdit && id ? `/printers/${id}` : '/printers')} className="rounded-md border border-border px-4 py-2 hover:bg-accent">
               Cancel
             </button>
           </div>

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -169,7 +169,7 @@ export default function ProductDetailPage() {
             <button
               onClick={toggleActive}
               disabled={saving}
-              className="inline-flex items-center gap-2 px-3 py-2 border border-border rounded-md hover:bg-accent disabled:opacity-50 cursor-pointer"
+              className="inline-flex items-center gap-2 px-3 py-2 border border-border rounded-md hover:bg-accent disabled:opacity-50"
             >
               {currentProduct.is_active ? <Archive className="w-4 h-4" /> : <ArchiveRestore className="w-4 h-4" />}
               {currentProduct.is_active ? 'Archive Product' : 'Restore Product'}
@@ -220,7 +220,7 @@ export default function ProductDetailPage() {
               setZeroReason('');
               setShowZeroStock(true);
             }}
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium border border-border hover:bg-accent transition-colors cursor-pointer"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium border border-border hover:bg-accent transition-colors"
           >
             <RotateCcw className="w-4 h-4" /> Set Stock to 0
           </button>

--- a/frontend/src/pages/ProductEditorPage.tsx
+++ b/frontend/src/pages/ProductEditorPage.tsx
@@ -330,7 +330,7 @@ export default function ProductEditorPage() {
             ) : (
               <div className="mt-4 space-y-3">
                 {recentTransactions.map((transaction: InventoryTransaction) => (
-                  <div key={transaction.id} className="rounded-md border border-border bg-background/80 px-4 py-3">
+                  <div key={transaction.id} className="rounded-md border border-border bg-background px-4 py-3">
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <p className="font-medium capitalize">{transaction.type}</p>

--- a/frontend/src/pages/RatesPage.tsx
+++ b/frontend/src/pages/RatesPage.tsx
@@ -93,7 +93,6 @@ export default function RatesPage() {
           type="button"
           onClick={() => toggleActive(r)}
           aria-label={r.active ? `Deactivate ${r.name}` : `Activate ${r.name}`}
-          className="cursor-pointer"
         >
           <StatusBadge tone={r.active ? 'success' : 'destructive'}>
             {r.active ? 'Active' : 'Inactive'}

--- a/frontend/src/pages/SaleDetailPage.tsx
+++ b/frontend/src/pages/SaleDetailPage.tsx
@@ -368,14 +368,14 @@ export default function SaleDetailPage() {
             {sale.status !== 'refunded' && sale.status !== 'cancelled' && (
               <button
                 onClick={handleRefund}
-                className="w-full flex items-center justify-center gap-2 px-4 py-2 border border-destructive text-destructive rounded-md hover:bg-destructive/10 cursor-pointer"
+                className="w-full flex items-center justify-center gap-2 px-4 py-2 border border-destructive text-destructive rounded-md hover:bg-destructive/10"
               >
                 <RefreshCw className="w-4 h-4" /> Refund Sale
               </button>
             )}
             <button
               onClick={handleDelete}
-              className="w-full px-4 py-2 border border-border text-muted-foreground rounded-md hover:bg-accent cursor-pointer"
+              className="w-full px-4 py-2 border border-border text-muted-foreground rounded-md hover:bg-accent"
             >
               Delete Sale
             </button>

--- a/frontend/src/pages/SaleFormPage.tsx
+++ b/frontend/src/pages/SaleFormPage.tsx
@@ -266,7 +266,7 @@ export default function SaleFormPage() {
           <div className="bg-card border border-border rounded-lg p-6">
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-lg font-semibold">Line Items</h2>
-              <button onClick={addItem} className="inline-flex items-center gap-1 text-sm text-primary hover:opacity-80 cursor-pointer">
+              <button onClick={addItem} className="inline-flex items-center gap-1 text-sm text-primary hover:opacity-80">
                 <Plus className="w-4 h-4" /> Add Item
               </button>
             </div>
@@ -304,7 +304,7 @@ export default function SaleFormPage() {
                     <Input id={`sale-item-${idx}-cost`} type="number" step="0.01" min="0" value={item.unit_cost} onChange={(e) => updateItem(idx, { unit_cost: Number(e.target.value) })} />
                   </div>
                   <div className="col-span-1 flex justify-end">
-                    <button onClick={() => removeItem(idx)} disabled={items.length === 1} className="p-2 hover:bg-accent rounded-md text-muted-foreground disabled:opacity-30 cursor-pointer">
+                    <button onClick={() => removeItem(idx)} disabled={items.length === 1} className="p-2 hover:bg-accent rounded-md text-muted-foreground disabled:opacity-30">
                       <Trash2 className="w-4 h-4" />
                     </button>
                   </div>

--- a/frontend/src/pages/SalesChannelsPage.tsx
+++ b/frontend/src/pages/SalesChannelsPage.tsx
@@ -171,7 +171,6 @@ function SalesChannelsTable({ channels, isLoading, onEdit, onToggleActive }: Sal
           type="button"
           onClick={() => onToggleActive(ch)}
           aria-label={ch.is_active ? `Deactivate ${ch.name}` : `Activate ${ch.name}`}
-          className="cursor-pointer"
         >
           <StatusBadge tone={ch.is_active ? 'success' : 'destructive'}>
             {ch.is_active ? 'Active' : 'Inactive'}
@@ -189,7 +188,7 @@ function SalesChannelsTable({ channels, isLoading, onEdit, onToggleActive }: Sal
           onClick={() => onEdit(ch)}
           aria-label={`Edit ${ch.name}`}
           title="Edit"
-          className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted cursor-pointer"
+          className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted"
         >
           <Edit className="h-4 w-4" />
         </button>

--- a/frontend/src/pages/admin/DataPage.tsx
+++ b/frontend/src/pages/admin/DataPage.tsx
@@ -76,7 +76,7 @@ export default function DataPage() {
             <button
               onClick={() => exportCsv(resource, label)}
               disabled={exporting === resource}
-              className="shrink-0 inline-flex items-center gap-2 px-3 py-2 border border-border rounded-lg text-sm font-medium hover:bg-accent transition-colors disabled:opacity-50 cursor-pointer"
+              className="shrink-0 inline-flex items-center gap-2 px-3 py-2 border border-border rounded-lg text-sm font-medium hover:bg-accent transition-colors disabled:opacity-50"
             >
               <Download className="w-4 h-4" />
               {exporting === resource ? 'Exporting...' : 'Export'}

--- a/frontend/src/pages/admin/SettingsPage.tsx
+++ b/frontend/src/pages/admin/SettingsPage.tsx
@@ -163,9 +163,9 @@ export default function SettingsPage() {
               })}
             </div>
 
-            <div className="mt-6 rounded-md border border-border bg-background/70 p-5">
+            <div className="mt-6 rounded-md border border-border bg-background p-5">
               <div className="mb-4 flex items-start gap-3">
-                <div className="rounded-xl bg-primary/10 p-2 text-primary">
+                <div className="rounded-md bg-primary/10 p-2 text-primary">
                   <KeyRound className="h-4 w-4" />
                 </div>
                 <div>

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -222,7 +222,7 @@ function UsersTable({ users, isLoading, currentUserId, onEdit, onDeactivate, onR
             onClick={() => onEdit(u)}
             aria-label={`Edit ${u.full_name}`}
             title="Edit"
-            className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted cursor-pointer"
+            className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted"
           >
             <Edit className="h-4 w-4" />
           </button>
@@ -233,7 +233,7 @@ function UsersTable({ users, isLoading, currentUserId, onEdit, onDeactivate, onR
                 onClick={() => onDeactivate(u)}
                 aria-label={`Deactivate ${u.full_name}`}
                 title="Deactivate"
-                className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive cursor-pointer"
+                className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
               >
                 <UserX className="h-4 w-4" />
               </button>
@@ -243,7 +243,7 @@ function UsersTable({ users, isLoading, currentUserId, onEdit, onDeactivate, onR
                 onClick={() => onReactivate(u)}
                 aria-label={`Reactivate ${u.full_name}`}
                 title="Reactivate"
-                className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-emerald-100 dark:hover:bg-emerald-900/20 hover:text-emerald-600 cursor-pointer"
+                className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-emerald-100 dark:hover:bg-emerald-900/20 hover:text-emerald-600"
               >
                 <Users className="h-4 w-4" />
               </button>


### PR DESCRIPTION
Closes #183. Parent epic: #173 (P1).

## Summary

Cross-cutting cleanup of holdout patterns left over from the workspace revamps. Every acceptance grep now comes back clean.

## Fixes

| Axis | Before | After |
|---|---|---|
| **X2 Radius** | `admin/SettingsPage` icon chip `rounded-xl` | `rounded-md` |
| **X3 Shadows** | `PrinterDetailPage` × 4 `shadow-md` cards | `shadow-xs` |
| **X4 Backdrop-blur** | `Footer` had `backdrop-blur` over `bg-card/30` | Removed both; border-top alone separates |
| **X5 Translucency** | `PrinterDetailPage`, POSPage, Pagination, ProductEditor, admin/Settings using `bg-card/85`, `bg-background/60-85`, `bg-card/30-50` | All opaque `bg-card` / `bg-background` |
| **X6 cursor-pointer** | ~17 manual `cursor-pointer` on `<button>` across 11 pages | Removed (native cursor-pointer on buttons); preserved on `<label>`, sortable `<th>`, clickable `<tr>`, checkbox `<input>` |

## Preserved (legitimate)

- `components/ui/{DropdownMenu,Popover,Select,Tooltip}.tsx` — overlay surfaces, `shadow-md` is correct
- `Layout.tsx` mobile drawer — `shadow-xl` is correct (overlay)
- `Dialog.tsx` — `backdrop-blur-sm` is correct (overlay)
- `PrinterMonitorPage.tsx` — kiosk gradient `backdrop-blur-sm` (covered by future #189)
- `DataTable` row/header/checkbox `cursor-pointer` (not buttons)
- `PrinterFormPage` `<label>` `cursor-pointer` (form ergonomics for checkbox)

## Acceptance

- [x] `rg 'rounded-(2xl|3xl)' src/components src/pages` → **0**
- [x] `rg 'rounded-xl' src/pages src/components/layout` → **0**
- [x] `rg 'bg-card/\d' src` → **0**
- [x] `rg 'bg-background/\d' src/pages` → **0**
- [x] `rg 'backdrop-blur' src` limited to Dialog + kiosk
- [x] `rg 'shadow-md' src/pages` → **0**
- [x] `rg 'cursor-pointer' src/pages src/components/layout` on `<button>` → **0**
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Printer detail page — sections render with subtle `shadow-xs` + opaque `bg-card`, no translucency
- [ ] POS — cart line tiles + customer mode + payment panels use opaque `bg-background`
- [ ] Footer — thin border-top separator without glass effect
- [ ] Pagination bar — opaque surface, no glass blur
- [ ] All buttons across the app still show pointer cursor on hover (native behavior)
- [ ] Form labels around checkboxes still show pointer cursor on hover (preserved)
- [ ] DataTable rows/sortable headers/checkboxes still show pointer cursor (preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)