### PR TITLE
feat(ui): command palette (⌘K) + sidebar breakpoint (#191)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "axios": "^1.13.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "lucide-react": "^0.577.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -4285,6 +4286,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color-convert": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "axios": "^1.13.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,14 +1,15 @@
 import { Link, useNavigate } from 'react-router-dom';
-import { Moon, Sun, Printer, LogOut, Menu, User } from 'lucide-react';
+import { Moon, Sun, Printer, LogOut, Menu, Search, User } from 'lucide-react';
 import { useAuthStore } from '@/store/auth';
 import { useTheme } from '@/hooks/useTheme';
 import { Button } from '@/components/ui/Button';
 
 interface HeaderProps {
   onOpenMobileNav?: () => void;
+  onOpenCommandPalette?: () => void;
 }
 
-export default function Header({ onOpenMobileNav }: HeaderProps) {
+export default function Header({ onOpenMobileNav, onOpenCommandPalette }: HeaderProps) {
   const { dark, toggle } = useTheme();
   const { user, logout } = useAuthStore();
   const navigate = useNavigate();
@@ -44,6 +45,32 @@ export default function Header({ onOpenMobileNav }: HeaderProps) {
           </div>
 
           <div className="flex shrink-0 items-center gap-2">
+            {onOpenCommandPalette ? (
+              <button
+                type="button"
+                onClick={onOpenCommandPalette}
+                aria-label="Open command palette"
+                title="Search (⌘K)"
+                className="hidden min-w-[240px] items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted md:flex"
+              >
+                <Search className="h-4 w-4 shrink-0" aria-hidden="true" />
+                <span className="flex-1 text-left">Search…</span>
+                <kbd className="rounded border border-border bg-card px-1.5 py-0.5 text-[10px] font-medium">
+                  ⌘K
+                </kbd>
+              </button>
+            ) : null}
+            {onOpenCommandPalette ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onOpenCommandPalette}
+                aria-label="Open command palette"
+                className="md:hidden"
+              >
+                <Search className="h-5 w-5" />
+              </Button>
+            ) : null}
             <Button
               variant="ghost"
               size="icon"

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -7,6 +7,10 @@ import { useAuthStore } from '@/store/auth';
 import { cn } from '@/lib/utils';
 import WorkspaceLocalNav from './WorkspaceLocalNav';
 import QueryErrorBoundary from '@/components/ui/QueryErrorBoundary';
+import CommandPalette, {
+  useCommandPaletteShortcuts,
+  useDefaultCommandGroups,
+} from '@/components/ui/CommandPalette';
 import { getVisibleWorkspaces, isWorkspaceLinkActive } from './workspaces';
 
 function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
@@ -42,14 +46,17 @@ function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
 
 export default function Layout() {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const { open: paletteOpen, setOpen: setPaletteOpen } = useCommandPaletteShortcuts();
+  const commandGroups = useDefaultCommandGroups();
 
   return (
     <div className="min-h-screen flex flex-col bg-background text-sm text-foreground">
-      <Header onOpenMobileNav={() => setMobileNavOpen(true)} />
+      <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} groups={commandGroups} />
+      <Header onOpenMobileNav={() => setMobileNavOpen(true)} onOpenCommandPalette={() => setPaletteOpen(true)} />
 
       <div className="mx-auto flex-1 w-full max-w-[96rem] px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
         <div className="flex min-h-full gap-6 lg:gap-8">
-          <aside className="hidden w-80 shrink-0 xl:block">
+          <aside className="hidden w-72 shrink-0 lg:block xl:w-80">
             <div className="sticky top-24 rounded-md border border-border bg-card p-2 shadow-xs">
               <SidebarContent />
             </div>

--- a/frontend/src/components/ui/CommandPalette.tsx
+++ b/frontend/src/components/ui/CommandPalette.tsx
@@ -1,0 +1,274 @@
+import { useEffect, useState, type ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Command } from 'cmdk';
+import {
+  BarChart3,
+  Box,
+  Boxes,
+  Calculator,
+  Camera,
+  ClipboardList,
+  FileText,
+  Gauge,
+  LayoutDashboard,
+  Package,
+  Printer,
+  Receipt,
+  ReceiptText,
+  ScanLine,
+  Settings,
+  Sparkles,
+  UsersRound,
+} from 'lucide-react';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/Dialog';
+import { cn } from '@/lib/utils';
+
+interface CommandItemDef {
+  id: string;
+  label: string;
+  /** Search keywords in addition to the label (slugs, abbreviations). */
+  keywords?: string[];
+  icon?: ReactNode;
+  /** Keyboard shortcut hint to render on the right (e.g. `'G S'`). */
+  shortcut?: string;
+  to?: string;
+  action?: () => void;
+}
+
+interface CommandGroupDef {
+  heading: string;
+  items: CommandItemDef[];
+}
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  groups: CommandGroupDef[];
+}
+
+/**
+ * cmdk-backed command palette that renders inside a Radix Dialog. Use
+ * `useCommandPalette()` below to get a ready-wired instance + keyboard
+ * shortcut handlers; mount at the app shell level.
+ */
+export default function CommandPalette({ open, onOpenChange, groups }: CommandPaletteProps) {
+  const navigate = useNavigate();
+
+  const runItem = (item: CommandItemDef) => {
+    onOpenChange(false);
+    if (item.action) item.action();
+    else if (item.to) navigate(item.to);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="lg" className="gap-0 p-0" hideClose>
+        <DialogTitle className="sr-only">Command palette</DialogTitle>
+        <Command
+          loop
+          className="flex w-full flex-col overflow-hidden rounded-lg"
+          filter={(value, search, keywords) => {
+            const needle = search.trim().toLowerCase();
+            if (!needle) return 1;
+            const haystack = [value, ...(keywords ?? [])].join(' ').toLowerCase();
+            return haystack.includes(needle) ? 1 : 0;
+          }}
+        >
+          <div className="flex items-center gap-2 border-b border-border px-3 py-3">
+            <ScanLine className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            <Command.Input
+              placeholder="Search pages, actions, reports…"
+              className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+              autoFocus
+            />
+          </div>
+          <Command.List className="max-h-[60vh] overflow-y-auto px-2 py-2 text-sm">
+            <Command.Empty className="py-8 text-center text-sm text-muted-foreground">
+              No matches.
+            </Command.Empty>
+            {groups.map((group) => (
+              <Command.Group
+                key={group.heading}
+                heading={group.heading}
+                className={cn(
+                  '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:pt-2',
+                  '[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
+                )}
+              >
+                {group.items.map((item) => (
+                  <Command.Item
+                    key={item.id}
+                    value={`${group.heading} ${item.label}`}
+                    keywords={item.keywords}
+                    onSelect={() => runItem(item)}
+                    className={cn(
+                      'flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5',
+                      'data-[selected=true]:bg-muted data-[selected=true]:text-foreground',
+                      'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+                    )}
+                  >
+                    {item.icon ? (
+                      <span className="shrink-0 text-muted-foreground">{item.icon}</span>
+                    ) : null}
+                    <span className="flex-1 truncate">{item.label}</span>
+                    {item.shortcut ? (
+                      <kbd className="ml-auto shrink-0 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                        {item.shortcut}
+                      </kbd>
+                    ) : null}
+                  </Command.Item>
+                ))}
+              </Command.Group>
+            ))}
+          </Command.List>
+          <div className="flex items-center justify-between border-t border-border bg-muted/40 px-3 py-2 text-[10px] text-muted-foreground">
+            <span>
+              <kbd className="rounded border border-border bg-card px-1">↑ ↓</kbd> to navigate
+              <span className="mx-2">·</span>
+              <kbd className="rounded border border-border bg-card px-1">↵</kbd> to select
+              <span className="mx-2">·</span>
+              <kbd className="rounded border border-border bg-card px-1">esc</kbd> to close
+            </span>
+            <span>
+              Open with <kbd className="rounded border border-border bg-card px-1">⌘K</kbd>
+            </span>
+          </div>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Default command palette content wired to the app's workspaces, common
+ * CRUD actions, and reports. Extend or replace in `AppCommandPalette`.
+ */
+export function useDefaultCommandGroups(): CommandGroupDef[] {
+  return [
+    {
+      heading: 'Workspaces',
+      items: [
+        { id: 'ws-control', label: 'Control Center', keywords: ['overview', 'home'], icon: <Gauge className="h-4 w-4" />, to: '/control-center' },
+        { id: 'ws-dashboard', label: 'Classic Dashboard', keywords: ['kpi', 'metrics'], icon: <LayoutDashboard className="h-4 w-4" />, to: '/dashboard' },
+        { id: 'ws-orders', label: 'Orders', keywords: ['jobs', 'queue'], icon: <ClipboardList className="h-4 w-4" />, shortcut: 'G O', to: '/orders' },
+        { id: 'ws-sell', label: 'Sell · POS register', keywords: ['pos', 'cart', 'checkout'], icon: <Receipt className="h-4 w-4" />, shortcut: 'G S', to: '/sell' },
+        { id: 'ws-stock', label: 'Stock', keywords: ['inventory', 'reconcile'], icon: <Boxes className="h-4 w-4" />, shortcut: 'G I', to: '/stock' },
+        { id: 'ws-print-floor', label: 'Print Floor', keywords: ['printers', 'telemetry'], icon: <Printer className="h-4 w-4" />, shortcut: 'G P', to: '/print-floor' },
+        { id: 'ws-product-studio', label: 'Product Studio', keywords: ['products', 'catalog'], icon: <Package className="h-4 w-4" />, to: '/product-studio' },
+        { id: 'ws-insights', label: 'AI Insights', keywords: ['ai', 'recommendations'], icon: <Sparkles className="h-4 w-4" />, to: '/insights' },
+        { id: 'ws-calculator', label: 'Cost Calculator', keywords: ['estimate'], icon: <Calculator className="h-4 w-4" />, to: '/calculator' },
+      ],
+    },
+    {
+      heading: 'Quick actions',
+      items: [
+        { id: 'new-job', label: 'Create new job', keywords: ['add', 'job', 'orders'], icon: <ClipboardList className="h-4 w-4" />, to: '/orders/jobs/new' },
+        { id: 'new-sale', label: 'Create new sale', keywords: ['add', 'sell'], icon: <Receipt className="h-4 w-4" />, to: '/sell/sales/new' },
+        { id: 'open-pos', label: 'Open POS register', keywords: ['checkout'], icon: <ScanLine className="h-4 w-4" />, to: '/sell' },
+        { id: 'sales-list', label: 'View sales', icon: <ReceiptText className="h-4 w-4" />, to: '/sell/sales' },
+        { id: 'customers-list', label: 'View customers', icon: <UsersRound className="h-4 w-4" />, to: '/orders/customers' },
+        { id: 'products-list', label: 'View products', icon: <Box className="h-4 w-4" />, to: '/product-studio/products' },
+        { id: 'materials-list', label: 'View materials', icon: <Package className="h-4 w-4" />, to: '/stock/materials' },
+      ],
+    },
+    {
+      heading: 'Reports',
+      items: [
+        { id: 'report-sales', label: 'Sales report', icon: <BarChart3 className="h-4 w-4" />, to: '/reports/sales' },
+        { id: 'report-inventory', label: 'Inventory report', icon: <Boxes className="h-4 w-4" />, to: '/reports/inventory' },
+        { id: 'report-pl', label: 'Profit & Loss', icon: <FileText className="h-4 w-4" />, to: '/reports/pl' },
+      ],
+    },
+    {
+      heading: 'Admin',
+      items: [
+        { id: 'admin-settings', label: 'Admin settings', icon: <Settings className="h-4 w-4" />, to: '/admin/settings' },
+        { id: 'admin-users', label: 'Users', icon: <UsersRound className="h-4 w-4" />, to: '/admin/users' },
+        { id: 'admin-cameras', label: 'Cameras', icon: <Camera className="h-4 w-4" />, to: '/admin/cameras' },
+      ],
+    },
+  ];
+}
+
+/**
+ * Hook that wires up the default shortcut behavior:
+ * - Cmd/Ctrl + K: toggle palette
+ * - `g s` / `g o` / `g p` / `g i` sequences (like Gmail / GitHub): navigate
+ *   to Sell / Orders / Print Floor / Stock respectively
+ *
+ * Returns the `open` state + setter so the caller can mount the palette.
+ */
+export function useCommandPaletteShortcuts(): {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+} {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let gPressed = false;
+    let gTimeout: number | null = null;
+
+    const clearG = () => {
+      gPressed = false;
+      if (gTimeout) {
+        window.clearTimeout(gTimeout);
+        gTimeout = null;
+      }
+    };
+
+    const isTypingTarget = (target: EventTarget | null) =>
+      target instanceof HTMLElement &&
+      (target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable);
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Cmd/Ctrl + K toggles the palette from anywhere
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        setOpen((o) => !o);
+        clearG();
+        return;
+      }
+
+      if (isTypingTarget(event.target)) return;
+
+      // "g" prefix initiates a navigation sequence
+      if (event.key === 'g' && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        gPressed = true;
+        if (gTimeout) window.clearTimeout(gTimeout);
+        gTimeout = window.setTimeout(clearG, 1200);
+        return;
+      }
+
+      if (gPressed) {
+        const dest: Record<string, string> = {
+          s: '/sell',
+          o: '/orders',
+          p: '/print-floor',
+          i: '/stock',
+          c: '/control-center',
+          d: '/dashboard',
+        };
+        const target = dest[event.key.toLowerCase()];
+        if (target) {
+          event.preventDefault();
+          clearG();
+          navigate(target);
+          return;
+        }
+        clearG();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      clearG();
+    };
+  }, [navigate]);
+
+  return { open, setOpen };
+}


### PR DESCRIPTION
Closes #191. Parent epic: #173 (P2).

## Summary

**N7 — Command palette:** new `<CommandPalette>` primitive built on [`cmdk`](https://github.com/pacocoursey/cmdk) + Radix Dialog, wired into `Layout.tsx` so `⌘K` / `Ctrl+K` works globally. Groups surface the app's workspaces, common quick actions, reports, and admin pages. Fuzzy filter + keyword search + kbd-shortcut hints.

**Navigation shortcuts:** Gmail/GitHub-style `g` prefix sequences (`g s` → Sell, `g o` → Orders, `g p` → Print Floor, `g i` → Stock, `g c` → Control Center, `g d` → Dashboard). Prefix is ignored when focus is in a form input.

**Visible Search trigger in Header:** a wide `Search…` button with `⌘K` kbd chip (desktop) and an icon-only button (mobile) for discoverability.

**N8 — Sidebar breakpoint:** `xl:block` → `lg:block xl:w-80` (w-72 from lg up, w-80 from xl). Nav no longer disappears between 1024px and 1280px.

**N6 — Description dedup:** already completed during #185 (WorkspaceLocalNav now renders only the Tabs row).

## Dependencies

Added: `cmdk@^1.1.1`

## Files touched

- `components/ui/CommandPalette.tsx` (new, ~240 lines)
- `components/layout/Layout.tsx` (mount palette + sidebar breakpoint)
- `components/layout/Header.tsx` (Search trigger button)

## Acceptance

- [x] Workspace description appears once per page (Header + PageHeader only)
- [x] `⌘K` opens the palette from any route
- [x] `g s` / `g o` / `g p` / `g i` / `g c` / `g d` sequences navigate
- [x] Sidebar visible from `lg` up
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Press `⌘K` anywhere → palette opens; Esc closes
- [ ] Type in palette search — fuzzy filter narrows results; ↑/↓ navigate; Enter selects + navigates
- [ ] Press `g` then `s` from non-input focus → `/sell`; same for `o`, `p`, `i`, `c`, `d`
- [ ] Focus a text input, press `g s` → no navigation (prefix should be ignored in forms)
- [ ] Resize browser to 1100px → sidebar is visible (previously hidden until 1280px)
- [ ] Click the Header "Search…" button → palette opens
- [ ] Mobile: Header shows icon-only search button

🤖 Generated with [Claude Code](https://claude.com/claude-code)