### PR TITLE
fix(api): /settings/bulk route shadowed by /{key}

### DIFF
--- a/backend/app/api/v1/endpoints/settings.py
+++ b/backend/app/api/v1/endpoints/settings.py
@@ -40,27 +40,6 @@ async def get_setting(key: str, admin: CurrentAdmin, db: DB):
 
 
 @router.put(
-    "/{key}",
-    response_model=SettingResponse,
-    summary="Update a setting",
-    description="Admin-only. Update the value of an existing configuration setting.",
-)
-async def update_setting(key: str, body: SettingUpdate, admin: CurrentAdmin, db: DB):
-    from app.models.setting import Setting
-
-    result = await db.execute(select(Setting).where(Setting.key == key))
-    setting = result.scalar_one_or_none()
-    if not setting:
-        raise HTTPException(status_code=404, detail=f"Setting '{key}' not found")
-    before = {"key": setting.key, "value": setting.value}
-    setting.value = body.value
-    await create_audit_log(db, actor_user_id=admin.id, entity_type="setting", entity_id=setting.key, action="update", before_snapshot=before, after_snapshot={"key": setting.key, "value": setting.value})
-    await db.commit()
-    await db.refresh(setting)
-    return setting
-
-
-@router.put(
     "/bulk",
     response_model=list[SettingResponse],
     summary="Bulk update settings",
@@ -80,3 +59,24 @@ async def bulk_update_settings(body: BulkSettingUpdate, admin: CurrentAdmin, db:
             updated.append(setting)
     await db.commit()
     return updated
+
+
+@router.put(
+    "/{key}",
+    response_model=SettingResponse,
+    summary="Update a setting",
+    description="Admin-only. Update the value of an existing configuration setting.",
+)
+async def update_setting(key: str, body: SettingUpdate, admin: CurrentAdmin, db: DB):
+    from app.models.setting import Setting
+
+    result = await db.execute(select(Setting).where(Setting.key == key))
+    setting = result.scalar_one_or_none()
+    if not setting:
+        raise HTTPException(status_code=404, detail=f"Setting '{key}' not found")
+    before = {"key": setting.key, "value": setting.value}
+    setting.value = body.value
+    await create_audit_log(db, actor_user_id=admin.id, entity_type="setting", entity_id=setting.key, action="update", before_snapshot=before, after_snapshot={"key": setting.key, "value": setting.value})
+    await db.commit()
+    await db.refresh(setting)
+    return setting

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -71,3 +71,51 @@ async def test_update_setting_requires_auth(client, seed_settings):
 async def test_list_settings_requires_admin(client, seed_settings, user_headers):
     resp = await client.get("/api/v1/settings", headers=user_headers)
     assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_settings(client, seed_settings, auth_headers):
+    """Regression: PUT /settings/bulk must hit the bulk handler (not /{key}).
+
+    Previously the /{key} route was registered before /bulk, so POSTing to
+    /settings/bulk matched with key="bulk" and validated against
+    SettingUpdate (single-value schema), producing a "value: Field required"
+    422 that the frontend couldn't explain to the user.
+    """
+    resp = await client.put(
+        "/api/v1/settings/bulk",
+        json={"settings": {"platform_fee_pct": "11.25", "currency": "EUR"}},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    data = resp.json()
+    assert isinstance(data, list)
+    keys = {row["key"]: row["value"] for row in data}
+    assert keys["platform_fee_pct"] == "11.25"
+    assert keys["currency"] == "EUR"
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_settings_requires_admin(client, seed_settings, user_headers):
+    resp = await client.put(
+        "/api/v1/settings/bulk",
+        json={"settings": {"platform_fee_pct": "11.25"}},
+        headers=user_headers,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_settings_skips_unknown_keys(
+    client, seed_settings, auth_headers
+):
+    """Unknown keys in the bulk payload are silently ignored (no 404)."""
+    resp = await client.put(
+        "/api/v1/settings/bulk",
+        json={"settings": {"currency": "GBP", "some_unknown_key": "x"}},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    keys = {row["key"]: row["value"] for row in resp.json()}
+    assert keys.get("currency") == "GBP"
+    assert "some_unknown_key" not in keys


### PR DESCRIPTION
## Problem

User reported (after #224 made validation errors readable): *"it is telling me there is a required field that it needs but do not see one."*

The toast from Admin → Settings said `body.value: Field required` — a field the frontend never sends and the UI doesn't expose. Users can't fix it because they don't know where `value` is supposed to come from.

## Root cause

`backend/app/api/v1/endpoints/settings.py` declared routes in this order:

```py
@router.put("/{key}")  # line 42 — catches /bulk as key="bulk"
@router.put("/bulk")    # line 63 — never reached
```

FastAPI dispatches routes in registration order. `PUT /settings/bulk` matched the first route with `key="bulk"` and validated against `SettingUpdate` (`{ value: str }`) — which fails because the frontend sends `{ settings: {...} }`.

The bulk handler was unreachable from the time it was added.

## Fix

Swap the declarations: `/bulk` (literal path) now comes first, `/{key}` (catch-all) second. This is the standard FastAPI pattern for parameterized routes.

## Regression tests

Added 3 tests in `backend/tests/test_api_settings.py`:

- `test_bulk_update_settings` — happy path returns 200 with updated rows
- `test_bulk_update_settings_requires_admin` — non-admin gets 403
- `test_bulk_update_settings_skips_unknown_keys` — unknown keys silently skipped (no 404)

The happy-path test would have caught this regression immediately — before the fix it would return 422 `body.value: Field required`.

## Test plan

- [ ] After merge + deploy, go to Admin → Settings, change any field, click Save → toast shows "Settings saved" (not a validation error)
- [ ] Change the AI provider + API key + model together and save → all three persist
- [ ] `python3 -m pytest backend/tests/test_api_settings.py` → 10 tests pass (was 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)