### PR TITLE
feat(ui): body default text-sm + section heading consolidation (#187)

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -44,7 +44,7 @@ export default function Layout() {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
   return (
-    <div className="min-h-screen flex flex-col bg-background">
+    <div className="min-h-screen flex flex-col bg-background text-sm text-foreground">
       <Header onOpenMobileNav={() => setMobileNavOpen(true)} />
 
       <div className="mx-auto flex-1 w-full max-w-[96rem] px-4 py-6 sm:px-6 lg:px-8 lg:py-8">

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -175,7 +175,7 @@ export default function InsightsPage() {
                 <p className="text-xs text-muted-foreground">
                   {summary.provider} · {summary.model}
                 </p>
-                <h2 className="mt-1 text-lg font-semibold">{summary.title}</h2>
+                <h2 className="mt-1 text-base font-semibold">{summary.title}</h2>
                 <p className="mt-2 text-sm text-muted-foreground">{summary.summary}</p>
                 <p className="mt-2 text-xs text-muted-foreground">
                   Generated {new Date(summary.generated_at).toLocaleString()}

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -160,7 +160,7 @@ export default function JobDetailPage() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Cost Breakdown */}
         <div className="bg-card border border-border rounded-lg p-6">
-          <h3 className="text-lg font-semibold mb-4">Cost Breakdown</h3>
+          <h3 className="text-base font-semibold mb-4">Cost Breakdown</h3>
           <CostRow label="Electricity" value={job.electricity_cost} />
           <CostRow label="Material" value={job.material_cost} />
           <CostRow label="Labor" value={job.labor_cost} />
@@ -181,7 +181,7 @@ export default function JobDetailPage() {
 
         {/* Pricing & Profit */}
         <div className="bg-card border border-border rounded-lg p-6">
-          <h3 className="text-lg font-semibold mb-4">Pricing & Profit</h3>
+          <h3 className="text-base font-semibold mb-4">Pricing & Profit</h3>
           <div className="space-y-4">
             <div className="flex justify-between py-2 border-b border-border">
               <span className="text-muted-foreground">Target Margin</span>

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -357,7 +357,7 @@ export default function JobFormPage() {
         <form onSubmit={handleSubmit} className="lg:col-span-2 space-y-6">
           {/* Job Info */}
           <div className="bg-card border border-border rounded-lg p-6">
-            <h3 className="text-lg font-semibold mb-4">Job Info</h3>
+            <h3 className="text-base font-semibold mb-4">Job Info</h3>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <Field label="Job Number" field="job_number" value={form.job_number} error={errors.job_number} onChange={update} placeholder="2026.03.24.001" />
@@ -432,7 +432,7 @@ export default function JobFormPage() {
 
           {/* Print Details */}
           <div className="bg-card border border-border rounded-lg p-6">
-            <h3 className="text-lg font-semibold mb-4">Print Details</h3>
+            <h3 className="text-base font-semibold mb-4">Print Details</h3>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-1.5">
                 <Label htmlFor="job-material">Material</Label>
@@ -458,7 +458,7 @@ export default function JobFormPage() {
 
           {/* Labor & Costs */}
           <div className="bg-card border border-border rounded-lg p-6">
-            <h3 className="text-lg font-semibold mb-4">Labor & Additional Costs</h3>
+            <h3 className="text-base font-semibold mb-4">Labor & Additional Costs</h3>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <Field label="Labor Time (mins)" field="labor_mins" type="number" value={form.labor_mins} error={errors.labor_mins} onChange={update} min={0} />
               <Field label="Design Time (hrs)" field="design_time_hrs" type="number" value={form.design_time_hrs} error={errors.design_time_hrs} onChange={update} min={0} step="0.01" />
@@ -491,7 +491,7 @@ export default function JobFormPage() {
         {/* Live Cost Preview */}
         <div className="lg:col-span-1">
           <div className="bg-card border border-border rounded-lg p-6 sticky top-24">
-            <h3 className="text-lg font-semibold mb-4">Cost Preview</h3>
+            <h3 className="text-base font-semibold mb-4">Cost Preview</h3>
             {preview ? (
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between"><span className="text-muted-foreground">Pieces</span><span className="font-medium">{preview.total_pieces}</span></div>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -87,7 +87,7 @@ export default function LoginPage() {
           <span className="text-2xl font-semibold">3D Print Sales</span>
         </div>
         <div className="bg-card border border-border rounded-lg p-8 shadow-sm">
-          <h2 className="text-xl font-semibold mb-6 text-center">Sign In</h2>
+          <h2 className="text-base font-semibold mb-6 text-center">Sign In</h2>
           {errors.form && (
             <div className="bg-destructive/10 text-destructive text-sm rounded-lg p-3 mb-4">
               {errors.form}

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -303,7 +303,7 @@ export default function PrinterDetailPage() {
         <section className="rounded-md border border-border bg-card p-5 shadow-xs">
           <div className="mb-4 flex items-start justify-between gap-3">
             <div>
-              <h2 className="text-xl font-semibold text-foreground">Live monitoring</h2>
+              <h2 className="text-base font-semibold text-foreground">Live monitoring</h2>
               <p className="mt-1 text-sm text-muted-foreground">
                 A denser, operator-friendly view of the current telemetry from the configured monitoring provider.
               </p>
@@ -368,7 +368,7 @@ export default function PrinterDetailPage() {
         <section className="rounded-md border border-border bg-card p-5 shadow-xs">
           <div className="mb-4 flex items-center justify-between">
             <div>
-              <h2 className="text-xl font-semibold text-foreground">Visual console</h2>
+              <h2 className="text-base font-semibold text-foreground">Visual console</h2>
               <p className="mt-1 text-sm text-muted-foreground">
                 {printer.camera_id ? `Live feed from ${printer.camera_name}` : 'Current print thumbnail plus the most relevant assignment and machine details.'}
               </p>
@@ -432,7 +432,7 @@ export default function PrinterDetailPage() {
       <section className="rounded-md border border-border bg-card p-5 shadow-xs">
         <div className="mb-4 flex items-start justify-between gap-3">
           <div>
-            <h2 className="text-xl font-semibold text-foreground">Recent floor activity</h2>
+            <h2 className="text-base font-semibold text-foreground">Recent floor activity</h2>
             <p className="mt-1 text-sm text-muted-foreground">
               Status changes and assignment events for this machine.
             </p>
@@ -481,7 +481,7 @@ export default function PrinterDetailPage() {
       <section className="rounded-md border border-border bg-card p-5 shadow-xs">
         <div className="mb-4 flex items-center justify-between gap-3">
           <div>
-            <h2 className="text-xl font-semibold text-foreground">Assigned jobs</h2>
+            <h2 className="text-base font-semibold text-foreground">Assigned jobs</h2>
             <p className="mt-1 text-sm text-muted-foreground">Current and recent jobs routed through this printer.</p>
           </div>
           <Link to="/orders" className="text-sm text-primary no-underline hover:underline">

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -198,7 +198,7 @@ export default function ProductDetailPage() {
 
       {/* Adjust Stock */}
       <div className="flex items-center justify-between mb-4 gap-3">
-        <h2 className="text-xl font-semibold">Transaction History</h2>
+        <h2 className="text-base font-semibold">Transaction History</h2>
         <div className="flex gap-2">
           <Button
             variant="outline"

--- a/frontend/src/pages/ProductEditorPage.tsx
+++ b/frontend/src/pages/ProductEditorPage.tsx
@@ -181,7 +181,7 @@ export default function ProductEditorPage() {
           <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex items-center gap-2">
               <ReceiptText className="h-5 w-5 text-muted-foreground" />
-              <h2 className="text-xl font-semibold">Identity and sellable details</h2>
+              <h2 className="text-base font-semibold">Identity and sellable details</h2>
             </div>
 
             <div className="mt-5 grid gap-4 lg:grid-cols-2">
@@ -305,7 +305,7 @@ export default function ProductEditorPage() {
           <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex items-center gap-2">
               <Boxes className="h-5 w-5 text-muted-foreground" />
-              <h2 className="text-xl font-semibold">Stock and activity context</h2>
+              <h2 className="text-base font-semibold">Stock and activity context</h2>
             </div>
             {isCreate ? (
               <EmptyState
@@ -357,7 +357,7 @@ export default function ProductEditorPage() {
           <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
             <div className="flex items-center gap-2">
               <BadgeDollarSign className="h-5 w-5 text-muted-foreground" />
-              <h2 className="text-xl font-semibold">Readiness and margin</h2>
+              <h2 className="text-base font-semibold">Readiness and margin</h2>
             </div>
 
             <div className="mt-4 space-y-3">
@@ -424,7 +424,7 @@ export default function ProductEditorPage() {
           </section>
 
           <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
-            <h2 className="text-xl font-semibold">Material context</h2>
+            <h2 className="text-base font-semibold">Material context</h2>
             {selectedMaterial ? (
               <div className="mt-4 space-y-3 text-sm">
                 <div className="rounded-md bg-background px-4 py-3">

--- a/frontend/src/pages/SaleDetailPage.tsx
+++ b/frontend/src/pages/SaleDetailPage.tsx
@@ -229,7 +229,7 @@ export default function SaleDetailPage() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2 bg-card border border-border rounded-lg p-6">
-          <h2 className="text-lg font-semibold mb-4">Line Items</h2>
+          <h2 className="text-base font-semibold mb-4">Line Items</h2>
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-border text-left text-muted-foreground">
@@ -256,7 +256,7 @@ export default function SaleDetailPage() {
 
         <div className="space-y-6">
           <div className="bg-card border border-border rounded-lg p-6">
-            <h2 className="text-lg font-semibold mb-4">Summary</h2>
+            <h2 className="text-base font-semibold mb-4">Summary</h2>
             <div className="space-y-2 text-sm">
               <div className="flex justify-between"><span className="text-muted-foreground">Subtotal</span><span>{formatCurrency(sale.subtotal)}</span></div>
               <div className="flex justify-between"><span className="text-muted-foreground">Shipping charged</span><span>{formatCurrency(sale.shipping_charged)}</span></div>
@@ -275,7 +275,7 @@ export default function SaleDetailPage() {
           </div>
 
           <div className="bg-card border border-border rounded-lg p-6">
-            <h2 className="text-lg font-semibold mb-4">Details</h2>
+            <h2 className="text-base font-semibold mb-4">Details</h2>
             <div className="space-y-2 text-sm">
               <div className="flex justify-between"><span className="text-muted-foreground">Channel</span><span>{channelName}</span></div>
               {sale.payment_method && <div className="flex justify-between"><span className="text-muted-foreground">Payment</span><span className="capitalize">{sale.payment_method}</span></div>}
@@ -287,7 +287,7 @@ export default function SaleDetailPage() {
           <div className="bg-card border border-border rounded-lg p-6 space-y-4">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h2 className="text-lg font-semibold">Shipping Label</h2>
+                <h2 className="text-base font-semibold">Shipping Label</h2>
                 <p className="text-sm text-muted-foreground">
                   Server renders a 4x6 browser-printable label. The workstation browser owns the final thermal print step.
                 </p>
@@ -352,7 +352,7 @@ export default function SaleDetailPage() {
           </div>
 
           <div className="bg-card border border-border rounded-lg p-6 space-y-3">
-            <h2 className="text-lg font-semibold mb-2">Actions</h2>
+            <h2 className="text-base font-semibold mb-2">Actions</h2>
             {sale.status !== 'refunded' && sale.status !== 'cancelled' && (
               <select
                 value={sale.status}

--- a/frontend/src/pages/SaleFormPage.tsx
+++ b/frontend/src/pages/SaleFormPage.tsx
@@ -152,7 +152,7 @@ export default function SaleFormPage() {
         <div className="lg:col-span-2 space-y-6">
           {/* Header info */}
           <div className="bg-card border border-border rounded-lg p-6">
-            <h2 className="text-lg font-semibold mb-4">Sale Details</h2>
+            <h2 className="text-base font-semibold mb-4">Sale Details</h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-1.5">
                 <Label htmlFor="sale-date">Date *</Label>
@@ -218,7 +218,7 @@ export default function SaleFormPage() {
           </div>
 
           <div className="bg-card border border-border rounded-lg p-6">
-            <h2 className="text-lg font-semibold mb-4">Shipment Label</h2>
+            <h2 className="text-base font-semibold mb-4">Shipment Label</h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-1.5">
                 <Label htmlFor="sale-ship-recipient">Recipient</Label>
@@ -261,7 +261,7 @@ export default function SaleFormPage() {
           {/* Line items */}
           <div className="bg-card border border-border rounded-lg p-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold">Line Items</h2>
+              <h2 className="text-base font-semibold">Line Items</h2>
               <button onClick={addItem} className="inline-flex items-center gap-1 text-sm text-primary hover:opacity-80">
                 <Plus className="w-4 h-4" /> Add Item
               </button>
@@ -314,7 +314,7 @@ export default function SaleFormPage() {
         <div className="space-y-6">
           {/* Shipping & Tax */}
           <div className="bg-card border border-border rounded-lg p-6">
-            <h2 className="text-lg font-semibold mb-4">Shipping & Tax</h2>
+            <h2 className="text-base font-semibold mb-4">Shipping & Tax</h2>
             <div className="space-y-3">
               <div className="space-y-1.5">
                 <Label htmlFor="sale-shipping-charged">Shipping Charged</Label>
@@ -333,7 +333,7 @@ export default function SaleFormPage() {
 
           {/* Order Total */}
           <div className="bg-card border border-border rounded-lg p-6">
-            <h2 className="text-lg font-semibold mb-4">Order Total</h2>
+            <h2 className="text-base font-semibold mb-4">Order Total</h2>
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
                 <span className="text-muted-foreground">Subtotal</span>

--- a/frontend/src/pages/admin/SettingsPage.tsx
+++ b/frontend/src/pages/admin/SettingsPage.tsx
@@ -133,7 +133,7 @@ export default function SettingsPage() {
                 <Bot className="h-6 w-6" />
               </div>
               <div>
-                <h2 className="text-lg font-semibold">AI Intelligence</h2>
+                <h2 className="text-base font-semibold">AI Intelligence</h2>
                 <p className="text-sm text-muted-foreground">
                   Configure one supported provider for the read-only Insights workspace. Keep the choice obvious, the model explicit, and the secrets scoped to admins only.
                 </p>
@@ -185,7 +185,7 @@ export default function SettingsPage() {
           {Object.entries(groups).map(([group, { keys, description }]) => (
             <div key={group} className="bg-card border border-border rounded-lg p-6">
               <div className="mb-4">
-                <h2 className="text-lg font-semibold">{group}</h2>
+                <h2 className="text-base font-semibold">{group}</h2>
                 <p className="text-sm text-muted-foreground">{description}</p>
               </div>
               <div className="space-y-4">

--- a/frontend/src/pages/reports/InventoryReportPage.tsx
+++ b/frontend/src/pages/reports/InventoryReportPage.tsx
@@ -35,7 +35,7 @@ export default function InventoryReportPage() {
 
   return (
     <div>
-      <h2 className="text-xl font-semibold mb-6">Inventory Report</h2>
+      <h2 className="text-base font-semibold mb-6">Inventory Report</h2>
 
       <ReportControls
         dateFrom={dateFrom}
@@ -64,7 +64,7 @@ export default function InventoryReportPage() {
           {/* Stock levels table */}
           {data.stock_levels.length > 0 && (
             <div className="space-y-3">
-              <h3 className="text-lg font-semibold">Stock Levels</h3>
+              <h3 className="text-base font-semibold">Stock Levels</h3>
               <DataTable<StockLevelRow>
                 data={data.stock_levels}
                 rowKey={(row) => row.product_id}
@@ -118,7 +118,7 @@ export default function InventoryReportPage() {
             {/* Turnover chart */}
             {data.turnover.length > 0 && (
               <div className="bg-card border border-border rounded-lg p-6">
-                <h3 className="text-lg font-semibold mb-4">Inventory Turnover</h3>
+                <h3 className="text-base font-semibold mb-4">Inventory Turnover</h3>
                 <ResponsiveContainer width="100%" height={280}>
                   <BarChart data={data.turnover.slice(0, 10)}>
                     <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
@@ -134,7 +134,7 @@ export default function InventoryReportPage() {
             {/* Material usage chart */}
             {data.material_usage.length > 0 && (
               <div className="bg-card border border-border rounded-lg p-6">
-                <h3 className="text-lg font-semibold mb-4">Material Usage</h3>
+                <h3 className="text-base font-semibold mb-4">Material Usage</h3>
                 <ResponsiveContainer width="100%" height={280}>
                   <PieChart>
                     <Pie

--- a/frontend/src/pages/reports/PLReportPage.tsx
+++ b/frontend/src/pages/reports/PLReportPage.tsx
@@ -39,7 +39,7 @@ export default function PLReportPage() {
 
   return (
     <div>
-      <h2 className="text-xl font-semibold mb-6">Profit & Loss</h2>
+      <h2 className="text-base font-semibold mb-6">Profit & Loss</h2>
 
       <ReportControls
         dateFrom={dateFrom}
@@ -82,7 +82,7 @@ export default function PLReportPage() {
 
           {/* Cost breakdown */}
           <div className="bg-card border border-border rounded-lg p-6">
-            <h3 className="text-lg font-semibold mb-4">Cost Breakdown</h3>
+            <h3 className="text-base font-semibold mb-4">Cost Breakdown</h3>
             <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
               {[
                 { label: 'Materials', value: s.material_costs },
@@ -106,7 +106,7 @@ export default function PLReportPage() {
           {/* Trend chart */}
           {data.period_data.length > 0 && (
             <div className="bg-card border border-border rounded-lg p-6">
-              <h3 className="text-lg font-semibold mb-4">P&L Trend</h3>
+              <h3 className="text-base font-semibold mb-4">P&L Trend</h3>
               <ResponsiveContainer width="100%" height={320}>
                 <BarChart data={data.period_data}>
                   <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
@@ -127,7 +127,7 @@ export default function PLReportPage() {
           {/* Period table */}
           {data.period_data.length > 0 && (
             <div className="space-y-3">
-              <h3 className="text-lg font-semibold">Period Detail</h3>
+              <h3 className="text-base font-semibold">Period Detail</h3>
               <DataTable<PLRow>
                 data={data.period_data}
                 rowKey={(row) => row.period}

--- a/frontend/src/pages/reports/SalesReportPage.tsx
+++ b/frontend/src/pages/reports/SalesReportPage.tsx
@@ -35,7 +35,7 @@ export default function SalesReportPage() {
 
   return (
     <div>
-      <h2 className="text-xl font-semibold mb-6">Sales Report</h2>
+      <h2 className="text-base font-semibold mb-6">Sales Report</h2>
 
       <ReportControls
         dateFrom={dateFrom}
@@ -75,7 +75,7 @@ export default function SalesReportPage() {
           {/* Revenue over time chart */}
           {data.period_data.length > 0 && (
             <div className="bg-card border border-border rounded-lg p-6">
-              <h3 className="text-lg font-semibold mb-4">Revenue Over Time</h3>
+              <h3 className="text-base font-semibold mb-4">Revenue Over Time</h3>
               <ResponsiveContainer width="100%" height={300}>
                 <LineChart data={data.period_data}>
                   <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
@@ -95,7 +95,7 @@ export default function SalesReportPage() {
             {/* Top products */}
             {data.top_products.length > 0 && (
               <div className="space-y-3">
-                <h3 className="text-lg font-semibold">Top Products</h3>
+                <h3 className="text-base font-semibold">Top Products</h3>
                 <DataTable<ProductRanking & { _idx: number }>
                   data={data.top_products.map((p, i) => ({ ...p, _idx: i }))}
                   rowKey={(p) => String(p._idx)}
@@ -132,7 +132,7 @@ export default function SalesReportPage() {
             {/* Channel breakdown */}
             {data.channel_breakdown.length > 0 && (
               <div className="bg-card border border-border rounded-lg p-6">
-                <h3 className="text-lg font-semibold mb-4">Channel Breakdown</h3>
+                <h3 className="text-base font-semibold mb-4">Channel Breakdown</h3>
                 <ResponsiveContainer width="100%" height={220}>
                   <BarChart data={data.channel_breakdown}>
                     <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />


### PR DESCRIPTION
Closes #187. Parent epic: #173 (P2).

## Summary

- **T5** — Layout root applies `text-sm text-foreground` so ad-hoc containers inherit 14px business density by default
- **D3** — ~30 section headings across 13 files consolidated from `text-lg|xl font-semibold` to `text-base font-semibold`. The app now uses just two type levels: page h1 via `PageHeader` (text-2xl) and section h2/h3 (text-base)

## Files touched

- `components/layout/Layout.tsx` (T5)
- `pages/reports/{PLReportPage, SalesReportPage, InventoryReportPage}.tsx`
- `pages/{JobFormPage, JobDetailPage, SaleFormPage, SaleDetailPage}.tsx`
- `pages/{ProductDetailPage, ProductEditorPage, PrinterDetailPage, InsightsPage, LoginPage}.tsx`
- `pages/admin/SettingsPage.tsx`

## Preserved (intentional data displays + touch-register exception)

- `RatesPage` / `ProductDetailPage` stat tile numeric values
- `POSPage` product-name `<h3>` in catalog cards (touch-size per #203)
- `POSPage` numeric qty/stepper/subtotal displays
- `InsightsPage` evidence-metric values

## Acceptance

- [x] Layout root applies `text-sm` default
- [x] `rg '<h\d[^>]*text-xl font-semibold' src/pages` → **0**
- [x] `rg '<h\d[^>]*text-lg font-semibold' src/pages` → **1** (POS catalog exception)
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Scroll through a report page — subsection + chart titles are all the same size; page title is the only big heading
- [ ] Job form + Sale form — section headings no longer compete with the PageHeader title
- [ ] Printer detail / Product detail — section h2s smaller, easier page scan
- [ ] POS — catalog product names still large enough for counter scanning; cart numbers still prominent
- [ ] Login — "Sign In" small but legible on the centered card

🤖 Generated with [Claude Code](https://claude.com/claude-code)