### PR TITLE
feat(ui): KPI sparklines + drill-through + finish ChartTooltip migration (#188)

### DIFF
--- a/frontend/src/components/layout/KPIStrip.tsx
+++ b/frontend/src/components/layout/KPIStrip.tsx
@@ -1,4 +1,7 @@
 import { type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
+import { Line, LineChart, ResponsiveContainer } from 'recharts';
 import { cn } from '@/lib/utils';
 
 interface KPIProps {
@@ -10,6 +13,23 @@ interface KPIProps {
   tone?: 'default' | 'warning' | 'success' | 'destructive';
   /** Optional helper text under the value (e.g. "last 7 days"). */
   sub?: string;
+  /**
+   * Optional drill-through destination. When set, the entire KPI card
+   * renders as a react-router `<Link>` so clicking navigates to the
+   * underlying list/report with filters pre-applied. An arrow chevron
+   * appears on hover to hint at interactivity.
+   */
+  href?: string;
+  /**
+   * Optional trend series for an inline sparkline rendered below the
+   * value (24px tall). Pass an array of at least 2 numbers. No axes,
+   * no tooltip — decorative trend hint only.
+   */
+  sparkline?: number[];
+  /** Override the sparkline stroke color. Default uses the primary token. */
+  sparklineColor?: string;
+  /** aria-label override when `href` is set. Defaults to `Open {label} details`. */
+  linkAriaLabel?: string;
 }
 
 const toneStyles: Record<NonNullable<KPIProps['tone']>, string> = {
@@ -19,25 +39,77 @@ const toneStyles: Record<NonNullable<KPIProps['tone']>, string> = {
   destructive: 'text-destructive',
 };
 
-export function KPI({ label, value, delta, icon, tone = 'default', sub }: KPIProps) {
+function SparklineLine({ data, color }: { data: number[]; color?: string }) {
+  if (!data || data.length < 2) return null;
+  const points = data.map((v, i) => ({ i, v }));
   return (
-    <div className="flex items-center gap-3 rounded-md border border-border bg-card px-4 py-3 shadow-xs">
+    <div className="mt-1 h-6 w-full" aria-hidden="true">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={points} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
+          <Line
+            type="monotone"
+            dataKey="v"
+            stroke={color || 'var(--color-primary)'}
+            strokeWidth={1.5}
+            dot={false}
+            isAnimationActive={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function KPIBody({ label, value, delta, icon, tone = 'default', sub, sparkline, sparklineColor }: KPIProps) {
+  return (
+    <>
       {icon ? <div className="shrink-0 text-muted-foreground">{icon}</div> : null}
       <div className="min-w-0 flex-1">
         <p className="text-xs font-medium text-muted-foreground">{label}</p>
         <p className={cn('mt-0.5 text-lg font-semibold tabular-nums', toneStyles[tone])}>{value}</p>
+        {sparkline && sparkline.length >= 2 ? <SparklineLine data={sparkline} color={sparklineColor} /> : null}
         {sub ? <p className="mt-0.5 text-xs text-muted-foreground">{sub}</p> : null}
       </div>
       {delta ? (
         <span
           className={cn(
             'shrink-0 text-xs font-medium tabular-nums',
-            delta.positive ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive'
+            delta.positive ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive',
           )}
         >
           {delta.value}
         </span>
       ) : null}
+    </>
+  );
+}
+
+export function KPI(props: KPIProps) {
+  const base =
+    'group relative flex items-center gap-3 rounded-md border border-border bg-card px-4 py-3 shadow-xs transition-colors';
+
+  if (props.href) {
+    return (
+      <Link
+        to={props.href}
+        aria-label={props.linkAriaLabel || `Open ${props.label} details`}
+        className={cn(
+          base,
+          'no-underline hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        )}
+      >
+        <KPIBody {...props} />
+        <ArrowRight
+          aria-hidden="true"
+          className="absolute right-2 top-2 h-3.5 w-3.5 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
+        />
+      </Link>
+    );
+  }
+
+  return (
+    <div className={base}>
+      <KPIBody {...props} />
     </div>
   );
 }

--- a/frontend/src/pages/ControlCenterPage.tsx
+++ b/frontend/src/pages/ControlCenterPage.tsx
@@ -175,24 +175,28 @@ export default function ControlCenterPage() {
             value={needsAttentionCount}
             sub={`${attentionPrinters.length} printers • ${blockerAlerts.length} stock blockers`}
             tone={needsAttentionCount > 0 ? 'warning' : 'success'}
+            href="/print-floor"
           />
           <KPI
             label="Draft queue"
             value={unassignedDraftJobs.length}
             sub="Draft jobs without printer"
             tone={unassignedDraftJobs.length > 0 ? 'warning' : 'default'}
+            href="/orders/jobs"
           />
           <KPI
             label="Printing now"
             value={busyPrinters.length}
             sub={`${printers.length} active printers in view`}
             tone={busyPrinters.length > 0 ? 'success' : 'default'}
+            href="/print-floor"
           />
           <KPI
             label="Low-stock blockers"
             value={alerts.length}
             sub={alerts.length ? 'Below reorder point' : 'No blockers'}
             tone={alerts.length ? 'warning' : 'success'}
+            href="/stock"
           />
         </KPIStrip>
       </PageHeader>
@@ -286,6 +290,7 @@ export default function ControlCenterPage() {
                     label="Orders"
                     value={salesMetrics.total_sales}
                     sub={`${salesMetrics.total_units_sold} units sold`}
+                    href="/sell/sales"
                   />
                   <KPI
                     label="Contribution"
@@ -404,11 +409,13 @@ export default function ControlCenterPage() {
                 label="Revenue"
                 value={summary ? formatCurrency(summary.total_revenue) : '—'}
                 sub={summary ? `${summary.total_jobs} jobs • ${summary.total_pieces} pieces` : 'Dashboard summary unavailable'}
+                href="/sell/sales"
               />
               <KPI
                 label="Net profit"
                 value={summary ? formatCurrency(summary.total_net_profit) : '—'}
                 sub={summary ? `Avg margin ${formatPercent(summary.avg_margin_pct)}` : 'Margin unavailable'}
+                href="/reports/pl"
               />
             </KPIStrip>
             {financeData ? (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -132,22 +132,30 @@ export default function DashboardPage() {
       />
 
       <KPIStrip columns={3}>
-        <KPI icon={<BarChart3 className="h-4 w-4" />} label="Total jobs" value={data.total_jobs.toLocaleString()} />
-        <KPI icon={<Package className="h-4 w-4" />} label="Total pieces" value={data.total_pieces.toLocaleString()} />
-        <KPI icon={<DollarSign className="h-4 w-4" />} label="Total revenue" value={formatCurrency(data.total_revenue)} />
-        <KPI icon={<Layers className="h-4 w-4" />} label="Total costs" value={formatCurrency(data.total_costs)} />
+        <KPI icon={<BarChart3 className="h-4 w-4" />} label="Total jobs" value={data.total_jobs.toLocaleString()} href="/orders/jobs" />
+        <KPI icon={<Package className="h-4 w-4" />} label="Total pieces" value={data.total_pieces.toLocaleString()} href="/orders/jobs" />
+        <KPI
+          icon={<DollarSign className="h-4 w-4" />}
+          label="Total revenue"
+          value={formatCurrency(data.total_revenue)}
+          href="/sell/sales"
+          sparkline={revenueData?.map((d) => d.revenue) || []}
+        />
+        <KPI icon={<Layers className="h-4 w-4" />} label="Total costs" value={formatCurrency(data.total_costs)} href="/reports/pl" />
         <KPI
           icon={<TrendingUp className="h-4 w-4" />}
           label="Net profit"
           value={formatCurrency(data.total_net_profit)}
           sub={`Avg margin ${formatPercent(data.avg_margin_pct)}`}
           tone={data.total_net_profit >= 0 ? 'success' : 'destructive'}
+          href="/reports/pl"
         />
         <KPI
           icon={<Award className="h-4 w-4" />}
           label="Top material"
           value={data.top_material || '—'}
           sub={`Avg profit/piece ${formatCurrency(data.avg_profit_per_piece)}`}
+          href="/stock/materials"
         />
       </KPIStrip>
 
@@ -261,16 +269,17 @@ export default function DashboardPage() {
         <section>
           <h2 className="mb-3 text-base font-semibold">Finance overview</h2>
           <KPIStrip columns={4}>
-            <KPI icon={<DollarSign className="h-4 w-4" />} label="Cash on hand" value={formatCurrency(financeData.cash_on_hand)} />
+            <KPI icon={<DollarSign className="h-4 w-4" />} label="Cash on hand" value={formatCurrency(financeData.cash_on_hand)} href="/reports/pl" />
             <KPI
               icon={<TrendingUp className="h-4 w-4" />}
               label="Month net income"
               value={formatCurrency(financeData.current_month_net_income)}
               tone={financeData.current_month_net_income >= 0 ? 'success' : 'destructive'}
+              href="/reports/pl"
             />
-            <KPI icon={<BarChart3 className="h-4 w-4" />} label="Unpaid invoices" value={formatCurrency(financeData.unpaid_invoices)} />
+            <KPI icon={<BarChart3 className="h-4 w-4" />} label="Unpaid invoices" value={formatCurrency(financeData.unpaid_invoices)} href="/sell/sales" />
             <KPI icon={<Layers className="h-4 w-4" />} label="Unpaid bills" value={formatCurrency(financeData.unpaid_bills)} />
-            <KPI icon={<Package className="h-4 w-4" />} label="Inventory asset value" value={formatCurrency(financeData.inventory_asset_value)} />
+            <KPI icon={<Package className="h-4 w-4" />} label="Inventory asset value" value={formatCurrency(financeData.inventory_asset_value)} href="/stock" />
             <KPI
               icon={<AlertTriangle className="h-4 w-4" />}
               label="Tax payable"
@@ -287,25 +296,28 @@ export default function DashboardPage() {
         <section>
           <h2 className="mb-3 text-base font-semibold">Sales overview</h2>
           <KPIStrip columns={3}>
-            <KPI icon={<ShoppingCart className="h-4 w-4" />} label="Total orders" value={salesMetrics.total_sales.toLocaleString()} />
-            <KPI icon={<DollarSign className="h-4 w-4" />} label="Gross sales" value={formatCurrency(salesMetrics.gross_sales)} />
-            <KPI icon={<Layers className="h-4 w-4" />} label="Item COGS" value={formatCurrency(salesMetrics.item_cogs)} />
+            <KPI icon={<ShoppingCart className="h-4 w-4" />} label="Total orders" value={salesMetrics.total_sales.toLocaleString()} href="/sell/sales" />
+            <KPI icon={<DollarSign className="h-4 w-4" />} label="Gross sales" value={formatCurrency(salesMetrics.gross_sales)} href="/sell/sales" />
+            <KPI icon={<Layers className="h-4 w-4" />} label="Item COGS" value={formatCurrency(salesMetrics.item_cogs)} href="/reports/pl" />
             <KPI
               icon={<TrendingUp className="h-4 w-4" />}
               label="Gross profit"
               value={formatCurrency(salesMetrics.gross_profit)}
               tone={salesMetrics.gross_profit >= 0 ? 'success' : 'destructive'}
+              href="/reports/pl"
             />
             <KPI
               icon={<DollarSign className="h-4 w-4" />}
               label="Platform fees + shipping"
               value={formatCurrency(salesMetrics.platform_fees + salesMetrics.shipping_costs)}
+              href="/reports/sales"
             />
             <KPI
               icon={<BarChart3 className="h-4 w-4" />}
               label="Contribution margin"
               value={formatCurrency(salesMetrics.contribution_margin)}
               sub={salesMetrics.refund_count > 0 ? `${salesMetrics.refund_count} refund(s)` : 'Net pending overhead allocation'}
+              href="/reports/pl"
             />
           </KPIStrip>
 

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -399,7 +399,7 @@ export default function InventoryPage() {
             sub="Nearing depletion"
             tone={nearReorderProducts.length > 0 ? 'warning' : 'default'}
           />
-          <KPI label="Material signals" value={materialAlerts.length} sub="Raw-material alerts" />
+          <KPI label="Material signals" value={materialAlerts.length} sub="Raw-material alerts" href="/stock/materials" />
         </KPIStrip>
       </PageHeader>
 

--- a/frontend/src/pages/OrdersPage.tsx
+++ b/frontend/src/pages/OrdersPage.tsx
@@ -245,9 +245,10 @@ export default function OrdersPage() {
             value={jobsNeedingAssignment.length}
             sub="Jobs missing a printer"
             tone={jobsNeedingAssignment.length > 0 ? 'warning' : 'default'}
+            href="/orders/jobs"
           />
-          <KPI label="In progress" value={productionActive.length} sub="Jobs on the production floor" />
-          <KPI label="Fulfillment queue" value={fulfillmentSales.length} sub="Sales pending ship/deliver" />
+          <KPI label="In progress" value={productionActive.length} sub="Jobs on the production floor" href="/orders/jobs" />
+          <KPI label="Fulfillment queue" value={fulfillmentSales.length} sub="Sales pending ship/deliver" href="/sell/sales" />
           <KPI
             label="Ready printers"
             value={readyPrinters.length}
@@ -257,6 +258,7 @@ export default function OrdersPage() {
                 : 'Idle, available for assignment'
             }
             tone={readyPrinters.length === 0 ? 'warning' : attentionPrinters.length > 0 ? 'warning' : 'default'}
+            href="/print-floor"
           />
         </KPIStrip>
       </PageHeader>

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -363,12 +363,14 @@ export default function POSPage() {
             value={lowStockCount}
             sub="At or below reorder point"
             tone={lowStockCount > 0 ? 'warning' : 'default'}
+            href="/stock"
           />
           <KPI
             label="Sales inbox"
             value={salesNeedingAttention}
             sub="Pending or refunded sales"
             tone={salesNeedingAttention > 0 ? 'warning' : 'default'}
+            href="/sell/sales"
           />
         </KPIStrip>
       </PageHeader>

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -444,6 +444,7 @@ export default function PrintersPage() {
             value={summary.unassignedJobs}
             tone={summary.unassignedJobs > 0 ? 'warning' : 'default'}
             sub="Draft or in-progress without a printer"
+            href="/orders/jobs"
           />
         </KPIStrip>
       </PageHeader>

--- a/frontend/src/pages/reports/SalesReportPage.tsx
+++ b/frontend/src/pages/reports/SalesReportPage.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid, ResponsiveContainer, Legend } from 'recharts';
 import api from '@/api/client';
+import { ChartTooltip } from '@/components/charts/ChartTooltip';
 import { formatCurrency } from '@/lib/utils';
 import ReportControls from '@/components/ui/ReportControls';
 import { SkeletonTable } from '@/components/ui/Skeleton';
@@ -81,7 +82,7 @@ export default function SalesReportPage() {
                   <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
                   <XAxis dataKey="period" tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" />
                   <YAxis tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" tickFormatter={(v) => `$${v}`} />
-                  <Tooltip formatter={formatTooltipCurrency} contentStyle={{ backgroundColor: 'var(--color-card)', border: '1px solid var(--color-border)', borderRadius: '8px' }} />
+                  <ChartTooltip formatter={formatTooltipCurrency} />
                   <Legend />
                   <Line type="monotone" dataKey="gross_sales" name="Gross Sales" stroke="var(--color-primary)" strokeWidth={2} dot={{ r: 3 }} />
                   <Line type="monotone" dataKey="gross_profit" name="Gross Profit" stroke="#10b981" strokeWidth={2} dot={{ r: 3 }} />
@@ -138,7 +139,7 @@ export default function SalesReportPage() {
                     <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
                     <XAxis dataKey="channel_name" tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" />
                     <YAxis tick={{ fontSize: 12 }} stroke="var(--color-muted-foreground)" tickFormatter={(v) => `$${v}`} />
-                    <Tooltip formatter={formatTooltipCurrency} contentStyle={{ backgroundColor: 'var(--color-card)', border: '1px solid var(--color-border)', borderRadius: '8px' }} />
+                    <ChartTooltip formatter={formatTooltipCurrency} />
                     <Legend />
                     <Bar dataKey="gross_sales" name="Gross Sales" fill="var(--color-primary)" radius={[4, 4, 0, 0]} />
                     <Bar dataKey="contribution_margin" name="Contribution Margin" fill="#10b981" radius={[4, 4, 0, 0]} />


### PR DESCRIPTION
Closes #188. Parent epic: #173 (P2).

## Summary

**D4** — Finished `<ChartTooltip>` migration: 2 remaining holdout `<Tooltip contentStyle>` calls in SalesReportPage swapped to the primitive.

**D5** — `<KPI sparkline={[…]}>` renders a minimalist 24px-tall recharts line below the value (no axes, no tooltip, primary stroke, decorative `aria-hidden`). Applied to Dashboard "Total revenue" using the existing revenueData series.

**D6** — `<KPI href="/path">` turns the KPI card into a react-router `<Link>` with a hover-revealed chevron. Applied to Dashboard + Orders + Inventory + POS + Printers + ControlCenter KPIStrips where a natural drill-through destination exists.

## New KPI props

| prop | behavior |
|---|---|
| `href?: string` | renders card as `<Link>` + hover chevron |
| `sparkline?: number[]` | renders 24px recharts `<LineChart>` under the value |
| `sparklineColor?: string` | optional stroke override (defaults to `var(--color-primary)`) |
| `linkAriaLabel?: string` | overrides default `Open {label} details` |

## Skipped href (documented)

- Dashboard finance: Unpaid bills / Tax payable / Payouts in transit — no natural list page
- Inventory: Product alerts / Critical stockouts / Near reorder — already in-context on Stock page
- POS: Cart total / Barcode ready — no meaningful drill-through
- Printers: Printing now / Ready / Need attention — already in-context
- ControlCenter inner: Contribution / Avg order — no natural target

## Acceptance

- [x] `rg 'Tooltip contentStyle' src/pages` → **0**
- [x] `<KPI>` supports `sparkline` + `href`
- [x] Dashboard KPIs navigate to Sales/Orders/Stock/PL report lists
- [x] "Total revenue" shows sparkline of revenueData series
- [x] `npm run build` passes
- [x] `npx vitest run` → 44 tests passing

## Test plan

- [ ] Hover a KPI with href — chevron fades in; click navigates
- [ ] Keyboard Tab through Dashboard KPI strip — each is focusable; Enter navigates
- [ ] "Total revenue" on Dashboard renders with a tiny blue sparkline under the value; no tooltip on hover
- [ ] Non-href KPIs (e.g. Dashboard "Unpaid bills", POS "Cart total") render identically to before (no chevron, not clickable)
- [ ] Screen reader announces the link label as "Open Total revenue details" etc.
- [ ] `/reports/sales` charts still render with consistent tooltip styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)