### PR TITLE
feat: race-safe reference number allocator for sales, invoices, quotes (closes #243)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -55,7 +55,7 @@
 
 ## Known Risks
 
-- `backend/app/services/sales_service.py` generates `sale_number` from a yearly row count. That is race-prone under concurrent sale creation because the column is unique.
+- ~~`backend/app/services/sales_service.py` generates `sale_number` from a yearly row count.~~ Closed by [#243](https://github.com/bbengt1/3d-print-sales/issues/243): all reference numbers (sales, invoices, quotes) now flow through the race-safe `reference_number_service` allocator. See `docs/reference_numbering.md`.
 - `backend/app/services/printer_monitoring.py` is imported during app startup and depends on `websockets`; backend environments need that dependency installed or the app and tests will fail before collection.
 - README coverage is broader than the minimum validated local setup. Verify routes and tests rather than relying on documentation alone.
 

--- a/backend/alembic/versions/20260509_01_add_reference_sequences.py
+++ b/backend/alembic/versions/20260509_01_add_reference_sequences.py
@@ -1,0 +1,94 @@
+"""add reference_sequences allocator + backfill from existing canonical numbers
+
+Revision ID: 20260509_01
+Revises: 20260508_03
+Create Date: 2026-05-09 16:00:00
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_01"
+down_revision = "20260508_03"
+branch_labels = None
+depends_on = None
+
+
+CANONICAL_PATTERNS = {
+    "sale": (re.compile(r"^S-(\d{4})-(\d+)$"), "sales", "sale_number"),
+    "invoice": (re.compile(r"^INV-(\d{4})-(\d+)$"), "invoices", "invoice_number"),
+    "quote": (re.compile(r"^Q-(\d{4})-(\d+)$"), "quotes", "quote_number"),
+}
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reference_sequences",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("scope", sa.String(length=50), nullable=False),
+        sa.Column("year", sa.Integer(), nullable=False),
+        sa.Column("last_value", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("scope", "year", name="uq_reference_sequences_scope_year"),
+    )
+    op.create_index("ix_reference_sequences_scope", "reference_sequences", ["scope"])
+    op.create_index("ix_reference_sequences_year", "reference_sequences", ["year"])
+
+    # Backfill: for each canonical scope, parse existing numbers and seed
+    # `last_value = max(parsed numeric suffix)` per (scope, year). Records that
+    # don't match the canonical pattern (operator-supplied invoice numbers
+    # like "CUST-PROJECT-7") simply don't influence the seed; they continue
+    # to coexist on the parent table without affecting the allocator.
+    bind = op.get_bind()
+    for scope, (pattern, table, column) in CANONICAL_PATTERNS.items():
+        try:
+            rows = bind.execute(sa.text(f"SELECT {column} FROM {table}")).all()
+        except Exception:
+            continue
+        per_year_max: dict[int, int] = {}
+        for (number,) in rows:
+            if not number:
+                continue
+            m = pattern.match(number)
+            if not m:
+                continue
+            year = int(m.group(1))
+            value = int(m.group(2))
+            per_year_max[year] = max(per_year_max.get(year, 0), value)
+        for year, max_value in per_year_max.items():
+            bind.execute(
+                sa.text(
+                    "INSERT INTO reference_sequences (id, scope, year, last_value) "
+                    "VALUES (:id, :scope, :year, :last_value)"
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "scope": scope,
+                    "year": year,
+                    "last_value": max_value,
+                },
+            )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_reference_sequences_year", table_name="reference_sequences")
+    op.drop_index("ix_reference_sequences_scope", table_name="reference_sequences")
+    op.drop_table("reference_sequences")

--- a/backend/app/api/v1/endpoints/invoices.py
+++ b/backend/app/api/v1/endpoints/invoices.py
@@ -100,12 +100,18 @@ async def get_invoice(invoice_id: uuid.UUID, db: DB):
 
 @router.post("", response_model=InvoiceResponse, status_code=status.HTTP_201_CREATED, summary="Create invoice")
 async def create_invoice(body: InvoiceCreate, user: CurrentUser, db: DB):
-    existing = await db.execute(select(Invoice.id).where(Invoice.invoice_number == body.invoice_number))
-    if existing.scalar_one_or_none():
-        raise HTTPException(status_code=409, detail=f"Invoice number '{body.invoice_number}' already exists")
+    from app.services.reference_number_service import next_number
+
+    invoice_number = body.invoice_number.strip() if body.invoice_number else ""
+    if not invoice_number:
+        invoice_number = await next_number(db, "invoice")
+    else:
+        existing = await db.execute(select(Invoice.id).where(Invoice.invoice_number == invoice_number))
+        if existing.scalar_one_or_none():
+            raise HTTPException(status_code=409, detail=f"Invoice number '{invoice_number}' already exists")
 
     invoice = Invoice(
-        invoice_number=body.invoice_number,
+        invoice_number=invoice_number,
         quote_id=body.quote_id,
         customer_id=body.customer_id,
         customer_name=body.customer_name,
@@ -146,12 +152,18 @@ async def create_invoice_from_quote(quote_id: uuid.UUID, body: InvoiceFromQuoteC
     if quote.status != "accepted":
         raise HTTPException(status_code=400, detail="Only accepted quotes can be invoiced")
 
-    existing = await db.execute(select(Invoice.id).where(Invoice.invoice_number == body.invoice_number))
-    if existing.scalar_one_or_none():
-        raise HTTPException(status_code=409, detail=f"Invoice number '{body.invoice_number}' already exists")
+    from app.services.reference_number_service import next_number
+
+    invoice_number = body.invoice_number.strip() if body.invoice_number else ""
+    if not invoice_number:
+        invoice_number = await next_number(db, "invoice")
+    else:
+        existing = await db.execute(select(Invoice.id).where(Invoice.invoice_number == invoice_number))
+        if existing.scalar_one_or_none():
+            raise HTTPException(status_code=409, detail=f"Invoice number '{invoice_number}' already exists")
 
     invoice = Invoice(
-        invoice_number=body.invoice_number,
+        invoice_number=invoice_number,
         quote_id=quote.id,
         customer_id=quote.customer_id,
         customer_name=quote.customer_name,

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -72,13 +72,21 @@ async def get_quote(quote_id: uuid.UUID, db: DB):
 
 @router.post("", response_model=QuoteResponse, status_code=201, summary="Create quote")
 async def create_quote(body: QuoteCreate, user: CurrentUser, db: DB):
-    existing = await db.execute(select(Quote.id).where(Quote.quote_number == body.quote_number))
-    if existing.scalar_one_or_none():
-        raise HTTPException(status_code=409, detail=f"Quote number '{body.quote_number}' already exists")
+    from app.services.reference_number_service import next_number
+
+    quote_number = body.quote_number.strip() if body.quote_number else ""
+    if not quote_number:
+        quote_number = await next_number(db, "quote")
+    else:
+        existing = await db.execute(select(Quote.id).where(Quote.quote_number == quote_number))
+        if existing.scalar_one_or_none():
+            raise HTTPException(status_code=409, detail=f"Quote number '{quote_number}' already exists")
 
     costs = await _calculate_quote_costs(db, body)
+    payload = body.model_dump(exclude={"shipping_cost", "quote_number"})
     quote = Quote(
-        **body.model_dump(exclude={"shipping_cost"}),
+        quote_number=quote_number,
+        **payload,
         total_pieces=body.qty_per_plate * body.num_plates,
         **costs,
     )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
 from app.models.camera import Camera  # noqa: F401
 from app.models.product_bom_item import ProductBOMItem  # noqa: F401
+from app.models.reference_sequence import ReferenceSequence  # noqa: F401
 from app.models.supply import Supply  # noqa: F401

--- a/backend/app/models/reference_sequence.py
+++ b/backend/app/models/reference_sequence.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class ReferenceSequence(Base):
+    """Per-(scope, year) monotonically-increasing counter.
+
+    Backs `app.services.reference_number_service.next_number` which atomically
+    increments `last_value` via INSERT ... ON CONFLICT on PostgreSQL (or a
+    SELECT FOR UPDATE-style fallback on SQLite during tests).
+    """
+
+    __tablename__ = "reference_sequences"
+    __table_args__ = (
+        UniqueConstraint("scope", "year", name="uq_reference_sequences_scope_year"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    scope: Mapped[str] = mapped_column(String(50), index=True)
+    year: Mapped[int] = mapped_column(Integer, index=True)
+    last_value: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/backend/app/schemas/invoice.py
+++ b/backend/app/schemas/invoice.py
@@ -38,7 +38,7 @@ class InvoiceLineResponse(BaseModel):
 
 
 class InvoiceCreate(BaseModel):
-    invoice_number: str = Field(..., min_length=1, max_length=50)
+    invoice_number: str | None = Field(None, max_length=50)
     quote_id: uuid.UUID | None = None
     customer_id: uuid.UUID | None = None
     customer_name: str | None = Field(None, max_length=200)
@@ -71,7 +71,7 @@ class InvoiceCreditApply(BaseModel):
 
 
 class InvoiceFromQuoteCreate(BaseModel):
-    invoice_number: str = Field(..., min_length=1, max_length=50)
+    invoice_number: str | None = Field(None, max_length=50)
     issue_date: datetime.date
     due_date: datetime.date | None = None
     tax_amount: Decimal = Field(0, ge=0)

--- a/backend/app/schemas/quote.py
+++ b/backend/app/schemas/quote.py
@@ -35,7 +35,7 @@ class QuoteBase(BaseModel):
 
 
 class QuoteCreate(QuoteBase):
-    quote_number: str = Field(..., min_length=1, max_length=50)
+    quote_number: str | None = Field(None, max_length=50)
     status: QuoteStatus = QuoteStatus.draft
 
 

--- a/backend/app/services/reference_number_service.py
+++ b/backend/app/services/reference_number_service.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import re
+from datetime import date
+from typing import Final
+
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.reference_sequence import ReferenceSequence
+
+
+# Per-scope format strings. Each must accept `year` (int) and `value` (int).
+# When adding a new scope (e.g. inventory_transfer, production_order), register
+# its format here and that's all that's needed for the allocator to support it.
+FORMATS: Final[dict[str, str]] = {
+    "sale": "S-{year}-{value:04d}",
+    "invoice": "INV-{year}-{value:04d}",
+    "quote": "Q-{year}-{value:04d}",
+}
+
+
+# Compiled regex per scope used by the migration backfill to parse existing
+# canonical-format numbers into a numeric suffix. Scopes with non-canonical
+# numbers (e.g. operator-supplied invoice numbers like "CUST-PROJECT-7") simply
+# don't match these and are ignored during seeding.
+_PARSE_PATTERNS: Final[dict[str, re.Pattern[str]]] = {
+    "sale": re.compile(r"^S-(\d{4})-(\d+)$"),
+    "invoice": re.compile(r"^INV-(\d{4})-(\d+)$"),
+    "quote": re.compile(r"^Q-(\d{4})-(\d+)$"),
+}
+
+
+def parse_reference_number(scope: str, number: str) -> tuple[int, int] | None:
+    """Parse a canonical reference number for `scope` into (year, value).
+
+    Returns None when the input doesn't match the canonical pattern; backfill
+    callers use this to skip non-canonical historical numbers.
+    """
+    pattern = _PARSE_PATTERNS.get(scope)
+    if pattern is None:
+        return None
+    m = pattern.match(number)
+    if m is None:
+        return None
+    return int(m.group(1)), int(m.group(2))
+
+
+def format_reference_number(scope: str, year: int, value: int) -> str:
+    if scope not in FORMATS:
+        raise KeyError(f"Unknown reference number scope: {scope!r}")
+    return FORMATS[scope].format(year=year, value=value)
+
+
+async def next_number(
+    session: AsyncSession,
+    scope: str,
+    year: int | None = None,
+) -> str:
+    """Atomically allocate and format the next reference number for (scope, year).
+
+    Caller must invoke this inside the same transaction that inserts the parent
+    record. Rollback of the outer transaction rolls back the increment, which
+    intentionally causes the next call to reissue the same number — accountants
+    consider that a feature, not a bug, because it keeps numbers contiguous on
+    successful posts. If a row creation fails after this call, the burned
+    number is acceptable per #243's design (skipped numbers OK).
+
+    On PostgreSQL the increment is one statement (`INSERT ... ON CONFLICT
+    DO UPDATE ... RETURNING`). On SQLite (test path) we fall back to
+    select-then-update, which is single-threaded enough to be safe.
+    """
+    if scope not in FORMATS:
+        raise KeyError(f"Unknown reference number scope: {scope!r}")
+
+    if year is None:
+        year = date.today().year
+
+    dialect = session.bind.dialect.name if session.bind else "postgresql"
+
+    if dialect == "postgresql":
+        stmt = pg_insert(ReferenceSequence).values(
+            scope=scope, year=year, last_value=1
+        )
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["scope", "year"],
+            set_={"last_value": ReferenceSequence.last_value + 1},
+        ).returning(ReferenceSequence.last_value)
+        result = await session.execute(stmt)
+        new_value = result.scalar_one()
+    else:
+        # SQLite test path. Tests run serially so no real race; this just needs
+        # to be correct.
+        existing = await session.execute(
+            select(ReferenceSequence).where(
+                ReferenceSequence.scope == scope,
+                ReferenceSequence.year == year,
+            )
+        )
+        row = existing.scalar_one_or_none()
+        if row is None:
+            row = ReferenceSequence(scope=scope, year=year, last_value=1)
+            session.add(row)
+            await session.flush()
+            new_value = 1
+        else:
+            new_value = row.last_value + 1
+            await session.execute(
+                update(ReferenceSequence)
+                .where(ReferenceSequence.id == row.id)
+                .values(last_value=new_value)
+            )
+
+    return format_reference_number(scope, year, new_value)
+
+
+async def seed_sequence(
+    session: AsyncSession,
+    *,
+    scope: str,
+    year: int,
+    last_value: int,
+) -> None:
+    """Idempotent seed used by migrations. If the (scope, year) row exists,
+    leave it alone. Otherwise insert with the given last_value.
+    """
+    existing = await session.execute(
+        select(ReferenceSequence).where(
+            ReferenceSequence.scope == scope,
+            ReferenceSequence.year == year,
+        )
+    )
+    if existing.scalar_one_or_none() is None:
+        session.add(
+            ReferenceSequence(scope=scope, year=year, last_value=last_value)
+        )
+        await session.flush()

--- a/backend/app/services/sales_service.py
+++ b/backend/app/services/sales_service.py
@@ -21,15 +21,16 @@ class InsufficientStockError(Exception):
 
 
 async def generate_sale_number(db: AsyncSession) -> str:
-    """Generate a unique sale number in format S-YYYY-NNNN."""
-    from datetime import date
-    year = date.today().year
-    prefix = f"S-{year}-"
-    result = await db.execute(
-        select(func.count()).select_from(Sale).where(Sale.sale_number.like(f"{prefix}%"))
-    )
-    count = result.scalar() or 0
-    return f"{prefix}{count + 1:04d}"
+    """Generate a unique sale number in format S-YYYY-NNNN.
+
+    Backed by the race-safe `reference_number_service` allocator (#243).
+    Caller invokes inside the same transaction as the Sale insert; on rollback
+    the allocation also rolls back, preserving contiguous numbering on success
+    and burning a number on failure (intended behavior).
+    """
+    from app.services.reference_number_service import next_number
+
+    return await next_number(db, "sale")
 
 
 async def get_or_create_sales_channel(

--- a/backend/tests/test_reference_number_service.py
+++ b/backend/tests/test_reference_number_service.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.reference_number_service import (
+    FORMATS,
+    format_reference_number,
+    next_number,
+    parse_reference_number,
+)
+
+
+@pytest.mark.asyncio
+async def test_next_number_allocates_first_value(db_session):
+    n = await next_number(db_session, "sale", year=2026)
+    assert n == "S-2026-0001"
+
+
+@pytest.mark.asyncio
+async def test_next_number_increments_within_year(db_session):
+    a = await next_number(db_session, "sale", year=2026)
+    b = await next_number(db_session, "sale", year=2026)
+    c = await next_number(db_session, "sale", year=2026)
+    assert (a, b, c) == ("S-2026-0001", "S-2026-0002", "S-2026-0003")
+
+
+@pytest.mark.asyncio
+async def test_next_number_resets_per_year(db_session):
+    a26 = await next_number(db_session, "sale", year=2026)
+    a27 = await next_number(db_session, "sale", year=2027)
+    b26 = await next_number(db_session, "sale", year=2026)
+    assert a26 == "S-2026-0001"
+    assert a27 == "S-2027-0001"
+    assert b26 == "S-2026-0002"
+
+
+@pytest.mark.asyncio
+async def test_next_number_separates_scopes(db_session):
+    s = await next_number(db_session, "sale", year=2026)
+    i = await next_number(db_session, "invoice", year=2026)
+    q = await next_number(db_session, "quote", year=2026)
+    assert s == "S-2026-0001"
+    assert i == "INV-2026-0001"
+    assert q == "Q-2026-0001"
+
+
+@pytest.mark.asyncio
+async def test_next_number_unknown_scope_raises(db_session):
+    with pytest.raises(KeyError):
+        await next_number(db_session, "not_a_scope", year=2026)
+
+
+def test_format_reference_number_unknown_scope_raises():
+    with pytest.raises(KeyError):
+        format_reference_number("not_a_scope", 2026, 1)
+
+
+def test_parse_reference_number_canonical_round_trip():
+    for scope in ("sale", "invoice", "quote"):
+        formatted = format_reference_number(scope, 2026, 42)
+        parsed = parse_reference_number(scope, formatted)
+        assert parsed == (2026, 42)
+
+
+def test_parse_reference_number_returns_none_for_non_canonical():
+    assert parse_reference_number("invoice", "CUST-PROJECT-7") is None
+    assert parse_reference_number("sale", "garbage") is None
+    assert parse_reference_number("not_a_scope", "anything") is None
+
+
+def test_formats_registry_has_all_expected_scopes():
+    # If a future issue adds a scope, add it here too. Failing this test on
+    # purpose forces the registration check.
+    assert set(FORMATS.keys()) >= {"sale", "invoice", "quote"}

--- a/docs/reference_numbering.md
+++ b/docs/reference_numbering.md
@@ -1,0 +1,48 @@
+# Reference Number Allocator
+
+Race-safe, single-source allocator for human-readable record numbers. Backs `sale_number`, `invoice_number`, `quote_number`, and (over time) any other numbered document we add. Closes the `sale_number` race historically called out in `agents.md` Known Risks.
+
+## Service contract
+
+```python
+from app.services.reference_number_service import next_number
+
+# Inside the same transaction that inserts the parent record:
+sale.sale_number = await next_number(session, "sale")
+```
+
+`next_number(session, scope, year=None) -> str` atomically:
+
+1. Increments `reference_sequences.last_value` for `(scope, year)` (defaults to `date.today().year`).
+2. Formats the result via the per-scope `FORMATS[scope]` template.
+3. Returns the canonical string.
+
+On PostgreSQL the increment is one statement (`INSERT ... ON CONFLICT DO UPDATE ... RETURNING`). On SQLite (the test path) it falls back to select-then-update.
+
+## Skipped numbers are intentional
+
+When the outer transaction rolls back after `next_number` ran, the increment also rolls back, so the **next call returns the same value** — accountants consider this a feature because it keeps numbers contiguous across successful posts. If a record creation fails *after* commit (e.g. an HTTP error reaches the client mid-response), the number is "burned" and the next allocation skips ahead. Documented behavior. Don't try to reuse skipped numbers.
+
+## Registered scopes (today)
+
+| Scope | Format | Example | Caller |
+|---|---|---|---|
+| `sale` | `S-{year}-{value:04d}` | `S-2026-0123` | `sales_service.generate_sale_number` |
+| `invoice` | `INV-{year}-{value:04d}` | `INV-2026-0042` | `invoices.create_invoice` (when `invoice_number` is null/blank) |
+| `quote` | `Q-{year}-{value:04d}` | `Q-2026-0007` | `quotes.create_quote` (when `quote_number` is null/blank) |
+
+## Adding a scope
+
+1. Add the format string to `FORMATS` in `backend/app/services/reference_number_service.py`.
+2. (Optional) Add a regex to `_PARSE_PATTERNS` if a backfill migration needs to seed historical values.
+3. Call `await next_number(session, "<your_scope>")` from the relevant create path.
+
+That's it — no model change, no migration, the existing `reference_sequences` table holds all scopes.
+
+## Manual / operator-supplied numbers
+
+Invoices and quotes accept an operator-supplied `invoice_number` / `quote_number` in the request body. When supplied, the allocator is **not** consulted — the existing uniqueness check on the parent table guards against collisions. When the field is null or blank, the allocator fills it in. Sales numbers are always allocator-generated.
+
+## Backfill on migration
+
+The `20260509_01_add_reference_sequences` migration parses every existing `sale_number`, `invoice_number`, `quote_number` against the canonical pattern. For each `(scope, year)` it seeds `last_value = max(parsed numeric suffix)`. Records with non-canonical numbers (e.g. an operator-supplied `CUST-PROJECT-7`) don't match the pattern and are simply ignored — they continue to coexist with the allocator.


### PR DESCRIPTION
## Summary
Implements [#243](https://github.com/bbengt1/3d-print-sales/issues/243). New `reference_sequences` table and `reference_number_service` provide a single race-safe allocator for `sale_number`, `invoice_number`, `quote_number`, and any future numbered document. Closes the historical `sale_number` race called out in `agents.md` Known Risks.

- Atomic increment via `INSERT ... ON CONFLICT DO UPDATE ... RETURNING` on Postgres, select-then-update fallback for SQLite tests.
- Per-scope formats: `S-{year}-{value:04d}`, `INV-{year}-{value:04d}`, `Q-{year}-{value:04d}`.
- Invoices and quotes gain optional auto-numbering (operator-supplied still works).
- Migration backfills from existing canonical-format records.
- New doc [docs/reference_numbering.md](docs/reference_numbering.md) covers the contract + skipped-number-on-rollback policy.
- `agents.md` Known Risks updated to mark the race closed.

**Frontend toggle deferred** — invoice/quote create forms don't exist in the React surface today (API-only). Will land alongside whichever issue introduces those forms (#244 is a likely trigger).

## Test plan
- [x] 291 backend tests pass (282 baseline + 9 new in `test_reference_number_service.py` covering first allocation, sequential increment, year reset, scope isolation, unknown-scope error, format parse round-trip, non-canonical parse, registry coverage).
- [x] Frontend build clean.
- [ ] Verify migration runs on web01.
- [ ] Smoke-test creating a sale on web01 (confirms allocator wired in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)