### PR TITLE
chore(deps): bump pytest 8.3.4 → 9.0.3 and pytest-asyncio 0.25.0 → 1.3.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,8 +9,8 @@ python-jose[cryptography]==3.4.0
 bcrypt==4.2.1
 python-multipart==0.0.22
 httpx==0.28.1
-pytest==8.3.4
-pytest-asyncio==0.25.0
+pytest==9.0.3
+pytest-asyncio==1.3.0
 aiosqlite==0.20.0
 python-barcode==0.15.1
 qrcode[pil]==8.0


### PR DESCRIPTION
## Summary
- `pytest` `8.3.4` → `9.0.3` — closes 1 advisory (medium): GHSA-6w46-j5rx-g56g (vulnerable `tmpdir` handling).
- `pytest-asyncio` `0.25.0` → `1.3.0` — pytest-asyncio's 1.x line is the supported pairing with pytest 9.

Major version bumps for both. The suite uses no `tmpdir` (the deprecated path the advisory references), so no test-side migrations were needed. Full backend suite (282 tests) passes; no new deprecation warnings.

Closes the final tier of #265. After all three PRs merge (#266, #267, this), all 25 Dependabot alerts should resolve.

## Test plan
- [x] `python3 -m pytest backend/tests -q` — all 282 tests pass.
- [x] Deprecation-warning sweep — no new warnings.
- [ ] Verify the pytest Dependabot alert closes on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)