### PR TITLE
feat(ui): form primitive polish — required + error props + inputCls cleanup (#190)

### DIFF
--- a/frontend/src/components/cameras/CameraFeed.tsx
+++ b/frontend/src/components/cameras/CameraFeed.tsx
@@ -267,7 +267,7 @@ export default function CameraFeed({
     return (
       <div className={`flex items-center justify-center bg-black/60 text-muted-foreground ${className}`}>
         <div className="flex flex-col items-center gap-2">
-          <VideoOff className="h-8 w-8 text-danger opacity-70" />
+          <VideoOff className="h-8 w-8 text-destructive opacity-70" />
           <span className="text-xs">Camera offline</span>
           <button
             type="button"

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,25 +1,49 @@
-import { forwardRef, type InputHTMLAttributes } from 'react';
+import { forwardRef, useId, type InputHTMLAttributes } from 'react';
 import { cn } from '@/lib/utils';
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   /** Show a destructive outline when the field has a validation error. */
   invalid?: boolean;
+  /**
+   * Inline validation message. When set, the input renders with destructive
+   * styling, `aria-invalid="true"`, and a below-input error paragraph that
+   * is wired to the input via `aria-describedby`. Overrides `invalid`.
+   */
+  error?: string | null | false;
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { className, invalid = false, ...props },
+  { className, invalid = false, error, id: providedId, 'aria-describedby': describedBy, ...props },
   ref,
 ) {
-  return (
+  const generatedId = useId();
+  const id = providedId ?? generatedId;
+  const errorId = error ? `${id}-error` : undefined;
+  const isInvalid = Boolean(error) || invalid;
+
+  const inputEl = (
     <input
       ref={ref}
-      aria-invalid={invalid || undefined}
+      id={id}
+      aria-invalid={isInvalid || undefined}
+      aria-describedby={cn(describedBy, errorId) || undefined}
       className={cn(
         'flex h-9 w-full rounded-md border bg-background px-3 py-1 text-sm transition-colors placeholder:text-muted-foreground file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
-        invalid ? 'border-destructive focus-visible:ring-destructive' : 'border-input',
+        isInvalid ? 'border-destructive focus-visible:ring-destructive' : 'border-input',
         className,
       )}
       {...props}
     />
+  );
+
+  if (!error) return inputEl;
+
+  return (
+    <div className="space-y-1">
+      {inputEl}
+      <p id={errorId} className="text-xs text-destructive">
+        {error}
+      </p>
+    </div>
   );
 });

--- a/frontend/src/components/ui/Label.tsx
+++ b/frontend/src/components/ui/Label.tsx
@@ -1,11 +1,23 @@
 import * as LabelPrimitive from '@radix-ui/react-label';
-import { forwardRef } from 'react';
+import { forwardRef, type ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
 type LabelRef = React.ElementRef<typeof LabelPrimitive.Root>;
-type LabelProps = React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>;
+type LabelBaseProps = React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>;
 
-export const Label = forwardRef<LabelRef, LabelProps>(function Label({ className, ...props }, ref) {
+export interface LabelProps extends LabelBaseProps {
+  /**
+   * When true, renders a trailing `*` in destructive color to signal the
+   * associated field is required. Does not set any form-validation
+   * behavior — pair with `required` on the associated input to enforce.
+   */
+  required?: boolean;
+}
+
+export const Label = forwardRef<LabelRef, LabelProps>(function Label(
+  { className, required = false, children, ...props },
+  ref,
+) {
   return (
     <LabelPrimitive.Root
       ref={ref}
@@ -14,6 +26,22 @@ export const Label = forwardRef<LabelRef, LabelProps>(function Label({ className
         className,
       )}
       {...props}
-    />
+    >
+      {children}
+      {required ? (
+        <span aria-hidden="true" className="ml-0.5 text-destructive">
+          *
+        </span>
+      ) : null}
+    </LabelPrimitive.Root>
   );
 });
+
+/** Shared export in case callers need to compose a label manually. */
+export function RequiredMarker({ className }: { className?: string }): ReactNode {
+  return (
+    <span aria-hidden="true" className={cn('ml-0.5 text-destructive', className)}>
+      *
+    </span>
+  );
+}

--- a/frontend/src/components/ui/ReportControls.tsx
+++ b/frontend/src/components/ui/ReportControls.tsx
@@ -1,5 +1,7 @@
 import { Download } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
 
 interface ReportControlsProps {
   dateFrom: string;
@@ -22,8 +24,6 @@ export default function ReportControls({
   onDateToChange,
   onPeriodChange,
 }: ReportControlsProps) {
-  const inputCls = 'px-3 py-2 border border-input rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring text-sm';
-
   const handleExport = () => {
     if (!csvUrl) return;
     const params = new URLSearchParams();
@@ -35,31 +35,54 @@ export default function ReportControls({
   };
 
   return (
-    <div className="flex flex-wrap gap-3 mb-6 items-end">
-      <div>
-        <label className="block text-xs text-muted-foreground mb-1">From</label>
-        <input type="date" value={dateFrom} onChange={(e) => onDateFromChange(e.target.value)} className={inputCls} />
+    <div className="mb-6 flex flex-wrap items-end gap-3">
+      <div className="space-y-1.5">
+        <Label htmlFor="report-date-from" className="text-xs text-muted-foreground">
+          From
+        </Label>
+        <Input
+          id="report-date-from"
+          type="date"
+          value={dateFrom}
+          onChange={(e) => onDateFromChange(e.target.value)}
+          className="w-auto"
+        />
       </div>
-      <div>
-        <label className="block text-xs text-muted-foreground mb-1">To</label>
-        <input type="date" value={dateTo} onChange={(e) => onDateToChange(e.target.value)} className={inputCls} />
+      <div className="space-y-1.5">
+        <Label htmlFor="report-date-to" className="text-xs text-muted-foreground">
+          To
+        </Label>
+        <Input
+          id="report-date-to"
+          type="date"
+          value={dateTo}
+          onChange={(e) => onDateToChange(e.target.value)}
+          className="w-auto"
+        />
       </div>
-      {showPeriod && onPeriodChange && (
-        <div>
-          <label className="block text-xs text-muted-foreground mb-1">Period</label>
-          <select value={period} onChange={(e) => onPeriodChange(e.target.value)} className={inputCls}>
+      {showPeriod && onPeriodChange ? (
+        <div className="space-y-1.5">
+          <Label htmlFor="report-period" className="text-xs text-muted-foreground">
+            Period
+          </Label>
+          <select
+            id="report-period"
+            value={period}
+            onChange={(e) => onPeriodChange(e.target.value)}
+            className="flex h-9 rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          >
             <option value="daily">Daily</option>
             <option value="weekly">Weekly</option>
             <option value="monthly">Monthly</option>
             <option value="yearly">Yearly</option>
           </select>
         </div>
-      )}
-      {csvUrl && (
+      ) : null}
+      {csvUrl ? (
         <Button variant="outline" onClick={handleExport}>
           <Download className="h-4 w-4" /> Export CSV
         </Button>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/ui/Textarea.tsx
+++ b/frontend/src/components/ui/Textarea.tsx
@@ -1,24 +1,48 @@
-import { forwardRef, type TextareaHTMLAttributes } from 'react';
+import { forwardRef, useId, type TextareaHTMLAttributes } from 'react';
 import { cn } from '@/lib/utils';
 
 export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   invalid?: boolean;
+  /**
+   * Inline validation message. When set, the textarea renders with
+   * destructive styling, `aria-invalid="true"`, and a below-textarea
+   * error paragraph wired via `aria-describedby`. Overrides `invalid`.
+   */
+  error?: string | null | false;
 }
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
-  { className, invalid = false, ...props },
+  { className, invalid = false, error, id: providedId, 'aria-describedby': describedBy, ...props },
   ref,
 ) {
-  return (
+  const generatedId = useId();
+  const id = providedId ?? generatedId;
+  const errorId = error ? `${id}-error` : undefined;
+  const isInvalid = Boolean(error) || invalid;
+
+  const textareaEl = (
     <textarea
       ref={ref}
-      aria-invalid={invalid || undefined}
+      id={id}
+      aria-invalid={isInvalid || undefined}
+      aria-describedby={cn(describedBy, errorId) || undefined}
       className={cn(
         'flex min-h-[72px] w-full rounded-md border bg-background px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
-        invalid ? 'border-destructive focus-visible:ring-destructive' : 'border-input',
+        isInvalid ? 'border-destructive focus-visible:ring-destructive' : 'border-input',
         className,
       )}
       {...props}
     />
+  );
+
+  if (!error) return textareaEl;
+
+  return (
+    <div className="space-y-1">
+      {textareaEl}
+      <p id={errorId} className="text-xs text-destructive">
+        {error}
+      </p>
+    </div>
   );
 });

--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -136,7 +136,7 @@ export default function CustomersPage() {
           </DialogHeader>
           <div className="space-y-3">
             <div className="space-y-1.5">
-              <Label htmlFor="cust-name">Name *</Label>
+              <Label htmlFor="cust-name" required>Name</Label>
               <Input id="cust-name" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
             </div>
             <div className="space-y-1.5">

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -411,7 +411,7 @@ export default function InventoryPage() {
           </DialogHeader>
           <div className="space-y-4">
             <div className="space-y-1.5">
-              <Label htmlFor="reconcile-product">Product *</Label>
+              <Label htmlFor="reconcile-product" required>Product</Label>
               <select
                 id="reconcile-product"
                 value={reconcileForm.product_id}
@@ -450,7 +450,7 @@ export default function InventoryPage() {
             ) : null}
 
             <div className="space-y-1.5">
-              <Label htmlFor="reconcile-counted">Counted quantity *</Label>
+              <Label htmlFor="reconcile-counted" required>Counted quantity</Label>
               <Input
                 id="reconcile-counted"
                 type="number"
@@ -463,7 +463,7 @@ export default function InventoryPage() {
             </div>
 
             <div className="space-y-1.5">
-              <Label htmlFor="reconcile-reason">Reason *</Label>
+              <Label htmlFor="reconcile-reason" required>Reason</Label>
               <Input
                 id="reconcile-reason"
                 value={reconcileForm.reason}
@@ -501,7 +501,7 @@ export default function InventoryPage() {
           </DialogHeader>
           <div className="space-y-4">
             <div className="space-y-1.5">
-              <Label htmlFor="adjust-product">Product *</Label>
+              <Label htmlFor="adjust-product" required>Product</Label>
               <select
                 id="adjust-product"
                 value={adjustForm.product_id}
@@ -541,7 +541,7 @@ export default function InventoryPage() {
             </div>
 
             <div className="space-y-1.5">
-              <Label htmlFor="adjust-quantity">Quantity *</Label>
+              <Label htmlFor="adjust-quantity" required>Quantity</Label>
               <Input
                 id="adjust-quantity"
                 type="number"

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -291,14 +291,13 @@ export default function JobFormPage() {
           </DialogHeader>
           <div className="space-y-3">
             <div className="space-y-1.5">
-              <Label htmlFor="create-product-name">Name *</Label>
+              <Label htmlFor="create-product-name" required>Name</Label>
               <Input
                 id="create-product-name"
                 value={productForm.name}
                 onChange={(e) => updateProductForm('name', e.target.value)}
-                invalid={Boolean(productErrors.name)}
+                error={productErrors.name}
               />
-              {productErrors.name && <p className="text-destructive text-xs">{productErrors.name}</p>}
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="create-product-description">Description</Label>
@@ -309,7 +308,7 @@ export default function JobFormPage() {
               />
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="create-product-material">Material *</Label>
+              <Label htmlFor="create-product-material" required>Material</Label>
               <select
                 id="create-product-material"
                 value={productForm.material_id}

--- a/frontend/src/pages/MaterialsPage.tsx
+++ b/frontend/src/pages/MaterialsPage.tsx
@@ -167,7 +167,7 @@ export default function MaterialsPage() {
           </DialogHeader>
           <div className="space-y-3">
             <div className="space-y-1.5">
-              <Label htmlFor="mat-name">Name *</Label>
+              <Label htmlFor="mat-name" required>Name</Label>
               <Input
                 id="mat-name"
                 value={form.name}
@@ -175,12 +175,11 @@ export default function MaterialsPage() {
                   setForm({ ...form, name: e.target.value });
                   setFormErrors({ ...formErrors, name: '' });
                 }}
-                invalid={Boolean(formErrors.name)}
+                error={formErrors.name}
               />
-              {formErrors.name && <p className="text-destructive text-xs">{formErrors.name}</p>}
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="mat-brand">Brand *</Label>
+              <Label htmlFor="mat-brand" required>Brand</Label>
               <Input
                 id="mat-brand"
                 value={form.brand}
@@ -188,44 +187,40 @@ export default function MaterialsPage() {
                   setForm({ ...form, brand: e.target.value });
                   setFormErrors({ ...formErrors, brand: '' });
                 }}
-                invalid={Boolean(formErrors.brand)}
+                error={formErrors.brand}
               />
-              {formErrors.brand && <p className="text-destructive text-xs">{formErrors.brand}</p>}
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <div className="space-y-1.5">
-                <Label htmlFor="mat-weight">Spool (g) *</Label>
+                <Label htmlFor="mat-weight" required>Spool (g)</Label>
                 <Input
                   id="mat-weight"
                   type="number"
                   value={form.spool_weight_g}
                   onChange={(e) => setForm({ ...form, spool_weight_g: Number(e.target.value) })}
-                  invalid={Boolean(formErrors.spool_weight_g)}
+                  error={formErrors.spool_weight_g}
                 />
-                {formErrors.spool_weight_g && <p className="text-destructive text-xs">{formErrors.spool_weight_g}</p>}
               </div>
               <div className="space-y-1.5">
-                <Label htmlFor="mat-price">Price ($) *</Label>
+                <Label htmlFor="mat-price" required>Price ($)</Label>
                 <Input
                   id="mat-price"
                   type="number"
                   step="0.01"
                   value={form.spool_price}
                   onChange={(e) => setForm({ ...form, spool_price: Number(e.target.value) })}
-                  invalid={Boolean(formErrors.spool_price)}
+                  error={formErrors.spool_price}
                 />
-                {formErrors.spool_price && <p className="text-destructive text-xs">{formErrors.spool_price}</p>}
               </div>
               <div className="space-y-1.5">
-                <Label htmlFor="mat-usable">Usable (g) *</Label>
+                <Label htmlFor="mat-usable" required>Usable (g)</Label>
                 <Input
                   id="mat-usable"
                   type="number"
                   value={form.net_usable_g}
                   onChange={(e) => setForm({ ...form, net_usable_g: Number(e.target.value) })}
-                  invalid={Boolean(formErrors.net_usable_g)}
+                  error={formErrors.net_usable_g}
                 />
-                {formErrors.net_usable_g && <p className="text-destructive text-xs">{formErrors.net_usable_g}</p>}
               </div>
             </div>
             <div className="grid grid-cols-2 gap-3">

--- a/frontend/src/pages/PrinterFormPage.tsx
+++ b/frontend/src/pages/PrinterFormPage.tsx
@@ -203,12 +203,11 @@ export default function PrinterFormPage() {
         <form onSubmit={handleSubmit} className="space-y-6">
           <div className="grid gap-5 sm:grid-cols-2">
             <div className="space-y-1.5">
-              <Label htmlFor="printer-name">Name *</Label>
-              <Input id="printer-name" value={form.name} onChange={(e) => update('name', e.target.value)} invalid={Boolean(errors.name)} placeholder="Bambu X1C #1" />
-              {errors.name && <p className="text-xs text-destructive">{errors.name}</p>}
+              <Label htmlFor="printer-name" required>Name</Label>
+              <Input id="printer-name" value={form.name} onChange={(e) => update('name', e.target.value)} error={errors.name} placeholder="Bambu X1C #1" />
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="printer-slug">Slug *</Label>
+              <Label htmlFor="printer-slug" required>Slug</Label>
               <Input
                 id="printer-slug"
                 value={form.slug}
@@ -216,10 +215,9 @@ export default function PrinterFormPage() {
                   setSlugTouched(true);
                   update('slug', slugify(e.target.value));
                 }}
-                invalid={Boolean(errors.slug)}
+                error={errors.slug}
                 placeholder="bambu-x1c-1"
               />
-              {errors.slug && <p className="text-xs text-destructive">{errors.slug}</p>}
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="printer-manufacturer">Manufacturer</Label>
@@ -281,18 +279,16 @@ export default function PrinterFormPage() {
                   </div>
                   <div className="space-y-1.5">
                     <Label htmlFor="printer-monitor-poll">Poll interval (seconds)</Label>
-                    <Input id="printer-monitor-poll" type="number" min={5} max={3600} value={form.monitor_poll_interval_seconds} onChange={(e) => update('monitor_poll_interval_seconds', Number(e.target.value) || 30)} invalid={Boolean(errors.monitor_poll_interval_seconds)} />
-                    {errors.monitor_poll_interval_seconds && <p className="text-xs text-destructive">{errors.monitor_poll_interval_seconds}</p>}
+                    <Input id="printer-monitor-poll" type="number" min={5} max={3600} value={form.monitor_poll_interval_seconds} onChange={(e) => update('monitor_poll_interval_seconds', Number(e.target.value) || 30)} error={errors.monitor_poll_interval_seconds} />
                   </div>
                 </div>
 
                 <div className="space-y-1.5">
-                  <Label htmlFor="printer-monitor-base-url">Base URL *</Label>
-                  <Input id="printer-monitor-base-url" value={form.monitor_base_url} onChange={(e) => update('monitor_base_url', e.target.value)} invalid={Boolean(errors.monitor_base_url)} placeholder={selectedProvider.placeholder} />
+                  <Label htmlFor="printer-monitor-base-url" required>Base URL</Label>
+                  <Input id="printer-monitor-base-url" value={form.monitor_base_url} onChange={(e) => update('monitor_base_url', e.target.value)} error={errors.monitor_base_url} placeholder={selectedProvider.placeholder} />
                   <p className="text-xs text-muted-foreground">
                     {form.monitor_provider === 'moonraker' ? 'Use the Moonraker API URL, typically port 7125.' : 'Use the OctoPrint base URL hosting the API.'}
                   </p>
-                  {errors.monitor_base_url && <p className="text-xs text-destructive">{errors.monitor_base_url}</p>}
                 </div>
 
                 <div className="space-y-1.5">

--- a/frontend/src/pages/PrinterMonitorPage.tsx
+++ b/frontend/src/pages/PrinterMonitorPage.tsx
@@ -59,7 +59,7 @@ export default function PrinterMonitorPage() {
     status === 'printing'
       ? 'text-primary'
       : status === 'error'
-        ? 'text-danger'
+        ? 'text-destructive'
         : status === 'paused'
           ? 'text-warning'
           : 'text-muted-foreground';
@@ -147,7 +147,7 @@ export default function PrinterMonitorPage() {
 
             {/* Nozzle temp */}
             <div className="flex items-center gap-1.5 text-white/70" title="Nozzle">
-              <Thermometer className="h-4 w-4 text-danger/70" />
+              <Thermometer className="h-4 w-4 text-destructive/70" />
               <span className="text-sm">{formatTemp(printer.monitor_tool_temp_c)}</span>
             </div>
 

--- a/frontend/src/pages/ProductEditorPage.tsx
+++ b/frontend/src/pages/ProductEditorPage.tsx
@@ -186,7 +186,7 @@ export default function ProductEditorPage() {
 
             <div className="mt-5 grid gap-4 lg:grid-cols-2">
               <div className="lg:col-span-2 space-y-1.5">
-                <Label htmlFor="product-name">Product name *</Label>
+                <Label htmlFor="product-name" required>Product name</Label>
                 <Input
                   id="product-name"
                   value={form.name}
@@ -194,10 +194,9 @@ export default function ProductEditorPage() {
                     setForm((current) => ({ ...current, name: event.target.value }));
                     setFormErrors((current) => ({ ...current, name: '' }));
                   }}
-                  invalid={Boolean(formErrors.name)}
+                  error={formErrors.name}
                   placeholder="Desk Dragon, Tool Holder, Display Plaque..."
                 />
-                {formErrors.name ? <p className="text-xs text-destructive">{formErrors.name}</p> : null}
               </div>
 
               <div className="lg:col-span-2 space-y-1.5">
@@ -233,7 +232,7 @@ export default function ProductEditorPage() {
               </div>
 
               <div className="space-y-1.5">
-                <Label htmlFor="product-material">Material *</Label>
+                <Label htmlFor="product-material" required>Material</Label>
                 <select
                   id="product-material"
                   value={form.material_id}
@@ -262,9 +261,8 @@ export default function ProductEditorPage() {
                   step="0.01"
                   value={form.unit_price}
                   onChange={(event) => setForm((current) => ({ ...current, unit_price: Number(event.target.value) }))}
-                  invalid={Boolean(formErrors.unit_price)}
+                  error={formErrors.unit_price}
                 />
-                {formErrors.unit_price ? <p className="text-xs text-destructive">{formErrors.unit_price}</p> : null}
               </div>
 
               <div className="space-y-1.5">
@@ -275,9 +273,8 @@ export default function ProductEditorPage() {
                   min="0"
                   value={form.reorder_point}
                   onChange={(event) => setForm((current) => ({ ...current, reorder_point: Number(event.target.value) }))}
-                  invalid={Boolean(formErrors.reorder_point)}
+                  error={formErrors.reorder_point}
                 />
-                {formErrors.reorder_point ? <p className="text-xs text-destructive">{formErrors.reorder_point}</p> : null}
               </div>
             </div>
 

--- a/frontend/src/pages/RatesPage.tsx
+++ b/frontend/src/pages/RatesPage.tsx
@@ -145,7 +145,7 @@ export default function RatesPage() {
           </DialogHeader>
           <div className="space-y-3">
             <div className="space-y-1.5">
-              <Label htmlFor="rate-name">Name *</Label>
+              <Label htmlFor="rate-name" required>Name</Label>
               <Input
                 id="rate-name"
                 value={form.name}
@@ -153,25 +153,23 @@ export default function RatesPage() {
                   setForm({ ...form, name: e.target.value });
                   setFormErrors({ ...formErrors, name: '' });
                 }}
-                invalid={Boolean(formErrors.name)}
+                error={formErrors.name}
               />
-              {formErrors.name && <p className="text-destructive text-xs">{formErrors.name}</p>}
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
-                <Label htmlFor="rate-value">Value *</Label>
+                <Label htmlFor="rate-value" required>Value</Label>
                 <Input
                   id="rate-value"
                   type="number"
                   step="0.01"
                   value={form.value}
                   onChange={(e) => setForm({ ...form, value: Number(e.target.value) })}
-                  invalid={Boolean(formErrors.value)}
+                  error={formErrors.value}
                 />
-                {formErrors.value && <p className="text-destructive text-xs">{formErrors.value}</p>}
               </div>
               <div className="space-y-1.5">
-                <Label htmlFor="rate-unit">Unit *</Label>
+                <Label htmlFor="rate-unit" required>Unit</Label>
                 <select
                   id="rate-unit"
                   value={form.unit}

--- a/frontend/src/pages/SaleFormPage.tsx
+++ b/frontend/src/pages/SaleFormPage.tsx
@@ -155,7 +155,7 @@ export default function SaleFormPage() {
             <h2 className="text-base font-semibold mb-4">Sale Details</h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-1.5">
-                <Label htmlFor="sale-date">Date *</Label>
+                <Label htmlFor="sale-date" required>Date</Label>
                 <Input id="sale-date" type="date" value={form.date} onChange={(e) => setForm({ ...form, date: e.target.value })} />
               </div>
               <div className="space-y-1.5">
@@ -284,7 +284,7 @@ export default function SaleFormPage() {
                     </select>
                   </div>
                   <div className="col-span-12 sm:col-span-3 space-y-1.5">
-                    <Label htmlFor={`sale-item-${idx}-description`} className="text-xs text-muted-foreground">Description *</Label>
+                    <Label htmlFor={`sale-item-${idx}-description`} className="text-xs text-muted-foreground" required>Description</Label>
                     <Input id={`sale-item-${idx}-description`} value={item.description} onChange={(e) => updateItem(idx, { description: e.target.value })} />
                   </div>
                   <div className="col-span-4 sm:col-span-1 space-y-1.5">

--- a/frontend/src/pages/SalesChannelsPage.tsx
+++ b/frontend/src/pages/SalesChannelsPage.tsx
@@ -92,7 +92,7 @@ export default function SalesChannelsPage() {
           </DialogHeader>
           <div className="space-y-3">
             <div className="space-y-1.5">
-              <Label htmlFor="channel-name">Name *</Label>
+              <Label htmlFor="channel-name" required>Name</Label>
               <Input id="channel-name" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
             </div>
             <div className="grid grid-cols-2 gap-3">

--- a/frontend/src/pages/admin/CamerasPage.tsx
+++ b/frontend/src/pages/admin/CamerasPage.tsx
@@ -222,9 +222,8 @@ export default function CamerasPage() {
                   value={form.name}
                   onChange={(e) => handleNameChange(e.target.value)}
                   placeholder="Wyze Cam - Bay 1"
-                  invalid={Boolean(errors.name)}
+                  error={errors.name}
                 />
-                {errors.name && <p className="text-xs text-danger">{errors.name}</p>}
               </div>
 
               {/* Slug */}
@@ -236,9 +235,8 @@ export default function CamerasPage() {
                   value={form.slug}
                   onChange={(e) => setForm((f) => ({ ...f, slug: e.target.value }))}
                   placeholder="wyze-cam-bay-1"
-                  invalid={Boolean(errors.slug)}
+                  error={errors.slug}
                 />
-                {errors.slug && <p className="text-xs text-danger">{errors.slug}</p>}
               </div>
 
               {/* go2rtc Base URL */}
@@ -251,11 +249,8 @@ export default function CamerasPage() {
                   onChange={(e) => setForm((f) => ({ ...f, go2rtc_base_url: e.target.value }))}
                   placeholder="http://192.168.1.50:1984"
                   className="font-mono"
-                  invalid={Boolean(errors.go2rtc_base_url)}
+                  error={errors.go2rtc_base_url}
                 />
-                {errors.go2rtc_base_url && (
-                  <p className="text-xs text-danger">{errors.go2rtc_base_url}</p>
-                )}
               </div>
 
               {/* Stream Name */}
@@ -268,11 +263,8 @@ export default function CamerasPage() {
                   onChange={(e) => setForm((f) => ({ ...f, stream_name: e.target.value }))}
                   placeholder="wyze_printer_1"
                   className="font-mono"
-                  invalid={Boolean(errors.stream_name)}
+                  error={errors.stream_name}
                 />
-                {errors.stream_name && (
-                  <p className="text-xs text-danger">{errors.stream_name}</p>
-                )}
               </div>
 
               {/* Snapshot Preview */}
@@ -298,7 +290,7 @@ export default function CamerasPage() {
                     )}
                     {!previewLoading && previewError && (
                       <div className="text-center px-4">
-                        <p className="text-danger text-sm">{previewError}</p>
+                        <p className="text-destructive text-sm">{previewError}</p>
                         <button
                           type="button"
                           onClick={fetchPreview}

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -111,16 +111,16 @@ export default function UsersPage() {
           </DialogHeader>
           <div className="space-y-3">
             <div className="space-y-1.5">
-              <Label htmlFor="user-name">Full name *</Label>
+              <Label htmlFor="user-name" required>Full name</Label>
               <Input id="user-name" value={form.full_name} onChange={(e) => setForm({ ...form, full_name: e.target.value })} />
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="user-email">Email *</Label>
+              <Label htmlFor="user-email" required>Email</Label>
               <Input id="user-email" type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} />
             </div>
             {editing === 'new' && (
               <div className="space-y-1.5">
-                <Label htmlFor="user-password">Password *</Label>
+                <Label htmlFor="user-password" required>Password</Label>
                 <Input
                   id="user-password"
                   type="password"


### PR DESCRIPTION
Closes #190. Parent epic: #173 (P2).

## Summary

- **F3** — Dead `inputCls` removed from `ReportControls.tsx`; date inputs + labels now use primitives.
- **F4** — Extended `<Label>` with a `required?: boolean` prop; renders a trailing `*` in `text-destructive` (aria-hidden). Migrated ~30 sites from literal `Name *` to `<Label required>Name</Label>`.
- **F5** — Extended `<Input>` and `<Textarea>` with an `error?: string` prop. When set, the primitive wraps the input in a `<div className="space-y-1">` with a below-input `<p className="text-xs text-destructive">` and `aria-describedby` wired correctly. Migrated ~15 error-paragraph blocks across 6 files. `invalid` prop kept for edge cases.
- **Bonus** — `text-danger` (invalid Tailwind class) → `text-destructive` across 4 additional sites.

## Files touched

- `components/ui/{Label, Input, Textarea, ReportControls}.tsx` (primitive extensions)
- `pages/{MaterialsPage, RatesPage, PrinterFormPage, JobFormPage, ProductEditorPage, InventoryPage, CustomersPage, SalesChannelsPage, SaleFormPage, admin/UsersPage, admin/CamerasPage}.tsx`
- `pages/PrinterMonitorPage.tsx`, `components/cameras/CameraFeed.tsx` (`text-danger` typo fix)

## Acceptance

- [x] `rg 'inputCls' src` → **0**
- [x] `rg '<Label [^>]*>[^<]*\*[[:space:]]*<' src/pages` → **0**
- [x] Input/Textarea error prop replaces manual paragraphs on primitive inputs
- [x] `rg 'text-danger' src` → **0**
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Required fields show a red `*` after the label text (screen reader announces "Name" not "Name asterisk")
- [ ] Submit a form with empty required fields — error text appears below each input; input has red border + `aria-invalid="true"`; focused input references error text via `aria-describedby`
- [ ] Keyboard focus on an invalid field — screen reader reads the label + error message
- [ ] Reports page — date range + period selector still functional with primitive inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)