### PR TITLE
feat(banking): bank account typing + reconciliation worksheet (#239)

### DIFF
--- a/backend/alembic/versions/20260509_03_add_bank_reconciliation.py
+++ b/backend/alembic/versions/20260509_03_add_bank_reconciliation.py
@@ -1,0 +1,107 @@
+"""add bank account typing, journal_line.cleared_status, and bank reconciliation tables
+
+Revision ID: 20260509_03
+Revises: 20260509_02
+Create Date: 2026-05-09 18:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_03"
+down_revision = "20260509_02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Account.is_bank_account + Account.bank_account_kind
+    op.add_column(
+        "accounts",
+        sa.Column("is_bank_account", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "accounts",
+        sa.Column("bank_account_kind", sa.String(length=30), nullable=True),
+    )
+    op.create_index("ix_accounts_is_bank_account", "accounts", ["is_bank_account"])
+
+    # JournalLine.cleared_status
+    op.add_column(
+        "journal_lines",
+        sa.Column(
+            "cleared_status",
+            sa.String(length=15),
+            nullable=False,
+            server_default="uncleared",
+        ),
+    )
+    op.create_index("ix_journal_lines_cleared_status", "journal_lines", ["cleared_status"])
+
+    # BankReconciliation
+    op.create_table(
+        "bank_reconciliations",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("account_id", sa.UUID(), nullable=False),
+        sa.Column("statement_end_date", sa.Date(), nullable=False),
+        sa.Column("statement_ending_balance", sa.Numeric(14, 4), nullable=False),
+        sa.Column("opening_balance", sa.Numeric(14, 4), nullable=False, server_default="0"),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="in_progress"),
+        sa.Column("finalized_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finalized_by_user_id", sa.UUID(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["account_id"], ["accounts.id"]),
+        sa.ForeignKeyConstraint(["finalized_by_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_bank_reconciliations_account_id", "bank_reconciliations", ["account_id"])
+    op.create_index("ix_bank_reconciliations_status", "bank_reconciliations", ["status"])
+
+    # BankReconciliationLine
+    op.create_table(
+        "bank_reconciliation_lines",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("reconciliation_id", sa.UUID(), nullable=False),
+        sa.Column("journal_line_id", sa.UUID(), nullable=False),
+        sa.Column("amount", sa.Numeric(14, 4), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["reconciliation_id"], ["bank_reconciliations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["journal_line_id"], ["journal_lines.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "reconciliation_id", "journal_line_id",
+            name="uq_bank_reconciliation_lines_recon_line",
+        ),
+    )
+    op.create_index(
+        "ix_bank_reconciliation_lines_reconciliation_id",
+        "bank_reconciliation_lines",
+        ["reconciliation_id"],
+    )
+    op.create_index(
+        "ix_bank_reconciliation_lines_journal_line_id",
+        "bank_reconciliation_lines",
+        ["journal_line_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_bank_reconciliation_lines_journal_line_id", table_name="bank_reconciliation_lines")
+    op.drop_index("ix_bank_reconciliation_lines_reconciliation_id", table_name="bank_reconciliation_lines")
+    op.drop_table("bank_reconciliation_lines")
+
+    op.drop_index("ix_bank_reconciliations_status", table_name="bank_reconciliations")
+    op.drop_index("ix_bank_reconciliations_account_id", table_name="bank_reconciliations")
+    op.drop_table("bank_reconciliations")
+
+    op.drop_index("ix_journal_lines_cleared_status", table_name="journal_lines")
+    op.drop_column("journal_lines", "cleared_status")
+
+    op.drop_index("ix_accounts_is_bank_account", table_name="accounts")
+    op.drop_column("accounts", "bank_account_kind")
+    op.drop_column("accounts", "is_bank_account")

--- a/backend/app/api/v1/endpoints/banking.py
+++ b/backend/app/api/v1/endpoints/banking.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.account import Account
+from app.models.bank_reconciliation import BankReconciliation
+from app.models.journal_entry import JournalEntry
+from app.services.bank_reconciliation_service import (
+    BankReconciliationError,
+    compute_account_balance,
+    compute_book_balance,
+    exclude_line,
+    finalize_reconciliation,
+    include_line,
+    list_eligible_lines,
+    reopen_reconciliation,
+    start_reconciliation,
+)
+
+
+router = APIRouter(prefix="/banking", tags=["Banking"])
+
+
+# ----------- account flagging -----------
+
+
+class BankAccountFlagRequest(BaseModel):
+    is_bank_account: bool
+    bank_account_kind: Literal[
+        "checking", "savings", "credit_card", "payment_processor"
+    ] | None = None
+
+
+class BankAccountResponse(BaseModel):
+    id: uuid.UUID
+    code: str
+    name: str
+    account_type: str
+    is_bank_account: bool
+    bank_account_kind: str | None
+    running_balance: Decimal
+
+
+@router.get("/accounts", response_model=list[BankAccountResponse], summary="List bank-typed accounts with running balance")
+async def list_bank_accounts(user: CurrentUser, db: DB):
+    accounts = (
+        await db.execute(
+            select(Account).where(Account.is_bank_account == True, Account.is_active == True)  # noqa: E712
+        )
+    ).scalars().all()
+    out: list[BankAccountResponse] = []
+    for a in accounts:
+        bal = await compute_account_balance(db, a.id)
+        out.append(
+            BankAccountResponse(
+                id=a.id,
+                code=a.code,
+                name=a.name,
+                account_type=a.account_type,
+                is_bank_account=a.is_bank_account,
+                bank_account_kind=a.bank_account_kind,
+                running_balance=bal,
+            )
+        )
+    return out
+
+
+@router.patch("/accounts/{account_id}/flag", response_model=BankAccountResponse, summary="Flag or unflag a GL account as a bank account")
+async def flag_bank_account(account_id: uuid.UUID, body: BankAccountFlagRequest, user: CurrentUser, db: DB):
+    account = (await db.execute(select(Account).where(Account.id == account_id))).scalar_one_or_none()
+    if not account:
+        raise HTTPException(status_code=404, detail="Account not found")
+    account.is_bank_account = body.is_bank_account
+    account.bank_account_kind = body.bank_account_kind if body.is_bank_account else None
+    await db.commit()
+    bal = await compute_account_balance(db, account.id)
+    return BankAccountResponse(
+        id=account.id,
+        code=account.code,
+        name=account.name,
+        account_type=account.account_type,
+        is_bank_account=account.is_bank_account,
+        bank_account_kind=account.bank_account_kind,
+        running_balance=bal,
+    )
+
+
+# ----------- reconciliations -----------
+
+
+class ReconciliationCreateRequest(BaseModel):
+    account_id: uuid.UUID
+    statement_end_date: date
+    statement_ending_balance: Decimal = Field(...)
+    notes: str | None = None
+
+
+class ReconciliationLineToggle(BaseModel):
+    journal_line_id: uuid.UUID
+    included: bool
+
+
+class JournalLineDTO(BaseModel):
+    id: uuid.UUID
+    journal_entry_id: uuid.UUID
+    entry_date: date
+    description: str | None
+    entry_type: str
+    amount: Decimal
+    cleared_status: str
+
+
+class ReconciliationDetailResponse(BaseModel):
+    id: uuid.UUID
+    account_id: uuid.UUID
+    statement_end_date: date
+    statement_ending_balance: Decimal
+    opening_balance: Decimal
+    book_balance: Decimal
+    variance: Decimal
+    status: str
+    finalized_at: datetime | None
+    notes: str | None
+    eligible_lines: list[JournalLineDTO]
+    included_line_ids: list[uuid.UUID]
+
+
+async def _hydrate_recon(db, recon: BankReconciliation) -> ReconciliationDetailResponse:
+    eligible = await list_eligible_lines(
+        db, account_id=recon.account_id, statement_end_date=recon.statement_end_date
+    )
+    eligible_dtos = [
+        JournalLineDTO(
+            id=line.id,
+            journal_entry_id=line.journal_entry_id,
+            entry_date=entry.entry_date,
+            description=line.description,
+            entry_type=line.entry_type,
+            amount=Decimal(line.amount),
+            cleared_status=line.cleared_status,
+        )
+        for line, entry in eligible
+    ]
+    book = await compute_book_balance(db, recon.id)
+    from app.models.bank_reconciliation import BankReconciliationLine
+    included_ids = [
+        r.journal_line_id
+        for r in (
+            await db.execute(
+                select(BankReconciliationLine).where(BankReconciliationLine.reconciliation_id == recon.id)
+            )
+        ).scalars().all()
+    ]
+    return ReconciliationDetailResponse(
+        id=recon.id,
+        account_id=recon.account_id,
+        statement_end_date=recon.statement_end_date,
+        statement_ending_balance=Decimal(recon.statement_ending_balance),
+        opening_balance=Decimal(recon.opening_balance),
+        book_balance=book,
+        variance=book - Decimal(recon.statement_ending_balance),
+        status=recon.status,
+        finalized_at=recon.finalized_at,
+        notes=recon.notes,
+        eligible_lines=eligible_dtos,
+        included_line_ids=included_ids,
+    )
+
+
+@router.post("/reconciliations", response_model=ReconciliationDetailResponse, status_code=status.HTTP_201_CREATED, summary="Start a reconciliation")
+async def create_reconciliation(body: ReconciliationCreateRequest, user: CurrentUser, db: DB):
+    try:
+        recon = await start_reconciliation(
+            db,
+            account_id=body.account_id,
+            statement_end_date=body.statement_end_date,
+            statement_ending_balance=body.statement_ending_balance,
+            notes=body.notes,
+        )
+    except BankReconciliationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate_recon(db, recon)
+
+
+@router.get("/reconciliations", summary="List reconciliations (filtered by account/status)")
+async def list_reconciliations(user: CurrentUser, db: DB, account_id: uuid.UUID | None = None, recon_status: str | None = None):
+    stmt = select(BankReconciliation).order_by(BankReconciliation.statement_end_date.desc())
+    if account_id is not None:
+        stmt = stmt.where(BankReconciliation.account_id == account_id)
+    if recon_status is not None:
+        stmt = stmt.where(BankReconciliation.status == recon_status)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "id": r.id,
+            "account_id": r.account_id,
+            "statement_end_date": r.statement_end_date,
+            "statement_ending_balance": Decimal(r.statement_ending_balance),
+            "status": r.status,
+            "finalized_at": r.finalized_at,
+        }
+        for r in rows
+    ]
+
+
+@router.get("/reconciliations/{reconciliation_id}", response_model=ReconciliationDetailResponse, summary="Get reconciliation detail")
+async def get_reconciliation(reconciliation_id: uuid.UUID, user: CurrentUser, db: DB):
+    recon = (await db.execute(select(BankReconciliation).where(BankReconciliation.id == reconciliation_id))).scalar_one_or_none()
+    if not recon:
+        raise HTTPException(status_code=404, detail="Reconciliation not found")
+    return await _hydrate_recon(db, recon)
+
+
+@router.patch("/reconciliations/{reconciliation_id}/toggle-line", response_model=ReconciliationDetailResponse, summary="Include or exclude a journal line in the reconciliation")
+async def toggle_recon_line(reconciliation_id: uuid.UUID, body: ReconciliationLineToggle, user: CurrentUser, db: DB):
+    try:
+        if body.included:
+            await include_line(db, reconciliation_id=reconciliation_id, journal_line_id=body.journal_line_id)
+        else:
+            await exclude_line(db, reconciliation_id=reconciliation_id, journal_line_id=body.journal_line_id)
+    except BankReconciliationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    recon = (await db.execute(select(BankReconciliation).where(BankReconciliation.id == reconciliation_id))).scalar_one()
+    return await _hydrate_recon(db, recon)
+
+
+@router.post("/reconciliations/{reconciliation_id}/finalize", response_model=ReconciliationDetailResponse, summary="Finalize a reconciliation (refuses if book != statement)")
+async def finalize_recon(reconciliation_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        recon = await finalize_reconciliation(
+            db, reconciliation_id=reconciliation_id, finalized_by_user_id=user.id
+        )
+    except BankReconciliationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate_recon(db, recon)
+
+
+@router.post("/reconciliations/{reconciliation_id}/reopen", response_model=ReconciliationDetailResponse, summary="Reopen a finalized reconciliation (admin)")
+async def reopen_recon(reconciliation_id: uuid.UUID, user: CurrentUser, db: DB):
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Only admins can reopen a finalized reconciliation")
+    try:
+        recon = await reopen_reconciliation(db, reconciliation_id=reconciliation_id)
+    except BankReconciliationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate_recon(db, recon)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, audit, auth, cameras, customers, dashboard, email, insights, inventory, invoices, jobs, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, supplies, tax
+from app.api.v1.endpoints import accounting, approvals, audit, auth, banking, cameras, customers, dashboard, email, insights, inventory, invoices, jobs, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -28,3 +28,4 @@ api_router.include_router(dashboard.router)
 api_router.include_router(insights.router)
 api_router.include_router(tax.router)
 api_router.include_router(email.router)
+api_router.include_router(banking.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.bank_reconciliation import BankReconciliation, BankReconciliationLine  # noqa: F401
 from app.models.camera import Camera  # noqa: F401
 from app.models.email_delivery import EmailDelivery  # noqa: F401
 from app.models.product_bom_item import ProductBOMItem  # noqa: F401

--- a/backend/app/models/account.py
+++ b/backend/app/models/account.py
@@ -26,6 +26,9 @@ class Account(Base):
     description: Mapped[str | None] = mapped_column(String(255), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     is_system: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_bank_account: Mapped[bool] = mapped_column(Boolean, default=False, index=True)
+    # nullable; one of: checking, savings, credit_card, payment_processor
+    bank_account_kind: Mapped[str | None] = mapped_column(String(30), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/backend/app/models/bank_reconciliation.py
+++ b/backend/app/models/bank_reconciliation.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class BankReconciliation(Base):
+    """One reconciliation = one operator pass against one bank account's
+    statement-end balance. Lifecycle: in_progress → finalized; an admin can
+    reopen a finalized reconciliation back to in_progress (#239).
+    """
+
+    __tablename__ = "bank_reconciliations"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"), index=True)
+    statement_end_date: Mapped[date] = mapped_column(Date)
+    statement_ending_balance: Mapped[Decimal] = mapped_column(Numeric(14, 4))
+    opening_balance: Mapped[Decimal] = mapped_column(Numeric(14, 4), default=0)
+    status: Mapped[str] = mapped_column(String(20), default="in_progress", index=True)
+    finalized_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finalized_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id"), nullable=True
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    lines = relationship("BankReconciliationLine", back_populates="reconciliation", cascade="all, delete-orphan")
+
+
+class BankReconciliationLine(Base):
+    """A `(reconciliation, journal_line)` link recording that the operator
+    matched this journal line to the statement during this reconciliation.
+    Snapshots `amount` for tamper detection.
+    """
+
+    __tablename__ = "bank_reconciliation_lines"
+    __table_args__ = (
+        UniqueConstraint(
+            "reconciliation_id", "journal_line_id",
+            name="uq_bank_reconciliation_lines_recon_line",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    reconciliation_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("bank_reconciliations.id", ondelete="CASCADE"), index=True
+    )
+    journal_line_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("journal_lines.id"), index=True
+    )
+    amount: Mapped[Decimal] = mapped_column(Numeric(14, 4))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    reconciliation = relationship("BankReconciliation", back_populates="lines")

--- a/backend/app/models/journal_line.py
+++ b/backend/app/models/journal_line.py
@@ -20,6 +20,10 @@ class JournalLine(Base):
     entry_type: Mapped[str] = mapped_column(String(10))
     amount: Mapped[Decimal] = mapped_column(Numeric(12, 4), default=0)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Bank reconciliation status. Only meaningful on lines whose account
+    # has is_bank_account=True; ignored otherwise. Values: uncleared,
+    # cleared, reconciled. See #239.
+    cleared_status: Mapped[str] = mapped_column(String(15), default="uncleared", index=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/backend/app/services/bank_reconciliation_service.py
+++ b/backend/app/services/bank_reconciliation_service.py
@@ -1,0 +1,357 @@
+"""Bank reconciliation lifecycle service (#239).
+
+Lifecycle:
+- start: caller provides account_id + statement_end_date + statement_ending_balance.
+  We snapshot opening_balance = sum of cleared+reconciled lines on this account
+  posted before today's effective recon. Status='in_progress'.
+- toggle_line: include/exclude a specific journal line in the recon. Including
+  flips the journal line's cleared_status to 'cleared'; excluding flips it back
+  to 'uncleared' (only safe while the recon is in_progress).
+- finalize: refuses unless `book_balance == statement_ending_balance`. On
+  success flips status='finalized', flips every included line's
+  cleared_status='reconciled', stamps finalized_at + finalized_by_user_id.
+- reopen: admin-only, flips status back to 'in_progress' and every line back
+  to 'cleared' (still kept on the recon, ready for re-finalize).
+
+Hard-block on edits: any attempt to update or delete a journal line whose
+cleared_status='reconciled' is rejected by the service-level guard
+`assert_journal_line_editable`. Endpoints that mutate journal lines should
+call this guard before saving.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account
+from app.models.bank_reconciliation import BankReconciliation, BankReconciliationLine
+from app.models.journal_entry import JournalEntry
+from app.models.journal_line import JournalLine
+
+
+class BankReconciliationError(RuntimeError):
+    """Operational error during reconciliation lifecycle."""
+
+
+class JournalLineLockedError(BankReconciliationError):
+    """Raised when caller tries to edit a journal line whose cleared_status is reconciled."""
+
+
+CLEARED_STATUS_RECONCILED = "reconciled"
+CLEARED_STATUS_CLEARED = "cleared"
+CLEARED_STATUS_UNCLEARED = "uncleared"
+
+STATUS_IN_PROGRESS = "in_progress"
+STATUS_FINALIZED = "finalized"
+
+
+async def _ensure_bank_account(db: AsyncSession, account_id: uuid.UUID) -> Account:
+    account = (await db.execute(select(Account).where(Account.id == account_id))).scalar_one_or_none()
+    if account is None:
+        raise BankReconciliationError(f"Account {account_id} not found")
+    if not account.is_bank_account:
+        raise BankReconciliationError(
+            f"Account {account.code} is not flagged is_bank_account=True"
+        )
+    return account
+
+
+def _signed_amount(line: JournalLine, account: Account) -> Decimal:
+    """Return the signed amount this journal line contributes to the account
+    balance. Debit-normal accounts: debit positive, credit negative; vice
+    versa for credit-normal. (Bank account assets are debit-normal.)
+    """
+    sign = 1 if account.normal_balance == "debit" else -1
+    if line.entry_type == "debit":
+        return Decimal(line.amount) * sign
+    return Decimal(line.amount) * (-sign)
+
+
+async def compute_account_balance(
+    db: AsyncSession,
+    account_id: uuid.UUID,
+    *,
+    only_cleared: bool = False,
+    through_date: date | None = None,
+) -> Decimal:
+    account = (await db.execute(select(Account).where(Account.id == account_id))).scalar_one_or_none()
+    if account is None:
+        raise BankReconciliationError(f"Account {account_id} not found")
+
+    stmt = (
+        select(JournalLine, JournalEntry)
+        .join(JournalEntry, JournalEntry.id == JournalLine.journal_entry_id)
+        .where(JournalLine.account_id == account_id)
+    )
+    rows = (await db.execute(stmt)).all()
+
+    total = Decimal("0")
+    for line, entry in rows:
+        if through_date is not None and entry.entry_date > through_date:
+            continue
+        if only_cleared and line.cleared_status not in (CLEARED_STATUS_CLEARED, CLEARED_STATUS_RECONCILED):
+            continue
+        total += _signed_amount(line, account)
+    return total
+
+
+async def start_reconciliation(
+    db: AsyncSession,
+    *,
+    account_id: uuid.UUID,
+    statement_end_date: date,
+    statement_ending_balance: Decimal,
+    notes: str | None = None,
+) -> BankReconciliation:
+    await _ensure_bank_account(db, account_id)
+
+    opening = await compute_account_balance(
+        db, account_id, only_cleared=True, through_date=statement_end_date
+    )
+
+    recon = BankReconciliation(
+        account_id=account_id,
+        statement_end_date=statement_end_date,
+        statement_ending_balance=Decimal(statement_ending_balance),
+        opening_balance=opening,
+        status=STATUS_IN_PROGRESS,
+        notes=notes,
+    )
+    db.add(recon)
+    await db.flush()
+    return recon
+
+
+async def list_eligible_lines(
+    db: AsyncSession,
+    *,
+    account_id: uuid.UUID,
+    statement_end_date: date,
+) -> list[tuple[JournalLine, JournalEntry]]:
+    """Return (line, entry) pairs for lines posting to this account on or
+    before statement_end_date and not yet reconciled.
+    """
+    stmt = (
+        select(JournalLine, JournalEntry)
+        .join(JournalEntry, JournalEntry.id == JournalLine.journal_entry_id)
+        .where(
+            JournalLine.account_id == account_id,
+            JournalLine.cleared_status != CLEARED_STATUS_RECONCILED,
+            JournalEntry.entry_date <= statement_end_date,
+        )
+        .order_by(JournalEntry.entry_date, JournalLine.line_number)
+    )
+    return list((await db.execute(stmt)).all())
+
+
+async def include_line(
+    db: AsyncSession,
+    *,
+    reconciliation_id: uuid.UUID,
+    journal_line_id: uuid.UUID,
+) -> BankReconciliationLine:
+    recon = await _get_in_progress_recon(db, reconciliation_id)
+
+    line = (await db.execute(select(JournalLine).where(JournalLine.id == journal_line_id))).scalar_one_or_none()
+    if line is None:
+        raise BankReconciliationError(f"Journal line {journal_line_id} not found")
+    if line.account_id != recon.account_id:
+        raise BankReconciliationError("Journal line account does not match reconciliation account")
+    if line.cleared_status == CLEARED_STATUS_RECONCILED:
+        raise BankReconciliationError("Journal line is already reconciled in another recon")
+
+    existing = (
+        await db.execute(
+            select(BankReconciliationLine).where(
+                BankReconciliationLine.reconciliation_id == reconciliation_id,
+                BankReconciliationLine.journal_line_id == journal_line_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing:
+        return existing
+
+    rline = BankReconciliationLine(
+        reconciliation_id=reconciliation_id,
+        journal_line_id=journal_line_id,
+        amount=Decimal(line.amount),
+    )
+    db.add(rline)
+    line.cleared_status = CLEARED_STATUS_CLEARED
+    await db.flush()
+    return rline
+
+
+async def exclude_line(
+    db: AsyncSession,
+    *,
+    reconciliation_id: uuid.UUID,
+    journal_line_id: uuid.UUID,
+) -> None:
+    recon = await _get_in_progress_recon(db, reconciliation_id)
+
+    rline = (
+        await db.execute(
+            select(BankReconciliationLine).where(
+                BankReconciliationLine.reconciliation_id == reconciliation_id,
+                BankReconciliationLine.journal_line_id == journal_line_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if rline is None:
+        return
+
+    line = (await db.execute(select(JournalLine).where(JournalLine.id == journal_line_id))).scalar_one_or_none()
+    await db.delete(rline)
+    if line is not None and line.cleared_status == CLEARED_STATUS_CLEARED:
+        # Only flip back to uncleared if no other in_progress recon includes
+        # this line.
+        other = (
+            await db.execute(
+                select(BankReconciliationLine).where(
+                    BankReconciliationLine.journal_line_id == journal_line_id,
+                    BankReconciliationLine.reconciliation_id != reconciliation_id,
+                )
+            )
+        ).first()
+        if other is None:
+            line.cleared_status = CLEARED_STATUS_UNCLEARED
+    _ = recon
+    await db.flush()
+
+
+async def compute_book_balance(
+    db: AsyncSession,
+    reconciliation_id: uuid.UUID,
+) -> Decimal:
+    """Returns: sum of signed amounts across this recon's included lines plus
+    the recon's opening_balance."""
+    recon = (
+        await db.execute(
+            select(BankReconciliation).where(BankReconciliation.id == reconciliation_id)
+        )
+    ).scalar_one_or_none()
+    if recon is None:
+        raise BankReconciliationError("Reconciliation not found")
+
+    account = (await db.execute(select(Account).where(Account.id == recon.account_id))).scalar_one()
+
+    rows = (
+        await db.execute(
+            select(JournalLine, BankReconciliationLine)
+            .join(BankReconciliationLine, BankReconciliationLine.journal_line_id == JournalLine.id)
+            .where(BankReconciliationLine.reconciliation_id == reconciliation_id)
+        )
+    ).all()
+
+    total = Decimal(recon.opening_balance)
+    for line, _rline in rows:
+        total += _signed_amount(line, account)
+    return total
+
+
+async def finalize_reconciliation(
+    db: AsyncSession,
+    *,
+    reconciliation_id: uuid.UUID,
+    finalized_by_user_id: uuid.UUID | None,
+) -> BankReconciliation:
+    recon = await _get_in_progress_recon(db, reconciliation_id)
+
+    book = await compute_book_balance(db, reconciliation_id)
+    if book != Decimal(recon.statement_ending_balance):
+        raise BankReconciliationError(
+            f"Cannot finalize: book balance {book} != statement balance {recon.statement_ending_balance}"
+        )
+
+    rows = (
+        await db.execute(
+            select(JournalLine)
+            .join(BankReconciliationLine, BankReconciliationLine.journal_line_id == JournalLine.id)
+            .where(BankReconciliationLine.reconciliation_id == reconciliation_id)
+        )
+    ).scalars().all()
+    for line in rows:
+        line.cleared_status = CLEARED_STATUS_RECONCILED
+
+    recon.status = STATUS_FINALIZED
+    recon.finalized_at = datetime.now(timezone.utc)
+    recon.finalized_by_user_id = finalized_by_user_id
+    await db.flush()
+    return recon
+
+
+async def reopen_reconciliation(
+    db: AsyncSession,
+    *,
+    reconciliation_id: uuid.UUID,
+) -> BankReconciliation:
+    recon = (
+        await db.execute(
+            select(BankReconciliation).where(BankReconciliation.id == reconciliation_id)
+        )
+    ).scalar_one_or_none()
+    if recon is None:
+        raise BankReconciliationError("Reconciliation not found")
+    if recon.status != STATUS_FINALIZED:
+        raise BankReconciliationError("Only finalized reconciliations can be reopened")
+
+    rows = (
+        await db.execute(
+            select(JournalLine)
+            .join(BankReconciliationLine, BankReconciliationLine.journal_line_id == JournalLine.id)
+            .where(BankReconciliationLine.reconciliation_id == reconciliation_id)
+        )
+    ).scalars().all()
+    for line in rows:
+        if line.cleared_status == CLEARED_STATUS_RECONCILED:
+            line.cleared_status = CLEARED_STATUS_CLEARED
+
+    recon.status = STATUS_IN_PROGRESS
+    recon.finalized_at = None
+    recon.finalized_by_user_id = None
+    await db.flush()
+    return recon
+
+
+async def _get_in_progress_recon(
+    db: AsyncSession, reconciliation_id: uuid.UUID
+) -> BankReconciliation:
+    recon = (
+        await db.execute(
+            select(BankReconciliation).where(BankReconciliation.id == reconciliation_id)
+        )
+    ).scalar_one_or_none()
+    if recon is None:
+        raise BankReconciliationError("Reconciliation not found")
+    if recon.status != STATUS_IN_PROGRESS:
+        raise BankReconciliationError(
+            f"Reconciliation {reconciliation_id} is {recon.status}, not in_progress"
+        )
+    return recon
+
+
+async def assert_journal_line_editable(
+    db: AsyncSession, journal_line_id: uuid.UUID
+) -> None:
+    """Hard-block edits/deletes on reconciled journal lines.
+
+    Endpoints that mutate journal lines (or upstream entities that fold into a
+    journal line edit) should call this **before** writing to ensure they
+    don't silently corrupt a finalized reconciliation. Raises
+    `JournalLineLockedError` (subclass of BankReconciliationError) which
+    callers should turn into a 409 to the API client.
+    """
+    line = (await db.execute(select(JournalLine).where(JournalLine.id == journal_line_id))).scalar_one_or_none()
+    if line is None:
+        return
+    if line.cleared_status == CLEARED_STATUS_RECONCILED:
+        raise JournalLineLockedError(
+            f"Journal line {journal_line_id} is reconciled and cannot be edited; "
+            f"reopen the relevant bank reconciliation first."
+        )

--- a/backend/tests/test_bank_reconciliation_service.py
+++ b/backend/tests/test_bank_reconciliation_service.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.bank_reconciliation import BankReconciliation
+from app.models.journal_entry import JournalEntry
+from app.models.journal_line import JournalLine
+from app.services.bank_reconciliation_service import (
+    BankReconciliationError,
+    JournalLineLockedError,
+    assert_journal_line_editable,
+    compute_account_balance,
+    exclude_line,
+    finalize_reconciliation,
+    include_line,
+    reopen_reconciliation,
+    start_reconciliation,
+)
+
+
+# ---------- helpers ----------
+
+
+async def _make_bank_account(db_session, code="1010", name="Operating Checking", kind="checking"):
+    a = Account(
+        code=code,
+        name=name,
+        account_type="asset",
+        normal_balance="debit",
+        is_active=True,
+        is_bank_account=True,
+        bank_account_kind=kind,
+    )
+    db_session.add(a)
+    await db_session.flush()
+    return a
+
+
+async def _post_je(db_session, account, *, entry_date, debit=None, credit=None, n=1):
+    e = JournalEntry(
+        entry_number=f"JE-{n}",
+        entry_date=entry_date,
+        status="posted",
+    )
+    db_session.add(e)
+    await db_session.flush()
+    line = JournalLine(
+        journal_entry_id=e.id,
+        account_id=account.id,
+        line_number=1,
+        entry_type="debit" if debit is not None else "credit",
+        amount=Decimal(debit if debit is not None else credit),
+    )
+    db_session.add(line)
+    await db_session.flush()
+    return e, line
+
+
+# ---------- tests ----------
+
+
+@pytest.mark.asyncio
+async def test_start_reconciliation_requires_bank_account(db_session):
+    a = Account(
+        code="9999",
+        name="Not a bank",
+        account_type="asset",
+        normal_balance="debit",
+        is_bank_account=False,
+    )
+    db_session.add(a)
+    await db_session.flush()
+    with pytest.raises(BankReconciliationError):
+        await start_reconciliation(
+            db_session,
+            account_id=a.id,
+            statement_end_date=datetime.date(2026, 1, 31),
+            statement_ending_balance=Decimal("100"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_compute_balance_matches_signed_sum(db_session):
+    a = await _make_bank_account(db_session)
+    await _post_je(db_session, a, entry_date=datetime.date(2026, 1, 1), debit=500, n=1)
+    await _post_je(db_session, a, entry_date=datetime.date(2026, 1, 5), credit=200, n=2)
+    bal = await compute_account_balance(db_session, a.id)
+    assert bal == Decimal("300")
+
+
+@pytest.mark.asyncio
+async def test_finalize_blocks_when_balances_differ(db_session):
+    a = await _make_bank_account(db_session)
+    await _post_je(db_session, a, entry_date=datetime.date(2026, 1, 1), debit=100, n=1)
+    recon = await start_reconciliation(
+        db_session,
+        account_id=a.id,
+        statement_end_date=datetime.date(2026, 1, 31),
+        statement_ending_balance=Decimal("999"),  # mismatched on purpose
+    )
+    # No lines included → book balance == opening (0); 0 != 999 → finalize blocked
+    with pytest.raises(BankReconciliationError):
+        await finalize_reconciliation(db_session, reconciliation_id=recon.id, finalized_by_user_id=None)
+
+
+@pytest.mark.asyncio
+async def test_full_lifecycle_finalize_and_lock(db_session):
+    a = await _make_bank_account(db_session)
+    _, line1 = await _post_je(db_session, a, entry_date=datetime.date(2026, 1, 1), debit=500, n=1)
+    _, line2 = await _post_je(db_session, a, entry_date=datetime.date(2026, 1, 10), credit=200, n=2)
+
+    recon = await start_reconciliation(
+        db_session,
+        account_id=a.id,
+        statement_end_date=datetime.date(2026, 1, 31),
+        statement_ending_balance=Decimal("300"),
+    )
+
+    await include_line(db_session, reconciliation_id=recon.id, journal_line_id=line1.id)
+    await include_line(db_session, reconciliation_id=recon.id, journal_line_id=line2.id)
+
+    finalized = await finalize_reconciliation(
+        db_session, reconciliation_id=recon.id, finalized_by_user_id=None
+    )
+    assert finalized.status == "finalized"
+    assert finalized.finalized_at is not None
+
+    refreshed_line = (await db_session.execute(select(JournalLine).where(JournalLine.id == line1.id))).scalar_one()
+    assert refreshed_line.cleared_status == "reconciled"
+
+    with pytest.raises(JournalLineLockedError):
+        await assert_journal_line_editable(db_session, line1.id)
+
+
+@pytest.mark.asyncio
+async def test_exclude_line_flips_back_to_uncleared(db_session):
+    a = await _make_bank_account(db_session)
+    _, line = await _post_je(db_session, a, entry_date=datetime.date(2026, 1, 1), debit=100, n=1)
+    recon = await start_reconciliation(
+        db_session,
+        account_id=a.id,
+        statement_end_date=datetime.date(2026, 1, 31),
+        statement_ending_balance=Decimal("0"),
+    )
+    await include_line(db_session, reconciliation_id=recon.id, journal_line_id=line.id)
+    refreshed = (await db_session.execute(select(JournalLine).where(JournalLine.id == line.id))).scalar_one()
+    assert refreshed.cleared_status == "cleared"
+
+    await exclude_line(db_session, reconciliation_id=recon.id, journal_line_id=line.id)
+    refreshed = (await db_session.execute(select(JournalLine).where(JournalLine.id == line.id))).scalar_one()
+    assert refreshed.cleared_status == "uncleared"
+
+
+@pytest.mark.asyncio
+async def test_reopen_finalized_recon(db_session):
+    a = await _make_bank_account(db_session)
+    _, line = await _post_je(db_session, a, entry_date=datetime.date(2026, 1, 1), debit=100, n=1)
+    recon = await start_reconciliation(
+        db_session,
+        account_id=a.id,
+        statement_end_date=datetime.date(2026, 1, 31),
+        statement_ending_balance=Decimal("100"),
+    )
+    await include_line(db_session, reconciliation_id=recon.id, journal_line_id=line.id)
+    await finalize_reconciliation(db_session, reconciliation_id=recon.id, finalized_by_user_id=None)
+
+    reopened = await reopen_reconciliation(db_session, reconciliation_id=recon.id)
+    assert reopened.status == "in_progress"
+    assert reopened.finalized_at is None
+
+    refreshed = (await db_session.execute(select(JournalLine).where(JournalLine.id == line.id))).scalar_one()
+    # After reopen the line goes back to cleared (still on the recon, ready for re-finalize)
+    assert refreshed.cleared_status == "cleared"
+    # Edit lock is released
+    await assert_journal_line_editable(db_session, line.id)
+
+
+@pytest.mark.asyncio
+async def test_reopen_only_works_on_finalized_recons(db_session):
+    a = await _make_bank_account(db_session)
+    recon = await start_reconciliation(
+        db_session,
+        account_id=a.id,
+        statement_end_date=datetime.date(2026, 1, 31),
+        statement_ending_balance=Decimal("0"),
+    )
+    with pytest.raises(BankReconciliationError):
+        await reopen_reconciliation(db_session, reconciliation_id=recon.id)
+
+
+@pytest.mark.asyncio
+async def test_cannot_include_already_reconciled_line(db_session):
+    a = await _make_bank_account(db_session)
+    _, line = await _post_je(db_session, a, entry_date=datetime.date(2026, 1, 1), debit=50, n=1)
+
+    r1 = await start_reconciliation(
+        db_session,
+        account_id=a.id,
+        statement_end_date=datetime.date(2026, 1, 31),
+        statement_ending_balance=Decimal("50"),
+    )
+    await include_line(db_session, reconciliation_id=r1.id, journal_line_id=line.id)
+    await finalize_reconciliation(db_session, reconciliation_id=r1.id, finalized_by_user_id=None)
+
+    r2 = await start_reconciliation(
+        db_session,
+        account_id=a.id,
+        statement_end_date=datetime.date(2026, 2, 28),
+        statement_ending_balance=Decimal("50"),
+    )
+    with pytest.raises(BankReconciliationError):
+        await include_line(db_session, reconciliation_id=r2.id, journal_line_id=line.id)
+
+
+@pytest.mark.asyncio
+async def test_assert_editable_on_uncleared_line_is_noop(db_session):
+    a = await _make_bank_account(db_session)
+    _, line = await _post_je(db_session, a, entry_date=datetime.date(2026, 1, 1), debit=10, n=1)
+    # Should not raise
+    await assert_journal_line_editable(db_session, line.id)

--- a/docs/bank_reconciliation.md
+++ b/docs/bank_reconciliation.md
@@ -1,0 +1,42 @@
+# Bank Reconciliation
+
+Operators reconcile a bank-typed GL account against a statement-end balance using a manual worksheet. Once finalized, the reconciled journal lines are locked from edits/deletes — preserving accounting integrity per #239.
+
+## Concepts
+
+- **Bank-typed account.** Any GL `Account` with `is_bank_account=True`. The kind dimension (`bank_account_kind`) is one of `checking`, `savings`, `credit_card`, `payment_processor`. Operators flag accounts via `PATCH /api/v1/banking/accounts/{id}/flag`.
+- **Cleared status on journal lines.** `JournalLine.cleared_status` is one of:
+  - `uncleared` — default, line has not been touched by any reconciliation.
+  - `cleared` — included in an in-progress reconciliation. Lines flip back to `uncleared` if excluded before finalize.
+  - `reconciled` — finalized in a reconciliation. **Edits and deletes are hard-blocked** until the reconciliation is reopened.
+- **Reconciliation lifecycle.** `in_progress → finalized`. Admin can reopen a finalized recon back to `in_progress`, which flips its journal lines back to `cleared`.
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `GET` | `/api/v1/banking/accounts` | Lists bank-typed accounts with `running_balance`. |
+| `PATCH` | `/api/v1/banking/accounts/{id}/flag` | Flag/unflag an account as a bank account. Body: `is_bank_account`, optional `bank_account_kind`. |
+| `POST` | `/api/v1/banking/reconciliations` | Start a recon. Body: `account_id`, `statement_end_date`, `statement_ending_balance`, optional `notes`. |
+| `GET` | `/api/v1/banking/reconciliations` | List recons (filter by `account_id`, `recon_status`). |
+| `GET` | `/api/v1/banking/reconciliations/{id}` | Detail — eligible journal lines, included line ids, computed book balance, variance. |
+| `PATCH` | `/api/v1/banking/reconciliations/{id}/toggle-line` | Include/exclude a journal line. Body: `journal_line_id`, `included` (bool). |
+| `POST` | `/api/v1/banking/reconciliations/{id}/finalize` | Refuses if `book_balance != statement_ending_balance`. |
+| `POST` | `/api/v1/banking/reconciliations/{id}/reopen` | Admin-only. Flips reconciled lines back to `cleared`. |
+
+## Edit lock
+
+`bank_reconciliation_service.assert_journal_line_editable(db, journal_line_id)` is the single guard call sites should use before mutating a journal line. It raises `JournalLineLockedError` (subclass of `BankReconciliationError`) when the line is reconciled — convert to a 409 at the API edge.
+
+This guard is currently called only by the recon service itself. Phase 2 follow-up: wire it in to every endpoint that can edit or delete a journal line transitively (sale refunds, invoice voids, manual JE edits, etc.). Until then, downstream callers can corrupt a finalized reconciliation; the right pattern is to call `assert_journal_line_editable` for each affected line before saving.
+
+## Phase 1 limitations / Phase 2 follow-ups
+
+Each can be its own issue when prioritized:
+
+1. **Wire the edit-lock guard into every journal-line mutation path** — sales refunds, invoice voids, manual JE edits, etc. (most important hardening step).
+2. **Frontend `/banking` route** — accounts overview + reconciliation worksheet UI. None of these endpoints have a UI surface today.
+3. **Period-close lock dates** — currently `accounting_period.py` doesn't gate `finalize_reconciliation`; if a recon is for a closed period the finalize succeeds. Worth tightening.
+4. **Multi-currency** — Phase 1 assumes USD-only.
+5. **Statement import** — picked up in #240 (depends on this issue's data model).
+6. **Auto-match rules** — picked up in #241 (depends on #240).


### PR DESCRIPTION
## Summary
Backend slice of [#239](https://github.com/bbengt1/3d-print-sales/issues/239). Operators can flag GL accounts as bank accounts, start reconciliations, include/exclude journal lines, and finalize when book balance matches the statement. Reconciled journal lines are locked from edits via the new `assert_journal_line_editable` guard.

- `Account.is_bank_account` + `bank_account_kind`
- `JournalLine.cleared_status` enum (`uncleared`/`cleared`/`reconciled`)
- New `bank_reconciliations` and `bank_reconciliation_lines` tables
- New `bank_reconciliation_service` with full lifecycle (start/include/exclude/finalize/reopen)
- New `/api/v1/banking` endpoints
- New doc [docs/bank_reconciliation.md](docs/bank_reconciliation.md)

**Frontend pages deferred** — no banking UI exists today; the endpoints are ready for #240's statement-import flow plus a future banking-frontend issue. Phase 2 follow-ups (most important: wire the edit-lock guard into every journal-line mutation path) are enumerated in the doc.

Unblocks #240 (statement import) and #246 (inter-account transfers). #241 (auto-match rules) chains off #240.

## Test plan
- [x] 305 backend tests pass (296 baseline + 9 new in `test_bank_reconciliation_service.py`).
- [x] Frontend build clean.
- [ ] Migration runs on web01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)