### PR TITLE
chore(deploy): canonical deploy.sh in repo, runs alembic upgrade automatically

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,5 +30,5 @@
 ### Deployment
 - Live host: `root@web01.bengtson.local`
 - App root: `/srv/3d-print-sales`
-- Deploy: `scripts/web01-compose.sh up -d --build` or `/srv/3d-print-sales/deploy.sh`
+- Deploy: `/srv/3d-print-sales/deploy.sh` — wraps repo `scripts/deploy.sh` which pulls, rebuilds, **runs `alembic upgrade head`**, restarts backend. Skipping migrations breaks startup if schema changed.
 - Post-deploy checks: container health, `curl /health`, `curl /`, review logs if relevant.

--- a/agents.md
+++ b/agents.md
@@ -146,5 +146,6 @@
 - Server env file: `/srv/3d-print-sales/env/web01.env`
 - Systemd unit: `3d-print-sales.service`
 - Compose wrapper: `/srv/3d-print-sales/repo/scripts/web01-compose.sh`
-- Helper deploy script: `/srv/3d-print-sales/deploy.sh`
+- Canonical deploy script (in repo): `scripts/deploy.sh` — pulls main, rebuilds containers, **runs `alembic upgrade head`**, restarts backend. The host's `/srv/3d-print-sales/deploy.sh` is a thin wrapper that delegates to this.
+- **Migrations must run on every schema-changing deploy.** Backend startup queries newly-added tables/columns; skipping migrations crashes the container. (Real incident on 2026-05-09 with PR #271 / #239.) Use `SKIP_MIGRATIONS=1` only for code-only emergency redeploys when you know there's no schema delta.
 - Running containers: `3d-print-sales-db`, `3d-print-sales-backend`, `3d-print-sales-frontend`

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Canonical deploy script for web01.
+#
+# Runs the full deploy sequence:
+#   1. Pull latest main from origin (fast-forward only).
+#   2. Bring containers up with --build (rebuilds backend/frontend images).
+#   3. Run pending Alembic migrations against the live DB. THIS IS REQUIRED:
+#      backend startup queries tables/columns added by recent migrations, so
+#      forgetting this step will crash the backend container after a deploy
+#      that adds schema. (Real incident on 2026-05-09 with PR #271 / #239.)
+#
+# Designed to be invoked from `/srv/3d-print-sales/deploy.sh` on web01:
+#   /srv/3d-print-sales/deploy.sh
+# That host script is a thin wrapper that cd's into the repo and calls this.
+#
+# Idempotent: re-running with no new commits is a no-op for git, a quick
+# rebuild check for compose, and a no-op for alembic (already at head).
+#
+# To skip migrations explicitly (rare — e.g. pre-flight a code-only deploy),
+# set SKIP_MIGRATIONS=1 in the environment.
+
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-/srv/3d-print-sales/repo}"
+COMPOSE="$REPO_DIR/scripts/web01-compose.sh"
+
+cd "$REPO_DIR"
+
+echo "==> [1/3] git pull --ff-only"
+git pull --ff-only
+
+echo "==> [2/3] compose up -d --build"
+"$COMPOSE" up -d --build
+
+if [[ "${SKIP_MIGRATIONS:-0}" == "1" ]]; then
+  echo "==> [3/3] migrations SKIPPED (SKIP_MIGRATIONS=1 set)"
+else
+  echo "==> [3/3] alembic upgrade head"
+  "$COMPOSE" run --rm backend alembic upgrade head
+  echo "==> migrations applied; restarting backend to pick up schema"
+  "$COMPOSE" up -d backend
+fi
+
+echo "==> done. containers:"
+"$COMPOSE" ps


### PR DESCRIPTION
## Summary
Adds `scripts/deploy.sh` as the canonical deploy script for web01. It runs the full sequence: pull → rebuild → **alembic upgrade head** → restart backend. The host's `/srv/3d-print-sales/deploy.sh` becomes a thin wrapper delegating to it.

## Why
Real incident on 2026-05-09 with PR #271 (#239 banking). Backend crashed on deploy because:
- The host's `deploy.sh` was just `git pull && compose up -d --build` — no migration step.
- Backend startup queries `accounts.is_bank_account` (added in migration `20260509_03`).
- Earlier PRs #269 (`reference_sequences`) and #270 (`email_deliveries`) had also failed to migrate prod, but only added new tables not queried at startup, so the breakage was silent until #271 added a column to an existing queried table.

Recovery: ran `alembic upgrade head` manually, brought containers up.

This PR makes that sequence automatic.

## Test plan
- [x] `scripts/deploy.sh` syntax-checked (`bash -n`).
- [ ] After merge: update `/srv/3d-print-sales/deploy.sh` on web01 to delegate to the repo script. (One-line change on the host.)
- [ ] Verify next deploy auto-runs migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)