### PR TITLE
chore(deps): bump Pillow 11.1.0 → 12.2.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,4 +14,4 @@ pytest-asyncio==0.25.0
 aiosqlite==0.20.0
 python-barcode==0.15.1
 qrcode[pil]==8.0
-Pillow==11.1.0
+Pillow==12.2.0


### PR DESCRIPTION
## Summary
- `Pillow` `11.1.0` → `12.2.0` — closes 5 advisories (3 high, 2 medium):
  - High: PSD OOB writes (×2), FITS GZIP decompression bomb
  - Medium: PDF parsing infinite loop, font integer overflow

Major version bump. Verified the production barcode/QR rendering path in [backend/app/services/barcode_service.py](backend/app/services/barcode_service.py) — used for product labels via `python-barcode` + `qrcode` — still produces valid PNGs across `upc`, `code128`, and `qr` formats.

Closes part of #265.

## Test plan
- [x] `python3 -m pytest backend/tests -q` — all 282 tests pass against Pillow 12.2.0.
- [x] `tests/test_api_products.py` and `tests/test_api_pos.py` (the barcode-touching modules) pass — 36 tests.
- [x] Direct call into `render_barcode` for upc/code128/qr produces valid PNG bytes (verified via PIL `Image.open` + format/size/mode inspection).
- [ ] Smoke-test product label printing in the UI after merge.
- [ ] Verify the 5 Pillow Dependabot alerts close on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)