### PR TITLE
feat(ui): misc chrome polish — max-width, footer, toast theming (#189)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Toaster } from 'sonner';
+import AppToaster from '@/components/ui/AppToaster';
 import ErrorBoundary from '@/components/ui/ErrorBoundary';
 import { Skeleton, SkeletonCard } from '@/components/ui/Skeleton';
 import { TooltipProvider } from '@/components/ui/Tooltip';
@@ -168,7 +168,7 @@ export default function App() {
             </Routes>
           </Suspense>
         </BrowserRouter>
-        <Toaster richColors position="top-right" />
+        <AppToaster />
         </TooltipProvider>
       </QueryClientProvider>
     </ErrorBoundary>

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,11 +1,11 @@
 export default function Footer() {
+  const appVersion = import.meta.env.VITE_APP_VERSION || 'dev';
+
   return (
-    <footer className="mt-auto border-t border-border py-6">
-      <div className="mx-auto flex max-w-[96rem] flex-col gap-2 px-4 text-center text-sm text-muted-foreground sm:px-6 lg:px-8 lg:flex-row lg:items-center lg:justify-between">
-        <p>&copy; {new Date().getFullYear()} 3D Print Sales.</p>
-        <p className="text-xs text-muted-foreground/90">
-          Control Center • Print Floor • Sell • Stock • Product Studio
-        </p>
+    <footer className="mt-auto border-t border-border py-3">
+      <div className="mx-auto flex max-w-[88rem] flex-col gap-1 px-4 text-center text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
+        <p>&copy; {new Date().getFullYear()} 3D Print Sales</p>
+        <p className="tabular-nums text-muted-foreground/80">Build {appVersion}</p>
       </div>
     </footer>
   );

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -21,7 +21,7 @@ export default function Header({ onOpenMobileNav, onOpenCommandPalette }: Header
 
   return (
     <header className="sticky top-0 z-40 border-b border-border bg-card">
-      <div className="mx-auto max-w-[96rem] px-4 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-[88rem] px-4 sm:px-6 lg:px-8">
         <div className="flex min-h-14 items-center justify-between gap-4 py-2">
           <div className="flex min-w-0 items-center gap-3">
             <Button

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -54,7 +54,7 @@ export default function Layout() {
       <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} groups={commandGroups} />
       <Header onOpenMobileNav={() => setMobileNavOpen(true)} onOpenCommandPalette={() => setPaletteOpen(true)} />
 
-      <div className="mx-auto flex-1 w-full max-w-[96rem] px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+      <div className="mx-auto flex-1 w-full max-w-[88rem] px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
         <div className="flex min-h-full gap-6 lg:gap-8">
           <aside className="hidden w-72 shrink-0 lg:block xl:w-80">
             <div className="sticky top-24 rounded-md border border-border bg-card p-2 shadow-xs">

--- a/frontend/src/components/ui/AppToaster.tsx
+++ b/frontend/src/components/ui/AppToaster.tsx
@@ -1,0 +1,38 @@
+import { Toaster as SonnerToaster } from 'sonner';
+import { useTheme } from '@/hooks/useTheme';
+
+/**
+ * Thin wrapper around `sonner`'s Toaster that binds the theme to the app's
+ * dark-mode toggle and styles toast surfaces with our design tokens
+ * (bg-card / border-border / text-foreground + tone-specific borders).
+ * Mount once at the app shell level.
+ */
+export default function AppToaster() {
+  const { dark } = useTheme();
+
+  return (
+    <SonnerToaster
+      theme={dark ? 'dark' : 'light'}
+      position="top-right"
+      closeButton
+      toastOptions={{
+        classNames: {
+          toast:
+            'group rounded-md border border-border bg-card text-foreground shadow-md text-sm',
+          title: 'text-sm font-semibold text-foreground',
+          description: 'text-xs text-muted-foreground',
+          actionButton:
+            'rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground hover:opacity-90',
+          cancelButton:
+            'rounded-md border border-border bg-card px-2 py-1 text-xs font-medium text-foreground hover:bg-muted',
+          closeButton:
+            'rounded-md border border-border bg-card text-muted-foreground hover:bg-muted',
+          success: 'border-emerald-300/60 bg-emerald-50/90 text-emerald-900 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200',
+          error: 'border-destructive/40 bg-destructive/10 text-destructive',
+          warning: 'border-amber-300/60 bg-amber-50/90 text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200',
+          info: 'border-sky-300/60 bg-sky-50/90 text-sky-900 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-200',
+        },
+      }}
+    />
+  );
+}


### PR DESCRIPTION
Closes #189. Parent epic: **#173 — last P2 issue; epic wraps up with this merge**.

## Summary

Cleans up the remaining misc chrome items. Most of the issue's scope (X1 kiosk gradient, X7 Insights hero, X8 light-mode header) was already addressed during earlier revamps (#185, #209, #183); this PR finishes X9/X10/X11.

## Changes

**X9 — Max-width:** `max-w-[96rem]` (1536px) → `max-w-[88rem]` (1408px) across Layout, Header, and Footer inner containers. ERP-typical 1280-1440px range; tables no longer drift wide on >1440px displays.

**X10 — Footer:** Simplified to a compact `py-3` bar with `© {year}` (left) + `Build {VITE_APP_VERSION || 'dev'}` (right). Dropped the marketing-ish workspace tagline ("Control Center • Print Floor • Sell • Stock • Product Studio").

**X11 — Toast theming:** New `components/ui/AppToaster.tsx` wraps sonner's `<Toaster>` with:
- `theme={dark ? 'dark' : 'light'}` bound to app theme toggle
- Toast surfaces use `bg-card` / `border-border` / `text-foreground`
- Success / error / warning / info variants use the same tone borders as `<Callout>`
- Action / cancel / close buttons follow `<Button>` conventions

Replaced `<Toaster richColors position="top-right" />` in App.tsx with `<AppToaster />`.

## Verified already complete (earlier PRs)

- **X1 Kiosk gradient** — `PrintersPage` wall-mode gradient already gated behind `wallMode` URL param; `PrinterMonitorPage` runs only on `/print-floor/monitor/:id` kiosk route.
- **X7 Insights hero** — already uses `<PageHeader>` (PR #210 / #209).
- **X8 Light-mode header** — header is `bg-card` opaque in both modes (PR #213 / #185).

## Acceptance

- [x] Kiosk gradients only render under wall mode / kiosk route
- [x] Insights uses `<PageHeader>`
- [x] Header color consistent light/dark
- [x] Content max-width ≤ 1440px
- [x] Footer is a compact chrome bar
- [x] Toaster matches app design tokens
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 44 tests passing

## Test plan

- [ ] Wide display (>1440px) — content caps at ~1408px; tables no longer expand past it
- [ ] Footer — single thin line with copyright + build version; no marketing tagline
- [ ] Trigger a success/error/warning toast — matches card chrome, border tone matches Callout colors; close button styled
- [ ] Flip theme — toast repaints in dark mode without mixing white/dark mix

🤖 Generated with [Claude Code](https://claude.com/claude-code)