### PR TITLE
feat(ui): Dialog size tokens + footer audit (#192)

### DIFF
--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -6,9 +6,9 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  type DialogSize,
 } from '@/components/ui/Dialog';
 import { Button } from '@/components/ui/Button';
-import { cn } from '@/lib/utils';
 
 export type ConfirmDialogTone = 'default' | 'destructive';
 
@@ -33,7 +33,9 @@ interface ConfirmDialogProps {
   closeOnConfirm?: boolean;
   /** Replace the default confirm button label when pending. */
   pendingLabel?: string;
-  /** Additional classes on the DialogContent (e.g. max-w override). */
+  /** Width token forwarded to DialogContent. Defaults to `sm` (tight confirm layout). */
+  size?: DialogSize;
+  /** Additional classes on the DialogContent. */
   className?: string;
 }
 
@@ -67,6 +69,7 @@ export default function ConfirmDialog({
   onConfirm,
   closeOnConfirm = true,
   pendingLabel,
+  size = 'sm',
   className,
 }: ConfirmDialogProps) {
   const [pending, setPending] = useState(false);
@@ -83,7 +86,7 @@ export default function ConfirmDialog({
 
   return (
     <Dialog open={open} onOpenChange={(next) => !pending && onOpenChange(next)}>
-      <DialogContent className={cn('max-w-md', className)}>
+      <DialogContent size={size} className={className}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {description ? <DialogDescription>{description}</DialogDescription> : null}

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -24,20 +24,36 @@ export const DialogOverlay = forwardRef<
   );
 });
 
+export type DialogSize = 'sm' | 'md' | 'lg' | 'xl';
+
+const dialogSizeClasses: Record<DialogSize, string> = {
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-lg',
+  xl: 'max-w-2xl',
+};
+
 interface DialogContentProps extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   /** Hide the built-in close X. Use when you want to own the close action yourself. */
   hideClose?: boolean;
+  /**
+   * Standard width token. Maps to `max-w-sm|md|lg|2xl`. Defaults to `md`
+   * (typical form-confirm width). Override via `className` only for
+   * exceptional cases.
+   */
+  size?: DialogSize;
 }
 
 export const DialogContent = forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, DialogContentProps>(
-  function DialogContent({ className, children, hideClose = false, ...props }, ref) {
+  function DialogContent({ className, children, hideClose = false, size = 'md', ...props }, ref) {
     return (
       <DialogPortal>
         <DialogOverlay />
         <DialogPrimitive.Content
           ref={ref}
           className={cn(
-            'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border border-border bg-card p-6 text-card-foreground shadow-lg',
+            'fixed left-1/2 top-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border border-border bg-card p-6 text-card-foreground shadow-lg',
+            dialogSizeClasses[size],
             'data-[state=open]:animate-in data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:zoom-out-95',
             'max-h-[90vh] overflow-y-auto',
             className,
@@ -100,6 +116,7 @@ interface SimpleDialogProps {
   footer?: ReactNode;
   className?: string;
   hideClose?: boolean;
+  size?: DialogSize;
 }
 
 export function SimpleDialog({
@@ -111,10 +128,11 @@ export function SimpleDialog({
   footer,
   className,
   hideClose = false,
+  size = 'md',
 }: SimpleDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={className} hideClose={hideClose}>
+      <DialogContent className={className} hideClose={hideClose} size={size}>
         {(title || description) && (
           <DialogHeader>
             {title && <DialogTitle>{title}</DialogTitle>}

--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -130,7 +130,7 @@ export default function CustomersPage() {
       />
 
       <Dialog open={editing !== null} onOpenChange={(open) => !open && close()}>
-        <DialogContent className="max-w-md">
+        <DialogContent size="md">
           <DialogHeader>
             <DialogTitle>{editing === 'new' ? 'Add customer' : 'Edit customer'}</DialogTitle>
           </DialogHeader>

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -405,7 +405,7 @@ export default function InventoryPage() {
 
       {/* Reconcile dialog */}
       <Dialog open={showReconcile} onOpenChange={(open) => !open && setShowReconcile(false)}>
-        <DialogContent className="max-w-lg">
+        <DialogContent size="lg">
           <DialogHeader>
             <DialogTitle>Stock reconciliation</DialogTitle>
           </DialogHeader>
@@ -495,7 +495,7 @@ export default function InventoryPage() {
 
       {/* Adjust dialog */}
       <Dialog open={showAdjust} onOpenChange={(open) => !open && setShowAdjust(false)}>
-        <DialogContent className="max-w-md">
+        <DialogContent size="md">
           <DialogHeader>
             <DialogTitle>Quick stock adjustment</DialogTitle>
           </DialogHeader>

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -285,7 +285,7 @@ export default function JobFormPage() {
       />
 
       <Dialog open={showCreateProduct} onOpenChange={(open) => !open && setShowCreateProduct(false)}>
-        <DialogContent className="max-w-md">
+        <DialogContent size="md">
           <DialogHeader>
             <DialogTitle>Create and link product</DialogTitle>
           </DialogHeader>

--- a/frontend/src/pages/MaterialsPage.tsx
+++ b/frontend/src/pages/MaterialsPage.tsx
@@ -161,7 +161,7 @@ export default function MaterialsPage() {
       />
 
       <Dialog open={editing !== null} onOpenChange={(o) => !o && close()}>
-        <DialogContent className="max-w-md">
+        <DialogContent size="md">
           <DialogHeader>
             <DialogTitle>{editing === 'new' ? 'Add material' : 'Edit material'}</DialogTitle>
           </DialogHeader>

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -221,7 +221,7 @@ export default function ProductDetailPage() {
 
       {/* Zero Stock Modal */}
       <Dialog open={showZeroStock} onOpenChange={(open) => !open && setShowZeroStock(false)}>
-        <DialogContent className="max-w-md">
+        <DialogContent size="md">
           <DialogHeader>
             <DialogTitle>Set stock to 0</DialogTitle>
           </DialogHeader>
@@ -265,7 +265,7 @@ export default function ProductDetailPage() {
 
       {/* Adjustment Modal */}
       <Dialog open={showAdjust} onOpenChange={(open) => !open && setShowAdjust(false)}>
-        <DialogContent className="max-w-sm">
+        <DialogContent size="sm">
           <DialogHeader>
             <DialogTitle>Adjust stock</DialogTitle>
           </DialogHeader>

--- a/frontend/src/pages/RatesPage.tsx
+++ b/frontend/src/pages/RatesPage.tsx
@@ -139,7 +139,7 @@ export default function RatesPage() {
       />
 
       <Dialog open={editing !== null} onOpenChange={(o) => !o && close()}>
-        <DialogContent className="max-w-md">
+        <DialogContent size="md">
           <DialogHeader>
             <DialogTitle>{editing === 'new' ? 'Add rate' : 'Edit rate'}</DialogTitle>
           </DialogHeader>

--- a/frontend/src/pages/SalesChannelsPage.tsx
+++ b/frontend/src/pages/SalesChannelsPage.tsx
@@ -86,7 +86,7 @@ export default function SalesChannelsPage() {
       />
 
       <Dialog open={editing !== null} onOpenChange={(o) => !o && close()}>
-        <DialogContent className="max-w-md">
+        <DialogContent size="md">
           <DialogHeader>
             <DialogTitle>{editing === 'new' ? 'Add channel' : 'Edit channel'}</DialogTitle>
           </DialogHeader>

--- a/frontend/src/pages/admin/CamerasPage.tsx
+++ b/frontend/src/pages/admin/CamerasPage.tsx
@@ -207,7 +207,7 @@ export default function CamerasPage() {
       />
 
       <Dialog open={Boolean(modal)} onOpenChange={(o) => !o && closeModal()}>
-        <DialogContent className="max-w-lg">
+        <DialogContent size="lg">
           <DialogHeader>
             <DialogTitle>{modal === 'create' ? 'Add camera' : 'Edit camera'}</DialogTitle>
           </DialogHeader>

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -105,7 +105,7 @@ export default function UsersPage() {
       </div>
 
       <Dialog open={editing !== null} onOpenChange={(o) => !o && close()}>
-        <DialogContent className="max-w-md">
+        <DialogContent size="md">
           <DialogHeader>
             <DialogTitle>{editing === 'new' ? 'Add user' : 'Edit user'}</DialogTitle>
           </DialogHeader>


### PR DESCRIPTION
Closes #192. Parent epic: #173 (P2).

## Summary

**M3 — Size tokens on DialogContent:**
- Added `size?: 'sm' | 'md' | 'lg' | 'xl'` prop; maps to `max-w-sm|md|lg|2xl`; defaults to `md`.
- Exported `DialogSize` type.
- Forwarded through `SimpleDialog` (default `md`) and `ConfirmDialog` (default `sm`).
- Migrated all 11 call sites from `className="max-w-X"` → `size="X"`.

| Call site | size |
|---|---|
| CustomersPage, JobFormPage, SalesChannelsPage, RatesPage, MaterialsPage, admin/UsersPage, ProductDetailPage zero-stock, InventoryPage quick-adjust | `md` |
| ProductDetailPage adjust-stock | `sm` |
| InventoryPage reconcile, admin/CamerasPage | `lg` |

**M2 — Footer order audit:**
All 11 `<DialogFooter>` usages reviewed. Every one conforms to Cancel-left / primary-right convention already (established during #178 + workspace revamps). No fixes required.

## Acceptance

- [x] `rg 'DialogContent [^>]*max-w-' src/pages` → **0**
- [x] Every `<DialogContent>` uses `size` prop
- [x] Footer order consistent (Cancel-left / primary-right)
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Open each migrated modal — verify it renders at the expected width
- [ ] Confirm dialogs (destructive actions across Users/Customers/Jobs/Printers/Products pages) → narrow `sm` width
- [ ] Inventory reconcile → wider `lg` width
- [ ] Standard forms (Material, Rate, Channel, User, Customer, Job create-product, Product adjust/zero-stock) → `md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)