### PR TITLE
feat(ui): ConfirmDialog primitive + replace 7 native confirm() sites (#181)

### DIFF
--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,106 @@
+import { useState, type ReactNode } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/Button';
+import { cn } from '@/lib/utils';
+
+export type ConfirmDialogTone = 'default' | 'destructive';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  /** Optional plain-language explanation of what will happen. */
+  description?: ReactNode;
+  /** Label on the confirm button. Defaults to "Confirm". */
+  confirmLabel?: string;
+  /** Label on the cancel button. Defaults to "Cancel". */
+  cancelLabel?: string;
+  /** `destructive` renders the confirm button in the destructive variant (red). */
+  tone?: ConfirmDialogTone;
+  /**
+   * Called when the user clicks the confirm button. If it returns a Promise, the
+   * confirm button shows a pending state until it resolves.
+   */
+  onConfirm: () => void | Promise<void>;
+  /** Close dialog automatically when onConfirm resolves. Default true. */
+  closeOnConfirm?: boolean;
+  /** Replace the default confirm button label when pending. */
+  pendingLabel?: string;
+  /** Additional classes on the DialogContent (e.g. max-w override). */
+  className?: string;
+}
+
+/**
+ * Styled replacement for `window.confirm()`. Built on top of Radix Dialog so it
+ * inherits focus-trap, ESC-to-close, and overlay click-to-close for free.
+ *
+ * ```tsx
+ * const [open, setOpen] = useState(false);
+ *
+ * <Button variant="outline" onClick={() => setOpen(true)}>Delete</Button>
+ * <ConfirmDialog
+ *   open={open}
+ *   onOpenChange={setOpen}
+ *   title="Delete customer?"
+ *   description={`${customer.name} will be removed. This cannot be undone.`}
+ *   confirmLabel="Delete"
+ *   tone="destructive"
+ *   onConfirm={async () => { await api.delete(`/customers/${customer.id}`); }}
+ * />
+ * ```
+ */
+export default function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  tone = 'default',
+  onConfirm,
+  closeOnConfirm = true,
+  pendingLabel,
+  className,
+}: ConfirmDialogProps) {
+  const [pending, setPending] = useState(false);
+
+  const handleConfirm = async () => {
+    setPending(true);
+    try {
+      await onConfirm();
+      if (closeOnConfirm) onOpenChange(false);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !pending && onOpenChange(next)}>
+      <DialogContent className={cn('max-w-md', className)}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description ? <DialogDescription>{description}</DialogDescription> : null}
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={pending}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={tone === 'destructive' ? 'destructive' : 'primary'}
+            onClick={handleConfirm}
+            disabled={pending}
+          >
+            {pending ? pendingLabel || `${confirmLabel}…` : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -12,6 +12,7 @@ import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
 import type { Customer } from '@/types';
 
@@ -32,6 +33,7 @@ export default function CustomersPage() {
   const [editing, setEditing] = useState<string | 'new' | null>(null);
   const [form, setForm] = useState(emptyForm);
   const [saving, setSaving] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<Customer | null>(null);
 
   const openNew = () => { setForm(emptyForm); setEditing('new'); };
   const openEdit = (c: Customer) => {
@@ -60,7 +62,6 @@ export default function CustomersPage() {
   };
 
   const deleteCustomer = async (c: Customer) => {
-    if (!confirm(`Delete ${c.name}?`)) return;
     try {
       await api.delete(`/customers/${c.id}`);
       toast.success('Customer deleted');
@@ -99,7 +100,7 @@ export default function CustomersPage() {
                 variant="ghost"
                 size="icon"
                 className="h-8 w-8"
-                onClick={() => deleteCustomer(c)}
+                onClick={() => setPendingDelete(c)}
                 aria-label={`Delete ${c.name}`}
               >
                 <Trash2 className="h-4 w-4" />
@@ -169,6 +170,18 @@ export default function CustomersPage() {
             <SearchInput value={search} onChange={setSearch} placeholder="Search customers…" />
           </TableToolbar>
         }
+      />
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => !open && setPendingDelete(null)}
+        title="Delete customer?"
+        description={pendingDelete ? `${pendingDelete.name} will be removed. This cannot be undone.` : undefined}
+        confirmLabel="Delete"
+        tone="destructive"
+        onConfirm={async () => {
+          if (pendingDelete) await deleteCustomer(pendingDelete);
+        }}
       />
     </div>
   );

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Edit, Calendar, User, Package, Printer, Copy } from 'lucide-
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { SkeletonCard } from '@/components/ui/Skeleton';
@@ -25,6 +26,7 @@ export default function JobDetailPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [duplicating, setDuplicating] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const { data: job, isLoading } = useQuery<Job>({
     queryKey: ['job', id],
@@ -32,7 +34,6 @@ export default function JobDetailPage() {
   });
 
   const handleDelete = async () => {
-    if (!confirm('Are you sure you want to delete this job?')) return;
     try {
       await api.delete(`/jobs/${id}`);
       toast.success('Job deleted');
@@ -109,13 +110,23 @@ export default function JobDetailPage() {
           </Button>
           <Button
             variant="outline"
-            onClick={handleDelete}
+            onClick={() => setConfirmDelete(true)}
             className="border-destructive/30 text-destructive hover:bg-destructive/10"
           >
             Delete
           </Button>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={confirmDelete}
+        onOpenChange={setConfirmDelete}
+        title="Delete job?"
+        description={`${job?.job_number ?? 'This job'} will be permanently removed. This cannot be undone.`}
+        confirmLabel="Delete"
+        tone="destructive"
+        onConfirm={handleDelete}
+      />
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         <div className="bg-card border border-border rounded-lg p-4 flex items-center gap-3">

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
@@ -21,6 +22,7 @@ import CameraFeed from '@/components/cameras/CameraFeed';
 import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import { SkeletonTable } from '@/components/ui/Skeleton';
 import { Button } from '@/components/ui/Button';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
 import PageHeader from '@/components/layout/PageHeader';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
@@ -115,16 +117,10 @@ export default function PrinterDetailPage() {
     enabled: Boolean(id),
   });
 
+  const [confirmToggle, setConfirmToggle] = useState(false);
+
   const toggleActive = async () => {
     if (!printer) return;
-    const confirmed = window.confirm(
-      printer.is_active
-        ? `Deactivate ${printer.name}?\n\nThis preserves historical assignments and removes it from active use.`
-        : `Restore ${printer.name} to active printers?`
-    );
-
-    if (!confirmed) return;
-
     try {
       if (printer.is_active) {
         await api.delete(`/printers/${printer.id}`);
@@ -220,7 +216,7 @@ export default function PrinterDetailPage() {
                 <Edit className="h-4 w-4" /> Edit
               </Link>
             </Button>
-            <Button variant="outline" onClick={toggleActive}>
+            <Button variant="outline" onClick={() => setConfirmToggle(true)}>
               {printer.is_active ? <Archive className="h-4 w-4" /> : <ArchiveRestore className="h-4 w-4" />}
               {printer.is_active ? 'Deactivate' : 'Restore'}
             </Button>
@@ -536,6 +532,20 @@ export default function PrinterDetailPage() {
           </div>
         )}
       </section>
+
+      <ConfirmDialog
+        open={confirmToggle}
+        onOpenChange={setConfirmToggle}
+        title={printer.is_active ? 'Deactivate printer?' : 'Restore printer?'}
+        description={
+          printer.is_active
+            ? `${printer.name} will preserve historical assignments and be removed from active use.`
+            : `${printer.name} will be restored to active printers.`
+        }
+        confirmLabel={printer.is_active ? 'Deactivate' : 'Restore'}
+        tone={printer.is_active ? 'destructive' : 'default'}
+        onConfirm={toggleActive}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -20,6 +20,7 @@ import CameraFeed from '@/components/cameras/CameraFeed';
 import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import EmptyState from '@/components/ui/EmptyState';
 import { Button } from '@/components/ui/Button';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
 import { Callout, calloutToneClasses } from '@/components/ui/Callout';
 import PageHeader from '@/components/layout/PageHeader';
 import { KPI, KPIStrip } from '@/components/layout/KPIStrip';
@@ -247,6 +248,7 @@ export default function PrintersPage() {
   const limit = 24;
   const wallMode = searchParams.get('mode') === 'wall';
   const [reducedMotion, setReducedMotion] = useState(false);
+  const [pendingToggle, setPendingToggle] = useState<Printer | null>(null);
 
   useEffect(() => {
     const media = window.matchMedia('(prefers-reduced-motion: reduce)');
@@ -362,14 +364,6 @@ export default function PrintersPage() {
   const attentionPrinters = wallGroups[0]?.printers || [];
 
   const toggleActive = async (printer: Printer) => {
-    const confirmed = window.confirm(
-      printer.is_active
-        ? `Deactivate ${printer.name}?\n\nThis keeps the printer in historical records but removes it from active assignment.`
-        : `Restore ${printer.name} to active printers?`
-    );
-
-    if (!confirmed) return;
-
     try {
       if (printer.is_active) {
         await api.delete(`/printers/${printer.id}`);
@@ -555,7 +549,7 @@ export default function PrintersPage() {
                         key={printer.id}
                         printer={printer}
                         currentJob={currentJobsByPrinter.get(printer.id)}
-                        onToggleActive={toggleActive}
+                        onToggleActive={setPendingToggle}
                         wallMode={wallMode}
                         reducedMotion={reducedMotion}
                       />
@@ -601,6 +595,24 @@ export default function PrintersPage() {
           }}
         />
       ) : null}
+
+      <ConfirmDialog
+        open={pendingToggle !== null}
+        onOpenChange={(open) => !open && setPendingToggle(null)}
+        title={pendingToggle?.is_active ? 'Deactivate printer?' : 'Restore printer?'}
+        description={
+          pendingToggle
+            ? pendingToggle.is_active
+              ? `${pendingToggle.name} will be kept in historical records but removed from active assignment.`
+              : `${pendingToggle.name} will be restored to active printers.`
+            : undefined
+        }
+        confirmLabel={pendingToggle?.is_active ? 'Deactivate' : 'Restore'}
+        tone={pendingToggle?.is_active ? 'destructive' : 'default'}
+        onConfirm={async () => {
+          if (pendingToggle) await toggleActive(pendingToggle);
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -7,6 +7,7 @@ import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
 import { Button } from '@/components/ui/Button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
@@ -43,6 +44,7 @@ export default function ProductDetailPage() {
   const [adjForm, setAdjForm] = useState({ type: 'adjustment', quantity: 0, notes: '' });
   const [zeroReason, setZeroReason] = useState('');
   const [saving, setSaving] = useState(false);
+  const [confirmToggle, setConfirmToggle] = useState(false);
 
   const submitAdjustment = async () => {
     if (adjForm.quantity === 0) { toast.error('Quantity cannot be 0'); return; }
@@ -68,14 +70,6 @@ export default function ProductDetailPage() {
   };
 
   const toggleActive = async () => {
-    const confirmed = window.confirm(
-      currentProduct.is_active
-        ? `Archive ${currentProduct.name}?\n\nThis keeps historical records and inventory history, but removes the product from active use.`
-        : `Restore ${currentProduct.name} to active products?`
-    );
-
-    if (!confirmed) return;
-
     setSaving(true);
     try {
       if (currentProduct.is_active) {
@@ -165,7 +159,7 @@ export default function ProductDetailPage() {
                 Open Editor
               </Link>
             </Button>
-            <Button variant="outline" onClick={toggleActive} disabled={saving}>
+            <Button variant="outline" onClick={() => setConfirmToggle(true)} disabled={saving}>
               {currentProduct.is_active ? <Archive className="h-4 w-4" /> : <ArchiveRestore className="h-4 w-4" />}
               {currentProduct.is_active ? 'Archive Product' : 'Restore Product'}
             </Button>
@@ -338,6 +332,20 @@ export default function ProductDetailPage() {
           </table>
         </div>
       )}
+
+      <ConfirmDialog
+        open={confirmToggle}
+        onOpenChange={setConfirmToggle}
+        title={currentProduct.is_active ? 'Archive product?' : 'Restore product?'}
+        description={
+          currentProduct.is_active
+            ? `${currentProduct.name} will be kept in historical records and inventory history, but removed from active use.`
+            : `${currentProduct.name} will be restored to active products.`
+        }
+        confirmLabel={currentProduct.is_active ? 'Archive' : 'Restore'}
+        tone={currentProduct.is_active ? 'destructive' : 'default'}
+        onConfirm={toggleActive}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -11,6 +11,7 @@ import TableToolbar from '@/components/data/TableToolbar';
 import SearchInput from '@/components/data/SearchInput';
 import Pagination from '@/components/data/Pagination';
 import { Button } from '@/components/ui/Button';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
 import { formatCurrency } from '@/lib/utils';
 import type { PaginatedProducts, Product } from '@/types';
@@ -22,6 +23,7 @@ export default function ProductsPage() {
   const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(25);
+  const [pendingToggle, setPendingToggle] = useState<Product | null>(null);
 
   const { data, isLoading, refetch } = useQuery<PaginatedProducts>({
     queryKey: ['products', search, sortKey, sortDir, page, pageSize],
@@ -45,12 +47,6 @@ export default function ProductsPage() {
 
   const toggleActive = async (product: Product) => {
     const action = product.is_active ? 'archive' : 'restore';
-    const confirmed = window.confirm(
-      product.is_active
-        ? `Archive ${product.name}?\n\nThis removes it from active selling while preserving history.`
-        : `Restore ${product.name} to active products?`,
-    );
-    if (!confirmed) return;
     try {
       if (product.is_active) {
         await api.delete(`/products/${product.id}`);
@@ -177,7 +173,7 @@ export default function ProductsPage() {
                 variant="ghost"
                 size="icon"
                 className="h-8 w-8"
-                onClick={() => toggleActive(p)}
+                onClick={() => setPendingToggle(p)}
                 aria-label={p.is_active ? `Archive ${p.name}` : `Restore ${p.name}`}
               >
                 {p.is_active ? <Archive className="h-4 w-4" /> : <ArchiveRestore className="h-4 w-4" />}
@@ -312,6 +308,24 @@ export default function ProductsPage() {
           </div>
         ))}
       </div>
+
+      <ConfirmDialog
+        open={pendingToggle !== null}
+        onOpenChange={(open) => !open && setPendingToggle(null)}
+        title={pendingToggle?.is_active ? 'Archive product?' : 'Restore product?'}
+        description={
+          pendingToggle
+            ? pendingToggle.is_active
+              ? `${pendingToggle.name} will be removed from active selling. History is preserved.`
+              : `${pendingToggle.name} will be restored to active products.`
+            : undefined
+        }
+        confirmLabel={pendingToggle?.is_active ? 'Archive' : 'Restore'}
+        tone={pendingToggle?.is_active ? 'destructive' : 'default'}
+        onConfirm={async () => {
+          if (pendingToggle) await toggleActive(pendingToggle);
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
 import StatusBadge from '@/components/data/StatusBadge';
 import DataTable, { type Column } from '@/components/data/DataTable';
@@ -35,6 +36,7 @@ export default function UsersPage() {
   const [editing, setEditing] = useState<string | 'new' | null>(null);
   const [form, setForm] = useState(emptyForm);
   const [saving, setSaving] = useState(false);
+  const [pendingDeactivate, setPendingDeactivate] = useState<UserRecord | null>(null);
 
   const openNew = () => { setForm(emptyForm); setEditing('new'); };
   const openEdit = (u: UserRecord) => {
@@ -68,7 +70,6 @@ export default function UsersPage() {
   };
 
   const deactivate = async (u: UserRecord) => {
-    if (!confirm(`Deactivate ${u.full_name}?`)) return;
     try {
       await api.delete(`/auth/users/${u.id}`);
       toast.success(`${u.full_name} deactivated`);
@@ -154,8 +155,24 @@ export default function UsersPage() {
         isLoading={isLoading}
         currentUserId={currentUser?.id}
         onEdit={openEdit}
-        onDeactivate={deactivate}
+        onDeactivate={setPendingDeactivate}
         onReactivate={reactivate}
+      />
+
+      <ConfirmDialog
+        open={pendingDeactivate !== null}
+        onOpenChange={(open) => !open && setPendingDeactivate(null)}
+        title="Deactivate user?"
+        description={
+          pendingDeactivate
+            ? `${pendingDeactivate.full_name} will lose access to the app. You can reactivate them later.`
+            : undefined
+        }
+        confirmLabel="Deactivate"
+        tone="destructive"
+        onConfirm={async () => {
+          if (pendingDeactivate) await deactivate(pendingDeactivate);
+        }}
       />
     </div>
   );


### PR DESCRIPTION
Closes #181. Parent epic: #173 — **last P1 issue**. Epic wraps up with this merge.

## Summary

Introduces `<ConfirmDialog>` on top of the Radix Dialog primitive and migrates all 7 native `window.confirm()` sites to the styled modal. Destructive actions now render with a red confirm button, full focus-trap, and keyboard support. The confirm button also supports async `onConfirm` (shows pending state while resolving).

## New primitive

`frontend/src/components/ui/ConfirmDialog.tsx`:

```tsx
<ConfirmDialog
  open={confirmOpen}
  onOpenChange={setConfirmOpen}
  title="Delete customer?"
  description={`${customer.name} will be removed. This cannot be undone.`}
  confirmLabel="Delete"
  tone="destructive"
  onConfirm={async () => { await api.delete(`/customers/${c.id}`); }}
/>
```

Features:
- Radix Dialog chrome (focus-trap, ESC, overlay click)
- Async-aware `onConfirm` — button shows "Delete…" while pending
- Auto-closes on resolve (opt-out via `closeOnConfirm={false}`)
- Blocks background close while pending
- `tone="destructive"` → red confirm button

## Migrated sites

| Page | Action | Tone |
|---|---|---|
| admin/UsersPage | Deactivate user | destructive |
| CustomersPage | Delete customer | destructive |
| JobDetailPage | Delete job | destructive |
| PrintersPage | Deactivate / Restore toggle | tone-switched |
| ProductDetailPage | Archive toggle | tone-switched |
| PrinterDetailPage | Deactivate / Restore toggle | tone-switched |
| ProductsPage | Archive toggle | tone-switched |

For toggles (Printers/Products/Printer/Product detail), `title`, `confirmLabel`, `description`, and `tone` flip based on the entity's current `is_active`.

## Acceptance

- [x] `rg 'confirm\(' frontend/src/pages` → **0**
- [x] All destructive actions show themed modal
- [x] Focus-trap + ESC-to-close + overlay click-to-close work (Radix default)
- [x] `tone="destructive"` renders red confirm button
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Admin users: click Deactivate → modal appears with user's name; ESC closes; overlay click closes; Cancel closes; Deactivate shows pending then closes
- [ ] Customers: click Delete icon on a customer row → modal appears; confirm removes customer from list
- [ ] Job detail: click Delete → modal appears with job number; confirm navigates away after delete
- [ ] Printers list: click Archive icon on an active printer → modal says "Deactivate printer?" with red button; click on an inactive printer → "Restore printer?" with default blue button
- [ ] Product detail, Printer detail, Products list: same toggle behavior
- [ ] Keyboard: Tab cycles focus between Cancel and Confirm inside the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)