### PR TITLE
feat(email): Phase 1 SMTP send for invoices and quotes (#244)

### DIFF
--- a/backend/alembic/versions/20260509_02_add_email_deliveries.py
+++ b/backend/alembic/versions/20260509_02_add_email_deliveries.py
@@ -1,0 +1,57 @@
+"""add email_deliveries audit table
+
+Revision ID: 20260509_02
+Revises: 20260509_01
+Create Date: 2026-05-09 17:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_02"
+down_revision = "20260509_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "email_deliveries",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("scope", sa.String(length=40), nullable=False),
+        sa.Column("record_id", sa.UUID(), nullable=False),
+        sa.Column("to_email", sa.String(length=320), nullable=False),
+        sa.Column("cc", sa.String(length=1000), nullable=True),
+        sa.Column("bcc", sa.String(length=1000), nullable=True),
+        sa.Column("from_email", sa.String(length=320), nullable=False),
+        sa.Column("from_name", sa.String(length=200), nullable=False),
+        sa.Column("subject", sa.String(length=500), nullable=False),
+        sa.Column("body_text", sa.Text(), nullable=True),
+        sa.Column("body_html", sa.Text(), nullable=True),
+        sa.Column("transport", sa.String(length=20), nullable=False),
+        sa.Column("provider_message_id", sa.String(length=200), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("sent_by_user_id", sa.UUID(), nullable=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["sent_by_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_email_deliveries_scope", "email_deliveries", ["scope"])
+    op.create_index("ix_email_deliveries_record_id", "email_deliveries", ["record_id"])
+    op.create_index("ix_email_deliveries_provider_message_id", "email_deliveries", ["provider_message_id"])
+    op.create_index("ix_email_deliveries_status", "email_deliveries", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_email_deliveries_status", table_name="email_deliveries")
+    op.drop_index("ix_email_deliveries_provider_message_id", table_name="email_deliveries")
+    op.drop_index("ix_email_deliveries_record_id", table_name="email_deliveries")
+    op.drop_index("ix_email_deliveries_scope", table_name="email_deliveries")
+    op.drop_table("email_deliveries")

--- a/backend/app/api/v1/endpoints/email.py
+++ b/backend/app/api/v1/endpoints/email.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, EmailStr, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.customer import Customer
+from app.models.email_delivery import EmailDelivery
+from app.models.invoice import Invoice
+from app.models.quote import Quote
+from app.models.setting import Setting
+from app.services.email_service import (
+    EmailConfigError,
+    EmailSendError,
+    render_invoice_template,
+    render_quote_template,
+    send_email,
+)
+
+
+router = APIRouter(tags=["Email"])
+
+
+class EmailSendRequest(BaseModel):
+    to_email: EmailStr | None = None
+    cc: list[EmailStr] = Field(default_factory=list)
+    bcc: list[EmailStr] = Field(default_factory=list)
+    subject_override: str | None = Field(None, max_length=500)
+
+
+class EmailDeliveryResponse(BaseModel):
+    id: uuid.UUID
+    scope: str
+    record_id: uuid.UUID
+    to_email: str
+    from_email: str
+    from_name: str
+    subject: str
+    transport: str
+    provider_message_id: str | None
+    status: str
+    sent_at: str | None
+    error: str | None
+
+    @classmethod
+    def from_model(cls, m: EmailDelivery) -> "EmailDeliveryResponse":
+        return cls(
+            id=m.id,
+            scope=m.scope,
+            record_id=m.record_id,
+            to_email=m.to_email,
+            from_email=m.from_email,
+            from_name=m.from_name,
+            subject=m.subject,
+            transport=m.transport,
+            provider_message_id=m.provider_message_id,
+            status=m.status,
+            sent_at=m.sent_at.isoformat() if m.sent_at else None,
+            error=m.error,
+        )
+
+
+async def _resolve_customer_name(db, customer_id, fallback) -> tuple[str, str | None]:
+    """Returns (to_email_or_empty, customer_name_or_none)."""
+    if not customer_id:
+        return "", fallback
+    row = (await db.execute(select(Customer).where(Customer.id == customer_id))).scalar_one_or_none()
+    if not row:
+        return "", fallback
+    return (row.email or ""), (row.name or fallback)
+
+
+async def _business_name(db) -> str:
+    row = (await db.execute(select(Setting).where(Setting.key == "business_name"))).scalar_one_or_none()
+    return (row.value if row else "").strip() or "Your Business"
+
+
+@router.post(
+    "/invoices/{invoice_id}/email",
+    response_model=EmailDeliveryResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Send an invoice via email",
+)
+async def email_invoice(invoice_id: uuid.UUID, body: EmailSendRequest, user: CurrentUser, db: DB):
+    invoice = (await db.execute(select(Invoice).where(Invoice.id == invoice_id, Invoice.is_deleted == False))).scalar_one_or_none()
+    if not invoice:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+
+    customer_email, customer_name = await _resolve_customer_name(db, invoice.customer_id, invoice.customer_name)
+    to_email = body.to_email or customer_email
+    if not to_email:
+        raise HTTPException(status_code=400, detail="No to_email supplied and customer has no email on file")
+
+    business_name = await _business_name(db)
+    subject, body_text, body_html = render_invoice_template(invoice, business_name, customer_name)
+    if body.subject_override:
+        subject = body.subject_override
+
+    try:
+        delivery = await send_email(
+            db,
+            scope="invoice",
+            record_id=invoice.id,
+            to_email=str(to_email),
+            subject=subject,
+            body_text=body_text,
+            body_html=body_html,
+            cc=[str(c) for c in body.cc],
+            bcc=[str(c) for c in body.bcc],
+            sent_by_user_id=user.id,
+        )
+    except EmailConfigError as e:
+        raise HTTPException(status_code=400, detail=f"Email transport not configured: {e}") from e
+    except EmailSendError as e:
+        # send_email already persisted the failed delivery row; surface 502 to caller.
+        raise HTTPException(status_code=502, detail=f"SMTP send failed: {e}") from e
+
+    await db.commit()
+    return EmailDeliveryResponse.from_model(delivery)
+
+
+@router.post(
+    "/quotes/{quote_id}/email",
+    response_model=EmailDeliveryResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Send a quote via email",
+)
+async def email_quote(quote_id: uuid.UUID, body: EmailSendRequest, user: CurrentUser, db: DB):
+    quote = (await db.execute(select(Quote).where(Quote.id == quote_id, Quote.is_deleted == False))).scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    customer_email, customer_name = await _resolve_customer_name(db, quote.customer_id, quote.customer_name)
+    to_email = body.to_email or customer_email
+    if not to_email:
+        raise HTTPException(status_code=400, detail="No to_email supplied and customer has no email on file")
+
+    business_name = await _business_name(db)
+    subject, body_text, body_html = render_quote_template(quote, business_name, customer_name)
+    if body.subject_override:
+        subject = body.subject_override
+
+    try:
+        delivery = await send_email(
+            db,
+            scope="quote",
+            record_id=quote.id,
+            to_email=str(to_email),
+            subject=subject,
+            body_text=body_text,
+            body_html=body_html,
+            cc=[str(c) for c in body.cc],
+            bcc=[str(c) for c in body.bcc],
+            sent_by_user_id=user.id,
+        )
+    except EmailConfigError as e:
+        raise HTTPException(status_code=400, detail=f"Email transport not configured: {e}") from e
+    except EmailSendError as e:
+        raise HTTPException(status_code=502, detail=f"SMTP send failed: {e}") from e
+
+    await db.commit()
+    return EmailDeliveryResponse.from_model(delivery)
+
+
+@router.get(
+    "/invoices/{invoice_id}/email-deliveries",
+    response_model=list[EmailDeliveryResponse],
+    summary="List email send history for an invoice",
+)
+async def list_invoice_deliveries(invoice_id: uuid.UUID, user: CurrentUser, db: DB):
+    rows = (
+        await db.execute(
+            select(EmailDelivery)
+            .where(EmailDelivery.scope == "invoice", EmailDelivery.record_id == invoice_id)
+            .order_by(EmailDelivery.created_at.desc())
+        )
+    ).scalars().all()
+    return [EmailDeliveryResponse.from_model(r) for r in rows]
+
+
+@router.get(
+    "/quotes/{quote_id}/email-deliveries",
+    response_model=list[EmailDeliveryResponse],
+    summary="List email send history for a quote",
+)
+async def list_quote_deliveries(quote_id: uuid.UUID, user: CurrentUser, db: DB):
+    rows = (
+        await db.execute(
+            select(EmailDelivery)
+            .where(EmailDelivery.scope == "quote", EmailDelivery.record_id == quote_id)
+            .order_by(EmailDelivery.created_at.desc())
+        )
+    ).scalars().all()
+    return [EmailDeliveryResponse.from_model(r) for r in rows]

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, audit, auth, cameras, customers, dashboard, insights, inventory, invoices, jobs, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, supplies, tax
+from app.api.v1.endpoints import accounting, approvals, audit, auth, cameras, customers, dashboard, email, insights, inventory, invoices, jobs, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -27,3 +27,4 @@ api_router.include_router(reports.router)
 api_router.include_router(dashboard.router)
 api_router.include_router(insights.router)
 api_router.include_router(tax.router)
+api_router.include_router(email.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
 from app.models.camera import Camera  # noqa: F401
+from app.models.email_delivery import EmailDelivery  # noqa: F401
 from app.models.product_bom_item import ProductBOMItem  # noqa: F401
 from app.models.reference_sequence import ReferenceSequence  # noqa: F401
 from app.models.supply import Supply  # noqa: F401

--- a/backend/app/models/email_delivery.py
+++ b/backend/app/models/email_delivery.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class EmailDelivery(Base):
+    """Per-send record for outbound transactional email.
+
+    Polymorphic via `(scope, record_id)` so a single audit table covers
+    invoice and quote sends today plus any future scopes (credit notes,
+    delivery notes, ...) that wire into the email service.
+    """
+
+    __tablename__ = "email_deliveries"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    scope: Mapped[str] = mapped_column(String(40), index=True)
+    record_id: Mapped[uuid.UUID] = mapped_column(index=True)
+    to_email: Mapped[str] = mapped_column(String(320))
+    cc: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    bcc: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    from_email: Mapped[str] = mapped_column(String(320))
+    from_name: Mapped[str] = mapped_column(String(200))
+    subject: Mapped[str] = mapped_column(String(500))
+    body_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    body_html: Mapped[str | None] = mapped_column(Text, nullable=True)
+    transport: Mapped[str] = mapped_column(String(20))
+    provider_message_id: Mapped[str | None] = mapped_column(String(200), nullable=True, index=True)
+    status: Mapped[str] = mapped_column(String(20), index=True)
+    sent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    sent_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id"), nullable=True
+    )
+    attempts: Mapped[int] = mapped_column(Integer, default=1)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,0 +1,295 @@
+"""Outbound transactional email — Phase 1 of #244.
+
+Phase 1 ships SMTP send for invoices and quotes with HTML+text body. PDF
+attachment (WeasyPrint), Resend transport, opens-tracking, and webhook
+signature verification are deferred to follow-up issues so the Docker
+image doesn't need cairo/pango/svix dependencies in this PR.
+
+Templates are hard-coded in this module for Phase 1; promoting them to
+operator-editable settings is a Phase 2 follow-up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import smtplib
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from email.message import EmailMessage
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.email_delivery import EmailDelivery
+from app.models.invoice import Invoice
+from app.models.quote import Quote
+from app.models.setting import Setting
+
+log = logging.getLogger(__name__)
+
+EmailScope = Literal["invoice", "quote"]
+
+
+class EmailConfigError(RuntimeError):
+    """Raised when SMTP settings are missing or invalid."""
+
+
+class EmailSendError(RuntimeError):
+    """Raised when the SMTP transport returns an error."""
+
+
+@dataclass
+class EmailMessagePayload:
+    to: list[str]
+    from_address: str
+    from_name: str
+    subject: str
+    body_text: str
+    body_html: str
+    cc: list[str] = field(default_factory=list)
+    bcc: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SmtpConfig:
+    host: str
+    port: int
+    username: str | None
+    password: str | None
+    use_tls: bool
+    from_address: str
+    from_name: str
+
+
+async def _load_setting(db: AsyncSession, key: str) -> str:
+    row = (await db.execute(select(Setting).where(Setting.key == key))).scalar_one_or_none()
+    return row.value if row else ""
+
+
+async def load_smtp_config(db: AsyncSession) -> SmtpConfig:
+    keys = [
+        "email_smtp_host",
+        "email_smtp_port",
+        "email_smtp_username",
+        "email_smtp_password",
+        "email_smtp_use_tls",
+        "email_from_address",
+        "email_from_name",
+    ]
+    values = {k: await _load_setting(db, k) for k in keys}
+    host = values["email_smtp_host"].strip()
+    from_address = values["email_from_address"].strip()
+    if not host:
+        raise EmailConfigError("email_smtp_host is not set")
+    if not from_address:
+        raise EmailConfigError("email_from_address is not set")
+    try:
+        port = int(values["email_smtp_port"] or "587")
+    except ValueError as e:
+        raise EmailConfigError(f"email_smtp_port must be an integer: {e}") from e
+    return SmtpConfig(
+        host=host,
+        port=port,
+        username=values["email_smtp_username"].strip() or None,
+        password=values["email_smtp_password"] or None,
+        use_tls=values["email_smtp_use_tls"].strip().lower() in ("true", "1", "yes"),
+        from_address=from_address,
+        from_name=values["email_from_name"].strip() or from_address,
+    )
+
+
+def _build_mime(payload: EmailMessagePayload) -> EmailMessage:
+    msg = EmailMessage()
+    msg["From"] = f"{payload.from_name} <{payload.from_address}>"
+    msg["To"] = ", ".join(payload.to)
+    if payload.cc:
+        msg["Cc"] = ", ".join(payload.cc)
+    msg["Subject"] = payload.subject
+    msg.set_content(payload.body_text)
+    msg.add_alternative(payload.body_html, subtype="html")
+    return msg
+
+
+def _smtp_send_blocking(config: SmtpConfig, payload: EmailMessagePayload) -> str:
+    """Run synchronously inside `asyncio.to_thread`. Returns the Message-ID
+    header that the server (or our composed MIME) carries — we use it as the
+    provider_message_id for the audit trail.
+    """
+    msg = _build_mime(payload)
+    server: smtplib.SMTP
+    if config.use_tls:
+        server = smtplib.SMTP(config.host, config.port, timeout=30)
+        server.ehlo()
+        server.starttls()
+        server.ehlo()
+    else:
+        server = smtplib.SMTP(config.host, config.port, timeout=30)
+    try:
+        if config.username and config.password:
+            server.login(config.username, config.password)
+        all_rcpts = list(payload.to) + list(payload.cc) + list(payload.bcc)
+        server.send_message(msg, from_addr=config.from_address, to_addrs=all_rcpts)
+    finally:
+        try:
+            server.quit()
+        except Exception:  # noqa: BLE001
+            server.close()
+    return msg.get("Message-ID", "")
+
+
+# ---------- Templates (Phase 1: hard-coded, edit-via-code) ----------
+
+INVOICE_SUBJECT = "Invoice {invoice_number} from {business_name}"
+INVOICE_BODY_TEXT = """Hi{name_clause},
+
+Please find your invoice {invoice_number} below.
+
+Total: {total}
+Issue date: {issue_date}
+Due date: {due_date}
+
+Thank you,
+{business_name}
+"""
+INVOICE_BODY_HTML = """\
+<!doctype html>
+<html><body style="font-family: -apple-system, system-ui, Segoe UI, sans-serif; max-width: 600px; margin: 0 auto;">
+<h2 style="color: #111;">Invoice {invoice_number}</h2>
+<p>Hi{name_clause},</p>
+<p>Please find your invoice details below:</p>
+<table style="border-collapse: collapse; margin: 1em 0;">
+<tr><td style="padding: 4px 12px;"><strong>Issue date</strong></td><td style="padding: 4px 12px;">{issue_date}</td></tr>
+<tr><td style="padding: 4px 12px;"><strong>Due date</strong></td><td style="padding: 4px 12px;">{due_date}</td></tr>
+<tr><td style="padding: 4px 12px;"><strong>Total</strong></td><td style="padding: 4px 12px;">{total}</td></tr>
+</table>
+<p>Thank you,<br/>{business_name}</p>
+</body></html>
+"""
+
+QUOTE_SUBJECT = "Quote {quote_number} from {business_name}"
+QUOTE_BODY_TEXT = """Hi{name_clause},
+
+Please find your quote {quote_number} below.
+
+Product: {product_name}
+Total: {total}
+Valid until: {valid_until}
+
+Thank you,
+{business_name}
+"""
+QUOTE_BODY_HTML = """\
+<!doctype html>
+<html><body style="font-family: -apple-system, system-ui, Segoe UI, sans-serif; max-width: 600px; margin: 0 auto;">
+<h2 style="color: #111;">Quote {quote_number}</h2>
+<p>Hi{name_clause},</p>
+<p>Please find your quote details below:</p>
+<table style="border-collapse: collapse; margin: 1em 0;">
+<tr><td style="padding: 4px 12px;"><strong>Product</strong></td><td style="padding: 4px 12px;">{product_name}</td></tr>
+<tr><td style="padding: 4px 12px;"><strong>Total</strong></td><td style="padding: 4px 12px;">{total}</td></tr>
+<tr><td style="padding: 4px 12px;"><strong>Valid until</strong></td><td style="padding: 4px 12px;">{valid_until}</td></tr>
+</table>
+<p>Thank you,<br/>{business_name}</p>
+</body></html>
+"""
+
+
+def _name_clause(name: str | None) -> str:
+    return f" {name}" if name and name.strip() else ""
+
+
+def render_invoice_template(invoice: Invoice, business_name: str, customer_name: str | None) -> tuple[str, str, str]:
+    ctx = {
+        "invoice_number": invoice.invoice_number,
+        "issue_date": invoice.issue_date.isoformat() if invoice.issue_date else "",
+        "due_date": invoice.due_date.isoformat() if invoice.due_date else "n/a",
+        "total": f"${invoice.total_due:,.2f}" if invoice.total_due is not None else "",
+        "business_name": business_name,
+        "name_clause": _name_clause(customer_name),
+    }
+    return (
+        INVOICE_SUBJECT.format(**ctx),
+        INVOICE_BODY_TEXT.format(**ctx),
+        INVOICE_BODY_HTML.format(**ctx),
+    )
+
+
+def render_quote_template(quote: Quote, business_name: str, customer_name: str | None) -> tuple[str, str, str]:
+    ctx = {
+        "quote_number": quote.quote_number,
+        "product_name": quote.product_name or "",
+        "valid_until": quote.valid_until.isoformat() if quote.valid_until else "n/a",
+        "total": f"${quote.total_revenue:,.2f}" if getattr(quote, "total_revenue", None) is not None else "",
+        "business_name": business_name,
+        "name_clause": _name_clause(customer_name),
+    }
+    return (
+        QUOTE_SUBJECT.format(**ctx),
+        QUOTE_BODY_TEXT.format(**ctx),
+        QUOTE_BODY_HTML.format(**ctx),
+    )
+
+
+# ---------- Send + audit ----------
+
+async def send_email(
+    db: AsyncSession,
+    *,
+    scope: EmailScope,
+    record_id: uuid.UUID,
+    to_email: str,
+    subject: str,
+    body_text: str,
+    body_html: str,
+    cc: list[str] | None = None,
+    bcc: list[str] | None = None,
+    sent_by_user_id: uuid.UUID | None = None,
+) -> EmailDelivery:
+    """Send and persist an EmailDelivery row regardless of outcome."""
+    config = await load_smtp_config(db)
+    payload = EmailMessagePayload(
+        to=[to_email],
+        from_address=config.from_address,
+        from_name=config.from_name,
+        subject=subject,
+        body_text=body_text,
+        body_html=body_html,
+        cc=cc or [],
+        bcc=bcc or [],
+    )
+
+    delivery = EmailDelivery(
+        scope=scope,
+        record_id=record_id,
+        to_email=to_email,
+        cc=", ".join(payload.cc) if payload.cc else None,
+        bcc=", ".join(payload.bcc) if payload.bcc else None,
+        from_email=config.from_address,
+        from_name=config.from_name,
+        subject=subject,
+        body_text=body_text,
+        body_html=body_html,
+        transport="smtp",
+        status="pending",
+        sent_by_user_id=sent_by_user_id,
+    )
+    db.add(delivery)
+    await db.flush()
+
+    try:
+        message_id = await asyncio.to_thread(_smtp_send_blocking, config, payload)
+    except Exception as e:  # noqa: BLE001
+        delivery.status = "failed"
+        delivery.error = f"{type(e).__name__}: {e}"
+        await db.flush()
+        log.exception("email send failed", extra={"scope": scope, "record_id": str(record_id)})
+        raise EmailSendError(str(e)) from e
+
+    delivery.status = "sent"
+    delivery.sent_at = datetime.now(timezone.utc)
+    delivery.provider_message_id = message_id or None
+    await db.flush()
+    return delivery

--- a/backend/app/services/settings_defaults.py
+++ b/backend/app/services/settings_defaults.py
@@ -27,4 +27,15 @@ LABEL_SETTINGS_DATA = [
     ("barcode_include_price", "false", "Include unit price on printed labels."),
 ]
 
-SETTINGS_DATA = BUSINESS_SETTINGS_DATA + AI_SETTINGS_DATA + LABEL_SETTINGS_DATA
+EMAIL_SETTINGS_DATA = [
+    ("email_transport", "smtp", "Outbound email transport: smtp (Phase 1). Resend planned in a follow-up."),
+    ("email_smtp_host", "", "SMTP server host (e.g. smtp.gmail.com, smtp.sendgrid.net)."),
+    ("email_smtp_port", "587", "SMTP port. 587 for STARTTLS, 465 for SMTPS, 25 unencrypted."),
+    ("email_smtp_username", "", "SMTP login username."),
+    ("email_smtp_password", "", "SMTP login password / API token. Stored plaintext in v1; encryption is a follow-up."),
+    ("email_smtp_use_tls", "true", "Whether to STARTTLS upgrade after EHLO. true/false."),
+    ("email_from_address", "", "Outbound from-address shown to recipients."),
+    ("email_from_name", "", "Outbound from-name shown to recipients."),
+]
+
+SETTINGS_DATA = BUSINESS_SETTINGS_DATA + AI_SETTINGS_DATA + LABEL_SETTINGS_DATA + EMAIL_SETTINGS_DATA

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from app.models.email_delivery import EmailDelivery
+from app.models.invoice import Invoice
+from app.models.setting import Setting
+from app.services.email_service import (
+    EmailConfigError,
+    EmailSendError,
+    load_smtp_config,
+    render_invoice_template,
+    send_email,
+)
+
+
+async def _seed_smtp_settings(db_session):
+    rows = [
+        ("email_transport", "smtp"),
+        ("email_smtp_host", "smtp.example.com"),
+        ("email_smtp_port", "587"),
+        ("email_smtp_username", "user"),
+        ("email_smtp_password", "pw"),
+        ("email_smtp_use_tls", "true"),
+        ("email_from_address", "noreply@example.com"),
+        ("email_from_name", "Test Shop"),
+        ("business_name", "Test Shop"),
+    ]
+    for k, v in rows:
+        db_session.add(Setting(key=k, value=v))
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_load_smtp_config_happy(db_session):
+    await _seed_smtp_settings(db_session)
+    cfg = await load_smtp_config(db_session)
+    assert cfg.host == "smtp.example.com"
+    assert cfg.port == 587
+    assert cfg.username == "user"
+    assert cfg.use_tls is True
+    assert cfg.from_address == "noreply@example.com"
+    assert cfg.from_name == "Test Shop"
+
+
+@pytest.mark.asyncio
+async def test_load_smtp_config_missing_host_raises(db_session):
+    db_session.add(Setting(key="email_smtp_host", value=""))
+    db_session.add(Setting(key="email_from_address", value="x@y.z"))
+    await db_session.commit()
+    with pytest.raises(EmailConfigError):
+        await load_smtp_config(db_session)
+
+
+def test_render_invoice_template_substitutes_fields():
+    invoice = Invoice(
+        id=None,
+        invoice_number="INV-2026-0001",
+        issue_date=datetime.date(2026, 5, 1),
+        due_date=datetime.date(2026, 5, 31),
+        subtotal=Decimal("100"),
+        tax_amount=Decimal("8"),
+        shipping_amount=Decimal("0"),
+        credits_applied=Decimal("0"),
+        total_due=Decimal("108"),
+        amount_paid=Decimal("0"),
+    )
+    subject, body_text, body_html = render_invoice_template(invoice, "Test Shop", "Alice")
+    assert "INV-2026-0001" in subject
+    assert "Test Shop" in subject
+    assert "Alice" in body_text
+    assert "$108.00" in body_text
+    assert "INV-2026-0001" in body_html
+    assert "$108.00" in body_html
+
+
+@pytest.mark.asyncio
+async def test_send_email_persists_sent_row_and_calls_smtp(db_session):
+    await _seed_smtp_settings(db_session)
+
+    mock_server = MagicMock()
+    mock_server.get.return_value = "<msg-1@test>"
+    with patch("app.services.email_service.smtplib.SMTP", return_value=mock_server):
+        delivery = await send_email(
+            db_session,
+            scope="invoice",
+            record_id=__import__("uuid").uuid4(),
+            to_email="customer@example.com",
+            subject="Test",
+            body_text="text body",
+            body_html="<p>html body</p>",
+        )
+    await db_session.commit()
+
+    rows = (await db_session.execute(select(EmailDelivery))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].status == "sent"
+    assert rows[0].to_email == "customer@example.com"
+    assert rows[0].sent_at is not None
+    mock_server.send_message.assert_called_once()
+    mock_server.quit.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_send_email_records_failure_and_raises(db_session):
+    await _seed_smtp_settings(db_session)
+
+    mock_server = MagicMock()
+    mock_server.send_message.side_effect = RuntimeError("connection refused")
+    with patch("app.services.email_service.smtplib.SMTP", return_value=mock_server):
+        with pytest.raises(EmailSendError):
+            await send_email(
+                db_session,
+                scope="invoice",
+                record_id=__import__("uuid").uuid4(),
+                to_email="customer@example.com",
+                subject="Test",
+                body_text="text body",
+                body_html="<p>html</p>",
+            )
+    await db_session.commit()
+
+    rows = (await db_session.execute(select(EmailDelivery))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].status == "failed"
+    assert "connection refused" in (rows[0].error or "")

--- a/docs/email_send.md
+++ b/docs/email_send.md
@@ -1,0 +1,62 @@
+# Outbound Email — Phase 1
+
+Operators send invoices and quotes to customers via SMTP. Each send persists an `EmailDelivery` audit row (sent / failed) so the history is visible per record.
+
+## Phase 1 scope (this PR)
+
+- **Transport: SMTP only.** Generic SMTP host + port + STARTTLS + login.
+- **Body: HTML + plain-text alternative.** Hard-coded templates for `invoice` and `quote` (see `app/services/email_service.py`).
+- **Audit: every send persists a row** in `email_deliveries` with status `sent` or `failed` and the SMTP `Message-ID`.
+- **No attachments.** PDF generation deferred to Phase 2 (needs WeasyPrint + Cairo/Pango in the Docker image).
+- **No Resend transport.** Deferred to Phase 2.
+- **No delivery-status webhooks.** SMTP doesn't provide them; Resend does, but Resend is Phase 2.
+- **No opens tracking.** Tied to a transactional provider (Phase 2).
+- **No editable templates.** Phase 1 uses code-defined templates; Phase 2 promotes to operator-editable settings (which requires a Setting.value column type bump from String(255) → Text — also deferred).
+
+## Settings (admin)
+
+| Key | Default | Notes |
+|---|---|---|
+| `email_transport` | `smtp` | Future: `resend` |
+| `email_smtp_host` | (empty) | e.g. `smtp.gmail.com`, `smtp.sendgrid.net` |
+| `email_smtp_port` | `587` | 587 STARTTLS, 465 SMTPS, 25 plaintext |
+| `email_smtp_username` | (empty) | |
+| `email_smtp_password` | (empty) | **Plaintext in v1.** Encryption-at-rest deferred. Use a sender-only API token (e.g. SendGrid restricted key, Postmark API token) rather than your real account password. |
+| `email_smtp_use_tls` | `true` | Whether to STARTTLS after EHLO |
+| `email_from_address` | (empty) | |
+| `email_from_name` | (empty) | Falls back to from_address if blank |
+
+If `email_smtp_host` or `email_from_address` is unset, the send endpoints return 400 with a clear "transport not configured" message.
+
+## API
+
+- `POST /api/v1/invoices/{invoice_id}/email` — body: `{ to_email?, cc?, bcc?, subject_override? }`. Resolves `to_email` from the invoice's customer email if not supplied. Returns the `EmailDelivery` row.
+- `POST /api/v1/quotes/{quote_id}/email` — same shape against quotes.
+- `GET /api/v1/invoices/{id}/email-deliveries` and `GET /api/v1/quotes/{id}/email-deliveries` — history list, newest first.
+
+The send is **synchronous** — the API call blocks on the SMTP round-trip (typically 0.5–2s; up to ~30s on flaky transports). On send failure the `EmailDelivery` row is still persisted with `status='failed'` so the audit trail is complete; the API returns 502 to the caller.
+
+## Operator runbook
+
+1. Pick an SMTP provider (Gmail SMTP for personal, SendGrid / Postmark / Mailgun for business). Generate a sender-only API token.
+2. In settings, set `email_smtp_host`, `email_smtp_port`, `email_smtp_username`, `email_smtp_password`, `email_from_address`, `email_from_name`.
+3. Test by issuing `POST /api/v1/invoices/{id}/email` against a real invoice (or via the upcoming frontend send modal).
+4. If the send fails, check the `email_deliveries` row's `error` column for the SMTP exception.
+
+## Phase 2 follow-ups (track separately)
+
+These are intentionally not in this PR; each can be its own issue when prioritized.
+
+1. **WeasyPrint PDF rendering** for invoice/quote attachments. Adds Cairo/Pango/gdk-pixbuf system deps to the Docker image. Render an invoice/quote to PDF and attach to the outbound email.
+2. **Resend transport.** Pluggable transport interface + `ResendEmailTransport`. Adds `httpx` POST to `https://api.resend.com/emails`.
+3. **Resend webhook.** Signature verification via `svix`, status updates on `EmailDelivery` (`delivered`, `bounced`, `complained`, opens count).
+4. **Opens tracking pixel** (Resend-provided).
+5. **Editable templates** in settings. Requires extending `Setting.value` from `String(255)` → `Text`.
+6. **At-rest encryption** for `email_smtp_password` (Fernet via app secret key).
+7. **Frontend send modal** with PDF preview and editable subject/body. Currently no invoice/quote create UI exists in the React surface (API-only); the modal would land alongside whichever issue introduces those forms.
+
+## Phase 1 limitations to call out to operators
+
+- **No PDF attachment.** The body has a summary; for the full invoice/quote line breakdown the customer should still log into the admin (or wait for Phase 2).
+- **Plaintext password storage.** Use a restricted API token, not your account password.
+- **No retry.** A 502 on send means try again from the UI; that creates a new `EmailDelivery` row each time.


### PR DESCRIPTION
## Summary
Phase 1 of [#244](https://github.com/bbengt1/3d-print-sales/issues/244) — operators can send invoices and quotes via SMTP with HTML+text body, and see per-record send history. PDF attachment (WeasyPrint), Resend transport, opens-tracking webhooks, and editable templates are explicitly **deferred to Phase 2 follow-ups** to keep this PR free of Docker native-dep changes and to land the audit/transport plumbing first.

What ships:
- `EmailDelivery` model + migration with status (sent/failed) per send.
- `email_service.py` — stdlib `smtplib` in `asyncio.to_thread`, hard-coded invoice/quote templates.
- Send endpoints + history endpoints on invoice/quote.
- Settings (`email_smtp_*`, `email_from_address`, `email_from_name`).
- Doc: [docs/email_send.md](docs/email_send.md) — covers scope, settings, runbook, Phase 2 list.

The doc explicitly enumerates Phase 2 follow-ups so they can be opened as separate issues when prioritized: WeasyPrint PDF, Resend transport, Resend webhook, opens tracking, editable templates (needs `Setting.value` Text bump), at-rest password encryption, frontend send modal.

## Test plan
- [x] 296 backend tests pass (291 baseline + 5 new in `test_email_service.py`: smtp config load happy/missing, template substitution, send happy with mocked smtplib, send failure persists `failed` row).
- [x] Frontend build clean.
- [ ] Migration runs on web01.
- [ ] Smoke test by configuring SMTP (e.g. SendGrid sandbox) and sending one real invoice email post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)