### PR TITLE
fix(ui): handle FastAPI validation errors without crashing (React #31)

### DIFF
--- a/frontend/src/lib/apiError.test.ts
+++ b/frontend/src/lib/apiError.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { getApiErrorMessage } from './apiError';
+
+describe('getApiErrorMessage', () => {
+  it('returns a string detail as-is', () => {
+    const err = { response: { data: { detail: 'Not enough stock on hand.' } } };
+    expect(getApiErrorMessage(err)).toBe('Not enough stock on hand.');
+  });
+
+  it('formats a Pydantic validation array', () => {
+    const err = {
+      response: {
+        data: {
+          detail: [
+            {
+              type: 'string_type',
+              loc: ['body', 'settings', 'ai_openai_api_key', 'value'],
+              msg: 'Input should be a valid string',
+              input: null,
+            },
+          ],
+        },
+      },
+    };
+    expect(getApiErrorMessage(err)).toBe(
+      'settings.ai_openai_api_key.value: Input should be a valid string',
+    );
+  });
+
+  it('joins multiple validation errors with a bullet', () => {
+    const err = {
+      response: {
+        data: {
+          detail: [
+            { loc: ['body', 'name'], msg: 'Field required' },
+            { loc: ['body', 'email'], msg: 'value is not a valid email address' },
+          ],
+        },
+      },
+    };
+    expect(getApiErrorMessage(err)).toBe(
+      'name: Field required · email: value is not a valid email address',
+    );
+  });
+
+  it('falls back to the axios message for network errors', () => {
+    const err = { message: 'Network Error' };
+    expect(getApiErrorMessage(err, 'Failed')).toBe('Network Error');
+  });
+
+  it('uses the fallback when no detail is available', () => {
+    expect(getApiErrorMessage({}, 'Failed to save')).toBe('Failed to save');
+    expect(getApiErrorMessage(null, 'Failed to save')).toBe('Failed to save');
+  });
+
+  it('treats an empty string detail as missing', () => {
+    const err = { response: { data: { detail: '   ' } } };
+    expect(getApiErrorMessage(err, 'Default')).toBe('Default');
+  });
+});

--- a/frontend/src/lib/apiError.ts
+++ b/frontend/src/lib/apiError.ts
@@ -1,0 +1,68 @@
+/**
+ * Extract a safe, human-readable error message from an axios error.
+ *
+ * FastAPI returns:
+ * - Business errors (`raise HTTPException(..., detail="Not enough stock")`)
+ *   → `{ detail: "Not enough stock" }` (string)
+ * - Pydantic validation errors (422)
+ *   → `{ detail: [{ type, loc, msg, input }, ...] }` (array)
+ *
+ * Passing the array straight into a `toast.error(...)` (or any React
+ * child) triggers React error #31 ("Objects are not valid as a React
+ * child"). This helper handles both shapes uniformly.
+ *
+ * @param err - the caught error (usually from axios)
+ * @param fallback - message to show if no usable detail is found
+ */
+export function getApiErrorMessage(err: unknown, fallback = 'Something went wrong'): string {
+  const detail = extractDetail(err);
+
+  if (typeof detail === 'string' && detail.trim()) {
+    return detail;
+  }
+
+  if (Array.isArray(detail) && detail.length > 0) {
+    return detail.map(formatValidationItem).filter(Boolean).join(' · ') || fallback;
+  }
+
+  // axios-level message (e.g. "Network Error")
+  if (err && typeof err === 'object' && 'message' in err) {
+    const m = (err as { message?: unknown }).message;
+    if (typeof m === 'string' && m.trim()) return m;
+  }
+
+  return fallback;
+}
+
+function extractDetail(err: unknown): unknown {
+  if (!err || typeof err !== 'object') return undefined;
+  const response = (err as { response?: { data?: unknown } }).response;
+  if (!response || typeof response !== 'object') return undefined;
+  const data = (response as { data?: unknown }).data;
+  if (!data || typeof data !== 'object') return undefined;
+  return (data as { detail?: unknown }).detail;
+}
+
+interface PydanticValidationItem {
+  type?: string;
+  loc?: Array<string | number>;
+  msg?: string;
+  input?: unknown;
+}
+
+function formatValidationItem(raw: unknown): string {
+  if (typeof raw === 'string') return raw;
+  if (!raw || typeof raw !== 'object') return '';
+  const item = raw as PydanticValidationItem;
+  const field = formatLoc(item.loc);
+  const msg = item.msg || item.type || '';
+  if (!msg) return field || '';
+  return field ? `${field}: ${msg}` : msg;
+}
+
+function formatLoc(loc: Array<string | number> | undefined): string {
+  if (!Array.isArray(loc) || loc.length === 0) return '';
+  // Drop the first "body" / "query" / "path" root marker when present.
+  const parts = loc[0] === 'body' || loc[0] === 'query' || loc[0] === 'path' ? loc.slice(1) : loc;
+  return parts.map(String).join('.');
+}

--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -15,6 +15,7 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '
 import ConfirmDialog from '@/components/ui/ConfirmDialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
 import type { Customer } from '@/types';
+import { getApiErrorMessage } from '@/lib/apiError';
 
 const emptyForm = { name: '', email: '', phone: '', notes: '' };
 
@@ -56,8 +57,8 @@ export default function CustomersPage() {
       }
       queryClient.invalidateQueries({ queryKey: ['customers'] });
       close();
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to save');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to save'));
     } finally { setSaving(false); }
   };
 

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -12,6 +12,7 @@ import StatusBadge, { type StatusTone } from '@/components/data/StatusBadge';
 import { Skeleton, SkeletonCard } from '@/components/ui/Skeleton';
 import EmptyState from '@/components/ui/EmptyState';
 import { useAuthStore } from '@/store/auth';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { AIInsightStatus, AIInsightSummary } from '@/types';
 
 const presetQuestions = [
@@ -38,8 +39,8 @@ export default function InsightsPage() {
   const summaryMutation = useMutation({
     mutationFn: async (nextQuestion: string | null) =>
       api.post('/insights/summary', { question: nextQuestion || null }).then((r) => r.data as AIInsightSummary),
-    onError: (err: any) => {
-      toast.error(err.response?.data?.detail || 'Failed to generate insights');
+    onError: (err) => {
+      toast.error(getApiErrorMessage(err, 'Failed to generate insights'));
     },
   });
 

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -27,6 +27,7 @@ import SearchInput from '@/components/data/SearchInput';
 import SelectInput from '@/components/data/Select';
 import Pagination from '@/components/data/Pagination';
 import { cn, formatCurrency } from '@/lib/utils';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type {
   InventoryAlert,
   InventoryReconcileResponse,
@@ -143,8 +144,8 @@ export default function InventoryPage() {
       queryClient.invalidateQueries({ queryKey: ['inventory-transactions'] });
       queryClient.invalidateQueries({ queryKey: ['inventory-alerts'] });
       queryClient.invalidateQueries({ queryKey: ['products'] });
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to reconcile inventory');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to reconcile inventory'));
     } finally {
       setReconcileSaving(false);
     }
@@ -177,8 +178,8 @@ export default function InventoryPage() {
       queryClient.invalidateQueries({ queryKey: ['inventory-transactions'] });
       queryClient.invalidateQueries({ queryKey: ['inventory-alerts'] });
       queryClient.invalidateQueries({ queryKey: ['products'] });
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to adjust stock');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to adjust stock'));
     } finally {
       setAdjustSaving(false);
     }

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -10,6 +10,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import { SkeletonCard } from '@/components/ui/Skeleton';
 import { formatCurrency, formatPercent } from '@/lib/utils';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { Job } from '@/types';
 
 function CostRow({ label, value }: { label: string; value: number }) {
@@ -50,8 +51,8 @@ export default function JobDetailPage() {
       queryClient.invalidateQueries({ queryKey: ['jobs'] });
       toast.success('Job copied to draft successfully');
       navigate(`/orders/jobs/${data.id}`);
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to copy job');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to copy job'));
     } finally {
       setDuplicating(false);
     }

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
 import PageHeader from '@/components/layout/PageHeader';
 import { formatCurrency } from '@/lib/utils';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { Material, Job, CalculateResponse, PaginatedProducts, PaginatedPrinters, Product } from '@/types';
 
 interface FieldProps {
@@ -227,8 +228,8 @@ export default function JobFormPage() {
       }));
       setShowCreateProduct(false);
       toast.success('Product created and linked to job');
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to create product');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to create product'));
     } finally {
       setCreatingProduct(false);
     }
@@ -269,9 +270,8 @@ export default function JobFormPage() {
       queryClient.invalidateQueries({ queryKey: ['jobs'] });
       queryClient.invalidateQueries({ queryKey: ['dashboard'] });
       navigate('/jobs');
-    } catch (err: any) {
-      const msg = err.response?.data?.detail || 'Failed to save job';
-      toast.error(msg);
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to save job'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -13,6 +13,7 @@ import Select from '@/components/data/Select';
 import Pagination from '@/components/data/Pagination';
 import { Button } from '@/components/ui/Button';
 import { formatCurrency } from '@/lib/utils';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { Job, PaginatedJobs } from '@/types';
 
 const STATUS_OPTIONS = [
@@ -57,8 +58,8 @@ export default function JobsPage() {
       queryClient.invalidateQueries({ queryKey: ['jobs'] });
       toast.success('Job copied to draft successfully');
       navigate(`/orders/jobs/${data.id}`);
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to copy job');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to copy job'));
     } finally {
       setDuplicatingId(null);
     }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
 import { useAuthStore } from '@/store/auth';
+import { getApiErrorMessage } from '@/lib/apiError';
 import { useTheme } from '@/hooks/useTheme';
 import { Moon, Sun } from 'lucide-react';
 
@@ -54,9 +55,8 @@ export default function LoginPage() {
       setAuth(user, token);
       toast.success(`Welcome back, ${user.full_name}`);
       navigate(from, { replace: true });
-    } catch (err: any) {
-      const message = err.response?.data?.detail || 'Invalid email or password';
-      setErrors({ form: message });
+    } catch (err) {
+      setErrors({ form: getApiErrorMessage(err, 'Invalid email or password') });
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/MaterialsPage.tsx
+++ b/frontend/src/pages/MaterialsPage.tsx
@@ -4,6 +4,7 @@ import { Edit, Plus } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
+import { getApiErrorMessage } from '@/lib/apiError';
 import PageHeader from '@/components/layout/PageHeader';
 import DataTable, { type Column } from '@/components/data/DataTable';
 import StatusBadge from '@/components/data/StatusBadge';
@@ -62,8 +63,8 @@ export default function MaterialsPage() {
       }
       queryClient.invalidateQueries({ queryKey: ['materials'] });
       close();
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to save');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to save'));
     } finally { setSaving(false); }
   };
 

--- a/frontend/src/pages/POSPage.tsx
+++ b/frontend/src/pages/POSPage.tsx
@@ -28,6 +28,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import { Callout } from '@/components/ui/Callout';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import { cn, formatCurrency } from '@/lib/utils';
+import { getApiErrorMessage } from '@/lib/apiError';
 import {
   addProductToCart,
   buildPOSCheckoutPayload,
@@ -51,41 +52,7 @@ type CustomerMode = 'guest' | 'existing' | 'new';
 type ProductFilter = 'all' | 'scannable' | 'low-stock' | 'in-cart';
 
 function getErrorDetail(error: unknown): string {
-  if (
-    typeof error === 'object' &&
-    error !== null &&
-    'response' in error &&
-    typeof error.response === 'object' &&
-    error.response !== null &&
-    'data' in error.response &&
-    typeof error.response.data === 'object' &&
-    error.response.data !== null &&
-    'detail' in error.response &&
-    typeof error.response.detail === 'string'
-  ) {
-    return error.response.detail;
-  }
-
-  if (
-    typeof error === 'object' &&
-    error !== null &&
-    'response' in error &&
-    typeof error.response === 'object' &&
-    error.response !== null &&
-    'data' in error.response &&
-    typeof error.response.data === 'object' &&
-    error.response.data !== null &&
-    'detail' in error.response.data &&
-    typeof error.response.data.detail === 'string'
-  ) {
-    return error.response.data.detail;
-  }
-
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-
-  return 'Failed to complete POS checkout';
+  return getApiErrorMessage(error, 'Failed to complete POS checkout');
 }
 
 function SalesInboxCard({ sale }: { sale: SaleListItem }) {

--- a/frontend/src/pages/PrinterDetailPage.tsx
+++ b/frontend/src/pages/PrinterDetailPage.tsx
@@ -18,6 +18,7 @@ import {
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { cn, formatCurrency } from '@/lib/utils';
+import { getApiErrorMessage } from '@/lib/apiError';
 import CameraFeed from '@/components/cameras/CameraFeed';
 import PrinterThumbnail from '@/components/printers/PrinterThumbnail';
 import { SkeletonTable } from '@/components/ui/Skeleton';
@@ -131,8 +132,8 @@ export default function PrinterDetailPage() {
       }
       queryClient.invalidateQueries({ queryKey: ['printers'] });
       queryClient.invalidateQueries({ queryKey: ['printer', printer.id] });
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to update printer');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to update printer'));
     }
   };
 
@@ -143,8 +144,8 @@ export default function PrinterDetailPage() {
       toast.success('Live status refreshed');
       queryClient.invalidateQueries({ queryKey: ['printer', printer.id] });
       queryClient.invalidateQueries({ queryKey: ['printers'] });
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Refresh failed');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Refresh failed'));
     }
   };
 
@@ -153,8 +154,8 @@ export default function PrinterDetailPage() {
     try {
       const { data } = await api.post<PrinterConnectionTestResult>(`/printers/${printer.id}/test-connection`);
       data.ok ? toast.success(data.message || 'Connection successful') : toast.error(data.message || 'Connection failed');
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Connection test failed');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Connection test failed'));
     }
   };
 

--- a/frontend/src/pages/PrinterFormPage.tsx
+++ b/frontend/src/pages/PrinterFormPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { Printer, PrinterConnectionTestResult } from '@/types';
 
 const STATUS_OPTIONS = ['idle', 'printing', 'paused', 'maintenance', 'offline', 'error'] as const;
@@ -147,8 +148,8 @@ export default function PrinterFormPage() {
 
       queryClient.invalidateQueries({ queryKey: ['printers'] });
       navigate(`/printers/${id}`);
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to save printer');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to save printer'));
     } finally {
       setSaving(false);
     }
@@ -171,8 +172,8 @@ export default function PrinterFormPage() {
       const testResponse = await api.post<PrinterConnectionTestResult>(`/printers/${createdPrinter.id}/test-connection`);
       await api.delete(`/printers/${createdPrinter.id}`);
       testResponse.data.ok ? toast.success(testResponse.data.message || 'Connection successful') : toast.error(testResponse.data.message || 'Connection failed');
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Connection test failed');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Connection test failed'));
     } finally {
       setTestingConnection(false);
     }

--- a/frontend/src/pages/PrintersPage.tsx
+++ b/frontend/src/pages/PrintersPage.tsx
@@ -29,6 +29,7 @@ import Pagination from '@/components/data/Pagination';
 import { SkeletonCard } from '@/components/ui/Skeleton';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import { cn } from '@/lib/utils';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { Job, PaginatedJobs, PaginatedPrinters, Printer } from '@/types';
 
 const STATUS_OPTIONS = ['idle', 'printing', 'paused', 'maintenance', 'offline', 'error'] as const;
@@ -374,8 +375,8 @@ export default function PrintersPage() {
       }
       queryClient.invalidateQueries({ queryKey: ['printers'] });
       queryClient.invalidateQueries({ queryKey: ['printer', printer.id] });
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to update printer');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to update printer'));
     }
   };
 

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Pencil, Plus, Archive, ArchiveRestore, RotateCcw } from 'luc
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
+import { getApiErrorMessage } from '@/lib/apiError';
 import { Button } from '@/components/ui/Button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
 import ConfirmDialog from '@/components/ui/ConfirmDialog';
@@ -62,8 +63,8 @@ export default function ProductDetailPage() {
       queryClient.invalidateQueries({ queryKey: ['transactions', id] });
       setShowAdjust(false);
       setAdjForm({ type: 'adjustment', quantity: 0, notes: '' });
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to adjust stock');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to adjust stock'));
     } finally {
       setSaving(false);
     }
@@ -81,8 +82,8 @@ export default function ProductDetailPage() {
       }
       queryClient.invalidateQueries({ queryKey: ['products'] });
       queryClient.invalidateQueries({ queryKey: ['product', id] });
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to update product status');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to update product status'));
     } finally {
       setSaving(false);
     }
@@ -115,8 +116,8 @@ export default function ProductDetailPage() {
       queryClient.invalidateQueries({ queryKey: ['transactions', id] });
       queryClient.invalidateQueries({ queryKey: ['inventory-transactions'] });
       queryClient.invalidateQueries({ queryKey: ['inventory-alerts'] });
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to set stock to 0');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to set stock to 0'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/ProductEditorPage.tsx
+++ b/frontend/src/pages/ProductEditorPage.tsx
@@ -22,6 +22,7 @@ import { Label } from '@/components/ui/Label';
 import { Callout, type CalloutTone } from '@/components/ui/Callout';
 import PageHeader from '@/components/layout/PageHeader';
 import { cn, formatCurrency } from '@/lib/utils';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { InventoryTransaction, Material, PaginatedTransactions, Product } from '@/types';
 
 const emptyForm = {
@@ -131,8 +132,8 @@ export default function ProductEditorPage() {
         queryClient.invalidateQueries({ queryKey: ['products'] });
         queryClient.invalidateQueries({ queryKey: ['product', id] });
       }
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to save product');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to save product'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/RatesPage.tsx
+++ b/frontend/src/pages/RatesPage.tsx
@@ -12,6 +12,7 @@ import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { Rate } from '@/types';
 
 const emptyForm = { name: '', value: 0, unit: '$/hour', notes: '' };
@@ -58,8 +59,8 @@ export default function RatesPage() {
       }
       queryClient.invalidateQueries({ queryKey: ['rates'] });
       close();
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to save');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to save'));
     } finally { setSaving(false); }
   };
 

--- a/frontend/src/pages/SaleDetailPage.tsx
+++ b/frontend/src/pages/SaleDetailPage.tsx
@@ -13,6 +13,7 @@ import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import StatusBadge, { defaultStatusTone } from '@/components/data/StatusBadge';
 import { getShippingLabelActionLabel, getShippingLabelMissingFields } from '@/lib/shippingLabels';
 import { formatCurrency } from '@/lib/utils';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { Sale, SalesChannel } from '@/types';
 
 export default function SaleDetailPage() {
@@ -71,8 +72,8 @@ export default function SaleDetailPage() {
       await api.put(`/sales/${id}`, { status: newStatus });
       await queryClient.invalidateQueries({ queryKey: ['sale', id] });
       toast.success(`Status updated to ${newStatus}`);
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to update');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to update'));
     }
   };
 
@@ -81,8 +82,8 @@ export default function SaleDetailPage() {
       await api.post(`/sales/${id}/refund`);
       await queryClient.invalidateQueries({ queryKey: ['sale', id] });
       toast.success('Sale refunded');
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to refund');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to refund'));
     }
   };
 
@@ -112,8 +113,8 @@ export default function SaleDetailPage() {
       });
       await queryClient.invalidateQueries({ queryKey: ['sale', id] });
       toast.success('Shipment details saved');
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to save shipment details');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to save shipment details'));
     } finally {
       setSavingShipment(false);
     }
@@ -144,9 +145,9 @@ export default function SaleDetailPage() {
       }, 250);
       await queryClient.invalidateQueries({ queryKey: ['sale', id] });
       toast.success('Print dialog opened on this workstation. Mark the label printed after a successful thermal print.');
-    } catch (err: any) {
+    } catch (err) {
       printWindow.close();
-      toast.error(err.response?.data?.detail || 'Failed to open shipping label');
+      toast.error(getApiErrorMessage(err, 'Failed to open shipping label'));
     } finally {
       setPrintingLabel(false);
     }
@@ -158,8 +159,8 @@ export default function SaleDetailPage() {
       await api.post(`/sales/${id}/shipping-label/mark-printed`);
       await queryClient.invalidateQueries({ queryKey: ['sale', id] });
       toast.success('Label marked as printed');
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to mark label printed');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to mark label printed'));
     } finally {
       setMarkingPrinted(false);
     }

--- a/frontend/src/pages/SaleFormPage.tsx
+++ b/frontend/src/pages/SaleFormPage.tsx
@@ -10,6 +10,7 @@ import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
 import PageHeader from '@/components/layout/PageHeader';
 import { formatCurrency } from '@/lib/utils';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { SalesChannel, PaginatedProducts, Customer } from '@/types';
 
 interface LineItem {
@@ -125,8 +126,8 @@ export default function SaleFormPage() {
       const resp = await api.post('/sales', payload);
       toast.success('Sale created');
       navigate(`/sales/${resp.data.id}`);
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to create sale');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to create sale'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/SalesChannelsPage.tsx
+++ b/frontend/src/pages/SalesChannelsPage.tsx
@@ -11,6 +11,7 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
 import StatusBadge from '@/components/data/StatusBadge';
 import DataTable, { type Column } from '@/components/data/DataTable';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { SalesChannel } from '@/types';
 
 const emptyForm = { name: '', platform_fee_pct: 0, fixed_fee: 0, is_active: true };
@@ -51,8 +52,8 @@ export default function SalesChannelsPage() {
       }
       queryClient.invalidateQueries({ queryKey: ['sales-channels'] });
       close();
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to save');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to save'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/admin/CamerasPage.tsx
+++ b/frontend/src/pages/admin/CamerasPage.tsx
@@ -11,6 +11,7 @@ import { Textarea } from '@/components/ui/Textarea';
 import { Label } from '@/components/ui/Label';
 import DataTable, { type Column } from '@/components/data/DataTable';
 import { Skeleton } from '@/components/ui/Skeleton';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { Camera, PaginatedCameras, PaginatedPrinters } from '@/types';
 
 type ModalMode = 'create' | 'edit' | null;
@@ -79,8 +80,8 @@ export default function CamerasPage() {
       qc.invalidateQueries({ queryKey: ['printers'] });
       closeModal();
     },
-    onError: (err: any) => {
-      toast.error(err?.response?.data?.detail || 'Failed to save camera');
+    onError: (err) => {
+      toast.error(getApiErrorMessage(err, 'Failed to save camera'));
     },
   });
 

--- a/frontend/src/pages/admin/SettingsPage.tsx
+++ b/frontend/src/pages/admin/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import api from '@/api/client';
 import { Button } from '@/components/ui/Button';
 import { SkeletonCard } from '@/components/ui/Skeleton';
+import { getApiErrorMessage } from '@/lib/apiError';
 import type { Setting } from '@/types';
 
 const groups: Record<string, { keys: string[]; description: string }> = {
@@ -67,8 +68,8 @@ export default function SettingsPage() {
       queryClient.invalidateQueries({ queryKey: ['settings'] });
       toast.success('Settings saved');
       setDirty(false);
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to save settings');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to save settings'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -12,6 +12,7 @@ import ConfirmDialog from '@/components/ui/ConfirmDialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
 import StatusBadge from '@/components/data/StatusBadge';
 import DataTable, { type Column } from '@/components/data/DataTable';
+import { getApiErrorMessage } from '@/lib/apiError';
 
 interface UserRecord {
   id: string;
@@ -64,8 +65,8 @@ export default function UsersPage() {
       }
       queryClient.invalidateQueries({ queryKey: ['users'] });
       close();
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to save');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to save'));
     } finally { setSaving(false); }
   };
 
@@ -74,8 +75,8 @@ export default function UsersPage() {
       await api.delete(`/auth/users/${u.id}`);
       toast.success(`${u.full_name} deactivated`);
       queryClient.invalidateQueries({ queryKey: ['users'] });
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to deactivate');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to deactivate'));
     }
   };
 
@@ -84,8 +85,8 @@ export default function UsersPage() {
       await api.put(`/auth/users/${u.id}`, { is_active: true });
       toast.success(`${u.full_name} reactivated`);
       queryClient.invalidateQueries({ queryKey: ['users'] });
-    } catch (err: any) {
-      toast.error(err.response?.data?.detail || 'Failed to reactivate');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to reactivate'));
     }
   };
 


### PR DESCRIPTION
## Problem

Saving AI provider settings in Admin → Settings surfaced:

> Minified React error #31; visit https://react.dev/errors/31?args[]=object%20with%20keys%20%7Btype%2C%20loc%2C%20msg%2C%20input%7D

Root cause: FastAPI returns Pydantic 422 validation errors as an array of `{ type, loc, msg, input }` objects. Throughout the app, catch handlers did:

```tsx
toast.error(err.response?.data?.detail || 'Failed to save');
```

When `detail` was the validation array, `toast.error(arr)` tried to render each object as a React child and crashed.

## Fix

New helper at `frontend/src/lib/apiError.ts`:

```ts
export function getApiErrorMessage(err: unknown, fallback?: string): string
```

- String detail → returns as-is
- Pydantic array → joins `field.path: msg` entries with `·`
- Network error → axios message
- Otherwise → fallback

Covered by 6 unit tests in `apiError.test.ts`.

Swept all 35 `err.response.data.detail` usages across 21 pages to use the helper. POSPage's `getErrorDetail` kept as a thin wrapper so callers don't need to change.

## Acceptance

- [x] `rg 'response\?\.data\?\.detail|response\.data\.detail' src` → **0**
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → **50 tests passing** (44 prior + 6 new)

## Test plan

- [ ] Admin → Settings → pick an AI provider but leave the API key blank → Save. Should show a specific validation message (e.g. `settings.ai_openai_api_key.value: Input should be a valid string`) rather than crashing with React #31
- [ ] Any form submit that violates backend validation (e.g. create a material with invalid spool weight) shows the field-level message
- [ ] Network failure (stop backend) shows axios-level `"Network Error"` or a readable fallback rather than an empty toast
- [ ] POS checkout with out-of-stock item still shows the backend's HTTPException detail string

🤖 Generated with [Claude Code](https://claude.com/claude-code)