### PR TITLE
feat(ui): barcode + QR label generator for products (#227)

### DIFF
--- a/backend/alembic/versions/20260420_01_add_barcode_settings.py
+++ b/backend/alembic/versions/20260420_01_add_barcode_settings.py
@@ -1,0 +1,49 @@
+"""add barcode / label settings
+
+Revision ID: 20260420_01
+Revises: 20260413_02
+Create Date: 2026-04-20 08:00:00
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+from app.services.settings_defaults import LABEL_SETTINGS_DATA
+
+
+revision = "20260420_01"
+down_revision = "20260413_02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    for key, value, notes in LABEL_SETTINGS_DATA:
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO settings (id, key, value, notes, updated_at)
+                VALUES (:id, :key, :value, :notes, NOW())
+                ON CONFLICT (key) DO NOTHING
+                """
+            ).bindparams(
+                id=uuid.uuid4(),
+                key=key,
+                value=value,
+                notes=notes,
+            )
+        )
+
+
+def downgrade() -> None:
+    keys = [key for key, _, _ in LABEL_SETTINGS_DATA]
+    op.execute(
+        sa.text("DELETE FROM settings WHERE key IN :keys").bindparams(
+            sa.bindparam("keys", expanding=True)
+        ),
+        {"keys": keys},
+    )

--- a/backend/app/api/v1/endpoints/products.py
+++ b/backend/app/api/v1/endpoints/products.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Response
 from sqlalchemy import func, select
 
 from app.api.deps import DB, CurrentUser
@@ -13,6 +13,7 @@ from app.schemas.product import (
     ProductResponse,
     ProductUpdate,
 )
+from app.services.barcode_service import BarcodeFormat, render_barcode
 from app.services.inventory_service import generate_sku
 
 router = APIRouter(prefix="/products", tags=["Products"])
@@ -143,3 +144,55 @@ async def delete_product(product_id: uuid.UUID, user: CurrentUser, db: DB):
         raise HTTPException(status_code=404, detail="Product not found")
     product.is_active = False
     await db.commit()
+
+
+@router.get(
+    "/{product_id}/barcode",
+    summary="Generate a printable barcode for a product",
+    description=(
+        "Returns a PNG-encoded barcode or QR code for the given product. "
+        "`format=code128` (default) encodes the product SKU; `format=upc` "
+        "encodes the UPC-A value and requires the product to have a 12-digit "
+        "UPC; `format=qr` encodes either the UPC/SKU or the product URL when "
+        "`url=1` is set."
+    ),
+    responses={200: {"content": {"image/png": {}}}},
+)
+async def get_product_barcode(
+    product_id: uuid.UUID,
+    user: CurrentUser,
+    db: DB,
+    format: BarcodeFormat = Query("code128", description="Barcode format"),
+    size: int = Query(2, ge=1, le=20, description="Visual size hint (1-20)"),
+    url: bool = Query(
+        False,
+        description="When format=qr, encode the public product URL instead of UPC/SKU.",
+    ),
+):
+    result = await db.execute(select(Product).where(Product.id == product_id))
+    product = result.scalar_one_or_none()
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+
+    if format == "qr" and url:
+        payload = f"/product-studio/products/{product.id}"
+    elif format == "upc":
+        if not product.upc:
+            raise HTTPException(
+                status_code=400,
+                detail="Product has no UPC assigned; use format=code128 or format=qr instead.",
+            )
+        payload = product.upc
+    else:
+        payload = product.upc or product.sku
+
+    try:
+        png = render_barcode(format=format, payload=payload, size=size)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return Response(
+        content=png,
+        media_type="image/png",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )

--- a/backend/app/services/barcode_service.py
+++ b/backend/app/services/barcode_service.py
@@ -1,0 +1,98 @@
+"""Barcode and QR code rendering for product labels.
+
+Wraps `python-barcode` (Code128 / UPC-A) and `qrcode` so the product
+endpoint can return a ready-to-print PNG. Kept behind a thin service so
+tests can stub or swap the libraries later (e.g. switch to SVG output,
+server-side caching, thermal-printer-specific DPI tweaks).
+
+Formats:
+- ``code128`` — works with any alphanumeric SKU; default for products
+  without a UPC.
+- ``upc`` — UPC-A; requires a 12-digit numeric input. Raises
+  ``ValueError`` when the product's UPC is empty or the wrong length.
+- ``qr`` — square QR code; caller decides whether to encode the UPC,
+  SKU, or a full product URL.
+"""
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Literal
+
+import barcode
+import qrcode
+from barcode.writer import ImageWriter
+
+BarcodeFormat = Literal["code128", "upc", "qr"]
+
+# UPC-A is exactly 12 numeric digits. python-barcode raises if the
+# length or charset is wrong, but we preflight for a cleaner 400.
+_UPC_LENGTH = 12
+
+
+def render_barcode(
+    *,
+    format: BarcodeFormat,
+    payload: str,
+    size: int = 2,
+) -> bytes:
+    """Render a barcode or QR code to PNG bytes.
+
+    :param format: ``code128`` | ``upc`` | ``qr``.
+    :param payload: String content to encode (SKU, UPC, or URL).
+    :param size: Visual size hint. For 1D barcodes this is the module
+        width in pixels (writer ``module_width``). For QR this is the
+        ``box_size`` in pixels.
+    :raises ValueError: If ``payload`` is empty, or the format-specific
+        validation fails (e.g. UPC must be 12 digits).
+    """
+    if not payload:
+        raise ValueError("Barcode payload is empty")
+
+    size = max(1, min(int(size), 20))
+
+    if format == "qr":
+        return _render_qr(payload, box_size=size * 4)
+
+    if format == "upc":
+        if len(payload) != _UPC_LENGTH or not payload.isdigit():
+            raise ValueError("UPC-A payload must be exactly 12 numeric digits")
+        return _render_1d("upca", payload[:-1], module_width=size)
+
+    if format == "code128":
+        return _render_1d("code128", payload, module_width=size)
+
+    raise ValueError(f"Unknown barcode format: {format!r}")
+
+
+def _render_1d(symbology: str, data: str, *, module_width: int) -> bytes:
+    writer = ImageWriter()
+    # module_width is in mm for python-barcode; scale up so 1 ≈ 0.2mm
+    # produces a sharp ~2px bar on screen. Size 2 → 0.4mm ≈ 4px.
+    options = {
+        "module_width": max(0.2, module_width * 0.2),
+        "module_height": 15.0,
+        "font_size": 10,
+        "text_distance": 4.0,
+        "quiet_zone": 4.0,
+        "write_text": True,
+    }
+    barcode_cls = barcode.get_barcode_class(symbology)
+    instance = barcode_cls(data, writer=writer)
+    buf = BytesIO()
+    instance.write(buf, options=options)
+    return buf.getvalue()
+
+
+def _render_qr(data: str, *, box_size: int) -> bytes:
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=box_size,
+        border=2,
+    )
+    qr.add_data(data)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white")
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()

--- a/backend/app/services/settings_defaults.py
+++ b/backend/app/services/settings_defaults.py
@@ -21,4 +21,10 @@ AI_SETTINGS_DATA = [
     ("ai_grok_api_key", "", "xAI API key for Grok insights."),
 ]
 
-SETTINGS_DATA = BUSINESS_SETTINGS_DATA + AI_SETTINGS_DATA
+LABEL_SETTINGS_DATA = [
+    ("barcode_default_format", "code128", "Default barcode format: code128, upc, or qr."),
+    ("barcode_label_template", "avery_5160", "Label sheet template: avery_5160 or continuous_roll_2x1."),
+    ("barcode_include_price", "false", "Include unit price on printed labels."),
+]
+
+SETTINGS_DATA = BUSINESS_SETTINGS_DATA + AI_SETTINGS_DATA + LABEL_SETTINGS_DATA

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,6 @@ httpx==0.28.1
 pytest==8.3.4
 pytest-asyncio==0.25.0
 aiosqlite==0.20.0
+python-barcode==0.15.1
+qrcode[pil]==8.0
+Pillow==11.1.0

--- a/backend/tests/test_api_products.py
+++ b/backend/tests/test_api_products.py
@@ -186,3 +186,82 @@ async def test_sku_auto_generation(client: AsyncClient, auth_headers: dict, seed
     )
     assert resp1.json()["sku"] == "PRD-PLA-0001"
     assert resp2.json()["sku"] == "PRD-PLA-0002"
+
+
+def _make_product_body(name: str, material_id: str, upc: str | None = None) -> dict:
+    body: dict = {"name": name, "material_id": material_id}
+    if upc is not None:
+        body["upc"] = upc
+    return body
+
+
+@pytest.mark.asyncio
+async def test_product_barcode_default_code128(
+    client: AsyncClient, auth_headers: dict, seed_material: Material
+):
+    create = await client.post(
+        "/api/v1/products",
+        headers=auth_headers,
+        json=_make_product_body("Barcode target", str(seed_material.id)),
+    )
+    product_id = create.json()["id"]
+
+    resp = await client.get(
+        f"/api/v1/products/{product_id}/barcode", headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"] == "image/png"
+    assert resp.content[:8] == b"\x89PNG\r\n\x1a\n"
+    assert "max-age" in resp.headers.get("cache-control", "")
+
+
+@pytest.mark.asyncio
+async def test_product_barcode_qr(
+    client: AsyncClient, auth_headers: dict, seed_material: Material
+):
+    create = await client.post(
+        "/api/v1/products",
+        headers=auth_headers,
+        json=_make_product_body("QR target", str(seed_material.id)),
+    )
+    product_id = create.json()["id"]
+
+    resp = await client.get(
+        f"/api/v1/products/{product_id}/barcode",
+        params={"format": "qr"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"] == "image/png"
+    assert resp.content[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+@pytest.mark.asyncio
+async def test_product_barcode_upc_without_upc_returns_400(
+    client: AsyncClient, auth_headers: dict, seed_material: Material
+):
+    create = await client.post(
+        "/api/v1/products",
+        headers=auth_headers,
+        json=_make_product_body("No UPC here", str(seed_material.id)),
+    )
+    product_id = create.json()["id"]
+
+    resp = await client.get(
+        f"/api/v1/products/{product_id}/barcode",
+        params={"format": "upc"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+    assert "UPC" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_product_barcode_missing_product_returns_404(
+    client: AsyncClient, auth_headers: dict
+):
+    resp = await client.get(
+        "/api/v1/products/00000000-0000-0000-0000-000000000000/barcode",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ const RatesPage = lazy(() => import('@/pages/RatesPage'));
 const CustomersPage = lazy(() => import('@/pages/CustomersPage'));
 const ProductsPage = lazy(() => import('@/pages/ProductsPage'));
 const ProductEditorPage = lazy(() => import('@/pages/ProductEditorPage'));
+const ProductLabelsPage = lazy(() => import('@/pages/ProductLabelsPage'));
 const ProductDetailPage = lazy(() => import('@/pages/ProductDetailPage'));
 const PrintersPage = lazy(() => import('@/pages/PrintersPage'));
 const PrinterDetailPage = lazy(() => import('@/pages/PrinterDetailPage'));
@@ -116,6 +117,7 @@ export default function App() {
                 <Route path="/product-studio/products/:id/edit" element={<ProductEditorPage />} />
                 <Route path="/product-studio/calculator" element={<CalculatorPage />} />
                 <Route path="/product-studio/rates" element={<RatesPage />} />
+                <Route path="/product-studio/labels" element={<ProductLabelsPage />} />
 
                 <Route path="/orders" element={<OrdersPage />} />
                 <Route path="/orders/jobs" element={<JobsPage />} />

--- a/frontend/src/components/labels/ProductLabel.tsx
+++ b/frontend/src/components/labels/ProductLabel.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from 'react';
+import { cn, formatCurrency } from '@/lib/utils';
+import { fetchBarcodeObjectUrl, type BarcodeFormat } from '@/lib/barcode';
+import type { Product } from '@/types';
+
+interface ProductLabelProps {
+  product: Product;
+  format: BarcodeFormat;
+  includePrice?: boolean;
+  /** Avery-5160 cell size is 2.625 × 1 in. Pass `compact` for sheet use. */
+  variant?: 'preview' | 'compact';
+  /** Optional className override on the outer card. */
+  className?: string;
+}
+
+/**
+ * Standalone printable product label. Renders name + SKU/UPC + barcode
+ * (+ optional price). Styled to print cleanly inside an Avery 5160
+ * cell when `variant="compact"`, or as a preview card otherwise.
+ */
+export default function ProductLabel({
+  product,
+  format,
+  includePrice = false,
+  variant = 'preview',
+  className,
+}: ProductLabelProps) {
+  const [src, setSrc] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let objectUrl: string | null = null;
+    let cancelled = false;
+    setError(null);
+    setSrc(null);
+
+    fetchBarcodeObjectUrl(product.id, { format, size: variant === 'compact' ? 2 : 3 })
+      .then((url) => {
+        objectUrl = url;
+        if (!cancelled) setSrc(url);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          const detail = err?.response?.data;
+          setError(
+            typeof detail === 'string'
+              ? detail
+              : 'Unable to render this barcode format for this product.',
+          );
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [product.id, format, variant]);
+
+  const isCompact = variant === 'compact';
+
+  return (
+    <div
+      className={cn(
+        'label-card flex flex-col items-center justify-between gap-1 rounded-md border border-border bg-card text-center text-foreground',
+        isCompact ? 'p-1 text-[0.6rem]' : 'p-4 text-sm',
+        className,
+      )}
+    >
+      <div className="w-full min-w-0">
+        <p
+          className={cn(
+            'truncate font-semibold',
+            isCompact ? 'text-[0.65rem] leading-tight' : 'text-sm',
+          )}
+          title={product.name}
+        >
+          {product.name}
+        </p>
+        <p
+          className={cn(
+            'truncate font-mono text-muted-foreground',
+            isCompact ? 'text-[0.55rem]' : 'text-xs',
+          )}
+        >
+          {product.sku}
+        </p>
+      </div>
+
+      <div className={cn('flex w-full items-center justify-center', isCompact ? 'h-[0.9in]' : 'h-32')}>
+        {error ? (
+          <span className="text-[0.55rem] text-destructive">{error}</span>
+        ) : src ? (
+          <img
+            src={src}
+            alt={`${product.name} ${format} barcode`}
+            className={cn('max-h-full max-w-full object-contain', format === 'qr' && 'aspect-square')}
+          />
+        ) : (
+          <span className="text-[0.55rem] text-muted-foreground">Loading…</span>
+        )}
+      </div>
+
+      {includePrice ? (
+        <p
+          className={cn(
+            'font-semibold tabular-nums',
+            isCompact ? 'text-[0.65rem]' : 'text-sm',
+          )}
+        >
+          {formatCurrency(product.unit_price)}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Open a blank window and render `html` with a minimal print-friendly
+ * stylesheet. Window auto-triggers `window.print()` once the content is
+ * loaded; the user can choose their printer from the browser dialog.
+ */
+export function openPrintWindow(title: string, bodyHtml: string, extraCss = '') {
+  const win = window.open('', '_blank', 'noopener,noreferrer,width=800,height=900');
+  if (!win) return;
+  win.document.open();
+  win.document.write(`<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>${title}</title>
+    <style>
+      :root { color-scheme: light; }
+      body { margin: 0; padding: 24px; font-family: ui-sans-serif, system-ui, sans-serif; color: #0f172a; background: #fff; }
+      h1 { font-size: 14px; margin: 0 0 16px; }
+      .label {
+        display: flex; flex-direction: column; align-items: center; gap: 4px;
+        border: 1px solid #cbd5e1; border-radius: 6px; padding: 12px; text-align: center;
+      }
+      .label .name { font-weight: 600; font-size: 12px; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .label .sku { font-family: ui-monospace, monospace; font-size: 10px; color: #475569; }
+      .label .price { font-weight: 600; font-size: 12px; margin-top: 2px; }
+      .label img { max-width: 100%; height: auto; }
+      .sheet { display: grid; grid-template-columns: repeat(3, 2.625in); grid-auto-rows: 1in; gap: 0; border: 0; }
+      .sheet .label { border: 1px dashed #e2e8f0; border-radius: 0; padding: 4px; gap: 2px; }
+      .sheet .label .name { font-size: 9px; }
+      .sheet .label .sku { font-size: 7px; }
+      .sheet .label .price { font-size: 9px; }
+      @media print {
+        body { padding: 0; }
+        h1 { display: none; }
+        .label, .sheet .label { border-color: transparent; page-break-inside: avoid; }
+      }
+      ${extraCss}
+    </style>
+  </head>
+  <body>
+    ${bodyHtml}
+    <script>
+      window.addEventListener('load', () => {
+        setTimeout(() => window.print(), 50);
+      });
+    </script>
+  </body>
+</html>`);
+  win.document.close();
+}

--- a/frontend/src/components/layout/workspaces.ts
+++ b/frontend/src/components/layout/workspaces.ts
@@ -102,6 +102,7 @@ export const workspaces: WorkspaceDefinition[] = [
       { to: '/product-studio', label: 'Products', matchPrefixes: ['/product-studio', '/products'] },
       { to: '/product-studio/calculator', label: 'Calculator', matchPrefixes: ['/product-studio/calculator', '/calculator'] },
       { to: '/product-studio/rates', label: 'Rates', matchPrefixes: ['/product-studio/rates', '/rates'] },
+      { to: '/product-studio/labels', label: 'Labels', matchPrefixes: ['/product-studio/labels'] },
     ],
   },
   {

--- a/frontend/src/components/ui/CommandPalette.tsx
+++ b/frontend/src/components/ui/CommandPalette.tsx
@@ -169,6 +169,7 @@ export function useDefaultCommandGroups(): CommandGroupDef[] {
         { id: 'customers-list', label: 'View customers', icon: <UsersRound className="h-4 w-4" />, to: '/orders/customers' },
         { id: 'products-list', label: 'View products', icon: <Box className="h-4 w-4" />, to: '/product-studio/products' },
         { id: 'materials-list', label: 'View materials', icon: <Package className="h-4 w-4" />, to: '/stock/materials' },
+        { id: 'print-labels', label: 'Print product labels', keywords: ['barcode', 'qr', 'sheet', 'avery'], icon: <ScanLine className="h-4 w-4" />, to: '/product-studio/labels' },
       ],
     },
     {

--- a/frontend/src/hooks/useLabelSettings.ts
+++ b/frontend/src/hooks/useLabelSettings.ts
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/api/client';
+import type { BarcodeFormat } from '@/lib/barcode';
+import type { Setting } from '@/types';
+
+export type LabelTemplate = 'avery_5160' | 'continuous_roll_2x1';
+
+export interface LabelSettings {
+  defaultFormat: BarcodeFormat;
+  labelTemplate: LabelTemplate;
+  includePrice: boolean;
+}
+
+const DEFAULTS: LabelSettings = {
+  defaultFormat: 'code128',
+  labelTemplate: 'avery_5160',
+  includePrice: false,
+};
+
+function parseBool(value: string | undefined): boolean {
+  return value === 'true' || value === '1';
+}
+
+function parseFormat(value: string | undefined): BarcodeFormat {
+  return value === 'qr' || value === 'upc' ? value : 'code128';
+}
+
+function parseTemplate(value: string | undefined): LabelTemplate {
+  return value === 'continuous_roll_2x1' ? 'continuous_roll_2x1' : 'avery_5160';
+}
+
+/**
+ * Reads the three barcode-label settings from `/settings` and returns
+ * typed defaults. Shares the same `['settings']` query key as
+ * SettingsPage so edits propagate automatically.
+ */
+export function useLabelSettings(): LabelSettings {
+  const { data: settings } = useQuery<Setting[]>({
+    queryKey: ['settings'],
+    queryFn: () => api.get('/settings').then((r) => r.data),
+  });
+
+  if (!settings) return DEFAULTS;
+  const map = new Map(settings.map((s) => [s.key, s.value]));
+  return {
+    defaultFormat: parseFormat(map.get('barcode_default_format')),
+    labelTemplate: parseTemplate(map.get('barcode_label_template')),
+    includePrice: parseBool(map.get('barcode_include_price')),
+  };
+}

--- a/frontend/src/lib/barcode.ts
+++ b/frontend/src/lib/barcode.ts
@@ -1,0 +1,56 @@
+import api from '@/api/client';
+
+export type BarcodeFormat = 'code128' | 'upc' | 'qr';
+
+export interface BarcodeOptions {
+  format?: BarcodeFormat;
+  size?: number;
+  /** When format=qr, encode the public product URL instead of UPC/SKU. */
+  url?: boolean;
+}
+
+/** Build the relative URL (uses client baseURL) for direct <img src> use. */
+export function buildBarcodeUrl(productId: string, opts: BarcodeOptions = {}): string {
+  const params = new URLSearchParams();
+  if (opts.format) params.set('format', opts.format);
+  if (opts.size) params.set('size', String(opts.size));
+  if (opts.url) params.set('url', '1');
+  const qs = params.toString();
+  return `/products/${productId}/barcode${qs ? `?${qs}` : ''}`;
+}
+
+/**
+ * Fetch a barcode PNG as a blob object URL. Callers are responsible for
+ * revoking the URL when the component unmounts (use the returned object
+ * with `URL.revokeObjectURL` on cleanup).
+ */
+export async function fetchBarcodeObjectUrl(
+  productId: string,
+  opts: BarcodeOptions = {},
+): Promise<string> {
+  const resp = await api.get(buildBarcodeUrl(productId, opts), {
+    responseType: 'blob',
+  });
+  return URL.createObjectURL(resp.data as Blob);
+}
+
+/**
+ * Fetch a barcode PNG as a self-contained data URL. Useful when the
+ * image needs to render in a separate window (print popup) that can't
+ * inherit the caller's auth state.
+ */
+export async function fetchBarcodeDataUrl(
+  productId: string,
+  opts: BarcodeOptions = {},
+): Promise<string> {
+  const resp = await api.get(buildBarcodeUrl(productId, opts), {
+    responseType: 'blob',
+  });
+  const blob = resp.data as Blob;
+  return await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}

--- a/frontend/src/lib/printLabels.ts
+++ b/frontend/src/lib/printLabels.ts
@@ -1,0 +1,77 @@
+import { fetchBarcodeDataUrl, type BarcodeFormat } from '@/lib/barcode';
+import { formatCurrency } from '@/lib/utils';
+import { openPrintWindow } from '@/components/labels/ProductLabel';
+import type { Product } from '@/types';
+
+export interface PrintOptions {
+  format: BarcodeFormat;
+  includePrice?: boolean;
+  /** Render a 30-up Avery 5160 sheet when true; single-label layout otherwise. */
+  sheet?: boolean;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+async function renderLabelHtml(
+  product: Product,
+  format: BarcodeFormat,
+  includePrice: boolean,
+): Promise<string> {
+  let imgTag = '';
+  try {
+    const dataUrl = await fetchBarcodeDataUrl(product.id, { format });
+    imgTag = `<img src="${dataUrl}" alt="${escapeHtml(product.name)} ${format} barcode" />`;
+  } catch (err) {
+    imgTag = `<span class="err">${escapeHtml(
+      (err as Error)?.message ?? 'Unable to render barcode',
+    )}</span>`;
+  }
+  const priceHtml = includePrice
+    ? `<div class="price">${escapeHtml(formatCurrency(product.unit_price))}</div>`
+    : '';
+  return `
+    <div class="label">
+      <div class="name">${escapeHtml(product.name)}</div>
+      <div class="sku">${escapeHtml(product.sku)}</div>
+      ${imgTag}
+      ${priceHtml}
+    </div>
+  `;
+}
+
+/**
+ * Open a print-ready window with one or more product labels. For single
+ * labels the popup is a centered card; for `sheet: true` it renders
+ * a 30-up Avery 5160 grid.
+ */
+export async function printProductLabels(
+  products: Product[],
+  opts: PrintOptions,
+): Promise<void> {
+  if (!products.length) return;
+
+  const html = await Promise.all(
+    products.map((p) => renderLabelHtml(p, opts.format, opts.includePrice ?? false)),
+  );
+
+  if (opts.sheet) {
+    openPrintWindow(
+      `Labels (${products.length})`,
+      `<div class="sheet">${html.join('\n')}</div>`,
+    );
+    return;
+  }
+
+  const title = products[0]?.name ? `Label — ${products[0].name}` : 'Label';
+  openPrintWindow(
+    title,
+    `<h1>${escapeHtml(title)}</h1><div style="max-width: 360px; margin: 0 auto;">${html.join('\n')}</div>`,
+  );
+}

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Pencil, Plus, Archive, ArchiveRestore, RotateCcw } from 'lucide-react';
+import { ArrowLeft, Pencil, Plus, Archive, ArchiveRestore, Printer, RotateCcw } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import { formatCurrency } from '@/lib/utils';
 import { getApiErrorMessage } from '@/lib/apiError';
+import { printProductLabels } from '@/lib/printLabels';
+import { useLabelSettings } from '@/hooks/useLabelSettings';
+import ProductLabel from '@/components/labels/ProductLabel';
+import type { BarcodeFormat } from '@/lib/barcode';
 import { Button } from '@/components/ui/Button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
 import ConfirmDialog from '@/components/ui/ConfirmDialog';
@@ -46,6 +50,8 @@ export default function ProductDetailPage() {
   const [zeroReason, setZeroReason] = useState('');
   const [saving, setSaving] = useState(false);
   const [confirmToggle, setConfirmToggle] = useState(false);
+  const labelSettings = useLabelSettings();
+  const [labelFormat, setLabelFormat] = useState<BarcodeFormat | null>(null);
 
   const submitAdjustment = async () => {
     if (adjForm.quantity === 0) { toast.error('Quantity cannot be 0'); return; }
@@ -195,6 +201,56 @@ export default function ProductDetailPage() {
             </p>
           </div>
         )}
+      </div>
+
+      {/* Label preview */}
+      <div className="mb-6 rounded-md border border-border bg-card p-5 shadow-xs">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-base font-semibold">Label</h2>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Print a barcode or QR label for this product. Format defaults come from Admin → Settings.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {(['code128', 'upc', 'qr'] as const).map((fmt) => {
+              const active = (labelFormat ?? labelSettings.defaultFormat) === fmt;
+              const disabled = fmt === 'upc' && !currentProduct.upc;
+              return (
+                <Button
+                  key={fmt}
+                  variant={active ? 'primary' : 'outline'}
+                  size="sm"
+                  disabled={disabled}
+                  onClick={() => setLabelFormat(fmt)}
+                  title={disabled ? 'Product has no UPC assigned' : undefined}
+                >
+                  {fmt === 'qr' ? 'QR' : fmt === 'upc' ? 'UPC' : 'Code128'}
+                </Button>
+              );
+            })}
+            <Button
+              size="sm"
+              onClick={() =>
+                printProductLabels([currentProduct], {
+                  format: labelFormat ?? labelSettings.defaultFormat,
+                  includePrice: labelSettings.includePrice,
+                })
+              }
+            >
+              <Printer className="h-3.5 w-3.5" /> Print label
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex justify-center">
+          <ProductLabel
+            product={currentProduct}
+            format={labelFormat ?? labelSettings.defaultFormat}
+            includePrice={labelSettings.includePrice}
+            className="w-full max-w-sm"
+          />
+        </div>
       </div>
 
       {/* Adjust Stock */}

--- a/frontend/src/pages/ProductLabelsPage.tsx
+++ b/frontend/src/pages/ProductLabelsPage.tsx
@@ -1,0 +1,201 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Printer } from 'lucide-react';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import TableToolbar from '@/components/data/TableToolbar';
+import SearchInput from '@/components/data/SearchInput';
+import Pagination from '@/components/data/Pagination';
+import { Button } from '@/components/ui/Button';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/Tabs';
+import EmptyState from '@/components/ui/EmptyState';
+import ProductLabel from '@/components/labels/ProductLabel';
+import { printProductLabels } from '@/lib/printLabels';
+import { useLabelSettings } from '@/hooks/useLabelSettings';
+import { formatCurrency } from '@/lib/utils';
+import type { BarcodeFormat } from '@/lib/barcode';
+import type { PaginatedProducts, Product } from '@/types';
+
+export default function ProductLabelsPage() {
+  const labelSettings = useLabelSettings();
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(25);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [formatOverride, setFormatOverride] = useState<BarcodeFormat | null>(null);
+  const [includePrice, setIncludePrice] = useState<boolean | null>(null);
+
+  const { data, isLoading } = useQuery<PaginatedProducts>({
+    queryKey: ['products', 'labels', search, page, pageSize],
+    queryFn: () =>
+      api
+        .get('/products', {
+          params: {
+            search: search || undefined,
+            skip: page * pageSize,
+            limit: pageSize,
+            is_active: true,
+          },
+        })
+        .then((r) => r.data),
+  });
+
+  const products = data?.items || [];
+  const total = data?.total || 0;
+  const productMap = useMemo(() => new Map(products.map((p) => [p.id, p])), [products]);
+  const selectedProducts = useMemo(
+    () => Array.from(selected).map((id) => productMap.get(id)).filter(Boolean) as Product[],
+    [selected, productMap],
+  );
+
+  const activeFormat = formatOverride ?? labelSettings.defaultFormat;
+  const activeIncludePrice = includePrice ?? labelSettings.includePrice;
+
+  const handlePrintSheet = () => {
+    if (!selectedProducts.length) return;
+    printProductLabels(selectedProducts, {
+      format: activeFormat,
+      includePrice: activeIncludePrice,
+      sheet: true,
+    });
+  };
+
+  const previewProducts = selectedProducts.slice(0, 30);
+
+  const columns: Column<Product>[] = [
+    { key: 'name', header: 'Product', cell: (p) => <span className="font-medium">{p.name}</span> },
+    { key: 'sku', header: 'SKU', cell: (p) => <span className="font-mono text-xs">{p.sku}</span> },
+    {
+      key: 'upc',
+      header: 'UPC',
+      colClassName: 'hidden md:table-cell',
+      cell: (p) =>
+        p.upc ? <span className="font-mono text-xs">{p.upc}</span> : <span className="text-muted-foreground">—</span>,
+    },
+    {
+      key: 'unit_price',
+      header: 'Price',
+      numeric: true,
+      cell: (p) => formatCurrency(p.unit_price),
+    },
+    {
+      key: 'stock_qty',
+      header: 'Stock',
+      numeric: true,
+      colClassName: 'hidden md:table-cell',
+      cell: (p) => p.stock_qty,
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Print labels"
+        description={
+          selected.size
+            ? `${selected.size} ${selected.size === 1 ? 'product' : 'products'} selected`
+            : 'Select products below to build a printable label sheet.'
+        }
+        actions={
+          <Button onClick={handlePrintSheet} disabled={!selected.size}>
+            <Printer className="h-4 w-4" />
+            {selected.size ? `Print sheet (${selected.size})` : 'Print sheet'}
+          </Button>
+        }
+      />
+
+      <section className="space-y-3 rounded-md border border-border bg-card p-5 shadow-xs">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-base font-semibold">Label settings</h2>
+          <Tabs
+            value={activeFormat}
+            onValueChange={(v) => setFormatOverride(v as BarcodeFormat)}
+          >
+            <TabsList>
+              <TabsTrigger value="code128">Code128</TabsTrigger>
+              <TabsTrigger value="upc">UPC</TabsTrigger>
+              <TabsTrigger value="qr">QR</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+        <label className="flex items-center gap-2 text-sm text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={activeIncludePrice}
+            onChange={(e) => setIncludePrice(e.target.checked)}
+            className="h-4 w-4 cursor-pointer rounded border-input accent-primary"
+          />
+          Include price on each label
+        </label>
+        <p className="text-xs text-muted-foreground">
+          Sheet layout is Avery 5160 (30 labels, 2.625 × 1 in). Use Admin → Settings to change the default format or price display for new prints.
+        </p>
+      </section>
+
+      <DataTable<Product>
+        data={products}
+        columns={columns}
+        rowKey={(p) => p.id}
+        selectable
+        selected={selected}
+        onSelectedChange={setSelected}
+        loading={isLoading}
+        emptyState="No active products found."
+        toolbar={
+          <TableToolbar total={total}>
+            <SearchInput
+              value={search}
+              onChange={(v) => {
+                setSearch(v);
+                setPage(0);
+              }}
+              placeholder="Search products…"
+            />
+          </TableToolbar>
+        }
+        footer={
+          <Pagination
+            page={page}
+            pageSize={pageSize}
+            total={total}
+            onPageChange={setPage}
+            onPageSizeChange={(n) => {
+              setPageSize(n);
+              setPage(0);
+            }}
+          />
+        }
+      />
+
+      {previewProducts.length ? (
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-base font-semibold">Preview ({previewProducts.length} of {selected.size})</h2>
+            {selected.size > 30 ? (
+              <p className="text-xs text-muted-foreground">Showing first 30 selections.</p>
+            ) : null}
+          </div>
+          <div className="grid gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6">
+            {previewProducts.map((p) => (
+              <ProductLabel
+                key={p.id}
+                product={p}
+                format={activeFormat}
+                includePrice={activeIncludePrice}
+                variant="compact"
+              />
+            ))}
+          </div>
+        </section>
+      ) : (
+        <EmptyState
+          compact
+          icon="products"
+          title="No labels previewed yet."
+          description="Pick products from the list above to see them on an Avery 5160-style sheet."
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { AlertTriangle, Archive, ArchiveRestore, Eye, Pencil, Plus, ScanBarcode } from 'lucide-react';
+import { AlertTriangle, Archive, ArchiveRestore, Eye, Pencil, Plus, Printer, ScanBarcode } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/api/client';
 import PageHeader from '@/components/layout/PageHeader';
@@ -14,6 +14,8 @@ import { Button } from '@/components/ui/Button';
 import ConfirmDialog from '@/components/ui/ConfirmDialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
 import { formatCurrency } from '@/lib/utils';
+import { printProductLabels } from '@/lib/printLabels';
+import { useLabelSettings } from '@/hooks/useLabelSettings';
 import type { PaginatedProducts, Product } from '@/types';
 
 export default function ProductsPage() {
@@ -24,6 +26,7 @@ export default function ProductsPage() {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(25);
   const [pendingToggle, setPendingToggle] = useState<Product | null>(null);
+  const labelSettings = useLabelSettings();
 
   const { data, isLoading, refetch } = useQuery<PaginatedProducts>({
     queryKey: ['products', search, sortKey, sortDir, page, pageSize],
@@ -144,7 +147,7 @@ export default function ProductsPage() {
     {
       key: 'actions',
       header: <span className="sr-only">Actions</span>,
-      width: '112px',
+      width: '144px',
       cell: (p) => (
         <div className="flex items-center justify-end gap-1">
           <Tooltip>
@@ -166,6 +169,25 @@ export default function ProductsPage() {
               </Button>
             </TooltipTrigger>
             <TooltipContent>View</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() =>
+                  printProductLabels([p], {
+                    format: labelSettings.defaultFormat,
+                    includePrice: labelSettings.includePrice,
+                  })
+                }
+                aria-label={`Print label for ${p.name}`}
+              >
+                <Printer className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Print label</TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/frontend/src/pages/admin/SettingsPage.tsx
+++ b/frontend/src/pages/admin/SettingsPage.tsx
@@ -25,6 +25,10 @@ const groups: Record<string, { keys: string[]; description: string }> = {
     keys: ['packaging_cost_per_order', 'shipping_charged_to_customer'],
     description: 'Packaging and shipping cost settings',
   },
+  Labels: {
+    keys: ['barcode_default_format', 'barcode_label_template', 'barcode_include_price'],
+    description: 'Default barcode format, label sheet template, and price display',
+  },
 };
 
 const aiProviders = [
@@ -79,10 +83,27 @@ export default function SettingsPage() {
   const activeProvider = values.ai_provider || 'chatgpt';
   const activeProviderConfig = aiProviders.find((provider) => provider.value === activeProvider) || aiProviders[0];
 
+  const selectOptions: Record<string, { value: string; label: string }[]> = {
+    barcode_default_format: [
+      { value: 'code128', label: 'Code128 (any SKU)' },
+      { value: 'upc', label: 'UPC-A (12-digit UPC)' },
+      { value: 'qr', label: 'QR code' },
+    ],
+    barcode_label_template: [
+      { value: 'avery_5160', label: 'Avery 5160 (30 per sheet)' },
+      { value: 'continuous_roll_2x1', label: 'Continuous roll 2 × 1 in' },
+    ],
+  };
+
+  const booleanKeys = new Set(['barcode_include_price']);
+
   const renderSettingInput = (key: string, helperLabel?: string) => {
     const setting = settingsMap.get(key);
     if (!setting) return null;
     const isSecret = key.endsWith('_api_key');
+    const options = selectOptions[key];
+    const isBoolean = booleanKeys.has(key);
+
     return (
       <div key={key} className="space-y-2">
         <div>
@@ -91,13 +112,37 @@ export default function SettingsPage() {
             <p className="text-xs text-muted-foreground">{setting.notes}</p>
           )}
         </div>
-        <input
-          type={isSecret ? 'password' : 'text'}
-          value={values[key] ?? ''}
-          onChange={(e) => update(key, e.target.value)}
-          placeholder={isSecret ? 'Paste API key' : undefined}
-          className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring font-mono text-sm"
-        />
+        {options ? (
+          <select
+            value={values[key] ?? options[0].value}
+            onChange={(e) => update(key, e.target.value)}
+            className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            {options.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        ) : isBoolean ? (
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={values[key] === 'true'}
+              onChange={(e) => update(key, e.target.checked ? 'true' : 'false')}
+              className="h-4 w-4 cursor-pointer rounded border-input accent-primary"
+            />
+            Enabled
+          </label>
+        ) : (
+          <input
+            type={isSecret ? 'password' : 'text'}
+            value={values[key] ?? ''}
+            onChange={(e) => update(key, e.target.value)}
+            placeholder={isSecret ? 'Paste API key' : undefined}
+            className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring font-mono text-sm"
+          />
+        )}
       </div>
     );
   };


### PR DESCRIPTION
Closes #227.

## Summary

Full-stack feature: product pages can now generate + print Code128, UPC-A, or QR labels; new `/product-studio/labels` page builds an Avery 5160 30-up print sheet from any multi-select of products.

## Backend

- `app/services/barcode_service.py` — wraps `python-barcode` (Code128 / UPC-A) and `qrcode` (QR) behind a testable seam
- `GET /api/v1/products/{id}/barcode?format=code128|upc|qr&size=N&url=0|1` returns a PNG with `Cache-Control: public, max-age=3600`
- 4 regression tests covering default, QR, UPC-without-UPC (400), and missing-product (404)
- Alembic migration `20260420_01` seeds 3 settings: `barcode_default_format`, `barcode_label_template`, `barcode_include_price`
- New deps: `python-barcode==0.15.1`, `qrcode[pil]==8.0`, `Pillow==11.1.0`

## Frontend

- `lib/barcode.ts` — URL builder + blob / data-URL fetchers
- `lib/printLabels.ts` — print popup that inlines barcode images as data URLs (self-contained, no cross-window auth)
- `components/labels/ProductLabel.tsx` — reusable label card + `openPrintWindow` helper with Avery 5160 CSS
- `hooks/useLabelSettings.ts` — typed wrapper around `/settings` for the three new keys
- **ProductDetailPage**: new Label section with format tabs (Code128 / UPC / QR; UPC disabled when product has no UPC), live preview, Print button
- **ProductsPage**: new "Print label" row action (ghost icon + Tooltip)
- **New `/product-studio/labels` page**: DataTable multi-select → Avery 5160 sheet preview → Print sheet CTA with session format/price overrides
- **Admin → Settings** — new "Labels" group with proper enum selects for format + template and a checkbox for include-price
- WorkspaceLocalNav + CommandPalette Quick actions entry for the new Labels page
- Route wiring in `App.tsx` (lazy-loaded)

## Deploy notes

- Requires `python-barcode`, `qrcode`, and `Pillow` in the backend container. Docker rebuild picks up `requirements.txt` automatically.
- Alembic upgrade runs on boot; fresh DBs get the rows via both `seed.py` and the migration, existing DBs via the migration only.

## Acceptance

- [x] `GET /api/v1/products/{id}/barcode` returns a valid PNG
- [x] 4 backend tests added (default / QR / UPC-missing / 404)
- [x] ProductDetail shows live preview + Print
- [x] Bulk sheet renders Avery 5160 layout for selected products
- [x] Admin Settings exposes the three barcode settings via the existing `/settings/bulk` flow
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` → 50 tests passing
- [ ] `python3 -m pytest backend/tests -q` → verified by CI

## Test plan

- [ ] Open any product detail → label preview renders; toggle Code128 / UPC / QR tabs; click Print → popup prints with correct image
- [ ] Products list → click Printer icon on a row → single-label print popup
- [ ] Open /product-studio/labels → search + select 5 products → click Print sheet → Avery 5160 layout prints
- [ ] Set `barcode_default_format = qr` in Admin Settings → ProductDetail default format switches to QR
- [ ] Set `barcode_include_price = true` → labels now show price
- [ ] Try UPC on a product without UPC → tab disabled with tooltip; `?format=upc` returns 400 with the expected message
- [ ] QR with `?url=1` encodes the product page URL (scan the code to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)