### PR TITLE
feat(fixed-assets): asset register with depreciation and disposal (#238)

### DIFF
--- a/backend/alembic/versions/20260509_04_add_fixed_assets.py
+++ b/backend/alembic/versions/20260509_04_add_fixed_assets.py
@@ -1,0 +1,138 @@
+"""add fixed_assets, depreciation_entries, and printers.fixed_asset_id
+
+Revision ID: 20260509_04
+Revises: 20260509_03
+Create Date: 2026-05-09 19:00:00
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_04"
+down_revision = "20260509_03"
+branch_labels = None
+depends_on = None
+
+
+# Mirrors the new FA-related accounts added to STARTER_CHART_OF_ACCOUNTS.
+# We re-seed here so existing installations get them without depending on
+# the seeder running from the lifespan path.
+NEW_ACCOUNTS = [
+    ("1700", "Equipment", "asset", "debit"),
+    ("1750", "Accumulated Depreciation — Equipment", "asset", "credit"),
+    ("6700", "Depreciation Expense", "expense", "debit"),
+    ("4910", "Gain on Disposal of Equipment", "revenue", "credit"),
+    ("6710", "Loss on Disposal of Equipment", "expense", "debit"),
+]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "fixed_assets",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("asset_tag", sa.String(length=120), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("acquired_on", sa.Date(), nullable=False),
+        sa.Column("acquisition_cost", sa.Numeric(14, 4), nullable=False),
+        sa.Column("salvage_value", sa.Numeric(14, 4), nullable=False, server_default="0"),
+        sa.Column("useful_life_months", sa.Integer(), nullable=False),
+        sa.Column("depreciation_method", sa.String(length=30), nullable=False, server_default="straight_line"),
+        sa.Column("declining_balance_rate", sa.Numeric(8, 6), nullable=True),
+        sa.Column("asset_account_id", sa.UUID(), nullable=False),
+        sa.Column("accumulated_depreciation_account_id", sa.UUID(), nullable=False),
+        sa.Column("depreciation_expense_account_id", sa.UUID(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="active"),
+        sa.Column("disposed_on", sa.Date(), nullable=True),
+        sa.Column("disposal_proceeds", sa.Numeric(14, 4), nullable=True),
+        sa.Column("disposal_journal_entry_id", sa.UUID(), nullable=True),
+        sa.Column("acquisition_bill_id", sa.UUID(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["asset_account_id"], ["accounts.id"]),
+        sa.ForeignKeyConstraint(["accumulated_depreciation_account_id"], ["accounts.id"]),
+        sa.ForeignKeyConstraint(["depreciation_expense_account_id"], ["accounts.id"]),
+        sa.ForeignKeyConstraint(["disposal_journal_entry_id"], ["journal_entries.id"]),
+        sa.ForeignKeyConstraint(["acquisition_bill_id"], ["bills.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("asset_tag", name="uq_fixed_assets_asset_tag"),
+    )
+    op.create_index("ix_fixed_assets_name", "fixed_assets", ["name"])
+    op.create_index("ix_fixed_assets_status", "fixed_assets", ["status"])
+
+    op.create_table(
+        "depreciation_entries",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("fixed_asset_id", sa.UUID(), nullable=False),
+        sa.Column("period_end", sa.Date(), nullable=False),
+        sa.Column("amount", sa.Numeric(14, 4), nullable=False),
+        sa.Column("journal_entry_id", sa.UUID(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["fixed_asset_id"], ["fixed_assets.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["journal_entry_id"], ["journal_entries.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "fixed_asset_id", "period_end",
+            name="uq_depreciation_entries_asset_period",
+        ),
+    )
+    op.create_index("ix_depreciation_entries_fixed_asset_id", "depreciation_entries", ["fixed_asset_id"])
+    op.create_index("ix_depreciation_entries_period_end", "depreciation_entries", ["period_end"])
+
+    op.add_column(
+        "printers",
+        sa.Column("fixed_asset_id", sa.UUID(), nullable=True),
+    )
+    op.create_index("ix_printers_fixed_asset_id", "printers", ["fixed_asset_id"])
+    op.create_foreign_key(
+        "fk_printers_fixed_asset_id",
+        "printers",
+        "fixed_assets",
+        ["fixed_asset_id"],
+        ["id"],
+    )
+
+    # Idempotent seed of the new chart-of-accounts entries (mirror of
+    # `STARTER_CHART_OF_ACCOUNTS` additions in #238).
+    bind = op.get_bind()
+    for code, name, account_type, normal_balance in NEW_ACCOUNTS:
+        existing = bind.execute(
+            sa.text("SELECT 1 FROM accounts WHERE code = :code"),
+            {"code": code},
+        ).first()
+        if existing:
+            continue
+        bind.execute(
+            sa.text(
+                "INSERT INTO accounts (id, code, name, account_type, normal_balance, "
+                "is_active, is_system, is_bank_account, created_at, updated_at) "
+                "VALUES (:id, :code, :name, :type, :normal, true, true, false, NOW(), NOW())"
+            ),
+            {
+                "id": str(uuid.uuid4()),
+                "code": code,
+                "name": name,
+                "type": account_type,
+                "normal": normal_balance,
+            },
+        )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_printers_fixed_asset_id", "printers", type_="foreignkey")
+    op.drop_index("ix_printers_fixed_asset_id", table_name="printers")
+    op.drop_column("printers", "fixed_asset_id")
+
+    op.drop_index("ix_depreciation_entries_period_end", table_name="depreciation_entries")
+    op.drop_index("ix_depreciation_entries_fixed_asset_id", table_name="depreciation_entries")
+    op.drop_table("depreciation_entries")
+
+    op.drop_index("ix_fixed_assets_status", table_name="fixed_assets")
+    op.drop_index("ix_fixed_assets_name", table_name="fixed_assets")
+    op.drop_table("fixed_assets")

--- a/backend/app/api/v1/endpoints/fixed_assets.py
+++ b/backend/app/api/v1/endpoints/fixed_assets.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.account import Account
+from app.models.fixed_asset import DepreciationEntry, FixedAsset
+from app.services.fixed_asset_service import (
+    FixedAssetError,
+    can_edit_critical_fields,
+    compute_book_value,
+    dispose_asset,
+    planned_schedule,
+    post_depreciation,
+)
+
+
+router = APIRouter(prefix="/fixed-assets", tags=["FixedAssets"])
+
+
+# ---------- schemas ----------
+
+
+class FixedAssetCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    asset_tag: str | None = Field(None, max_length=120)
+    description: str | None = None
+    acquired_on: date
+    acquisition_cost: Decimal = Field(..., gt=0)
+    salvage_value: Decimal = Field(0, ge=0)
+    useful_life_months: int = Field(..., gt=0)
+    depreciation_method: Literal["straight_line", "declining_balance"] = "straight_line"
+    declining_balance_rate: Decimal | None = Field(None, gt=0)
+    asset_account_id: uuid.UUID | None = None
+    accumulated_depreciation_account_id: uuid.UUID | None = None
+    depreciation_expense_account_id: uuid.UUID | None = None
+    acquisition_bill_id: uuid.UUID | None = None
+    notes: str | None = None
+
+
+class FixedAssetUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=120)
+    asset_tag: str | None = Field(None, max_length=120)
+    description: str | None = None
+    acquisition_cost: Decimal | None = Field(None, gt=0)
+    salvage_value: Decimal | None = Field(None, ge=0)
+    useful_life_months: int | None = Field(None, gt=0)
+    depreciation_method: Literal["straight_line", "declining_balance"] | None = None
+    declining_balance_rate: Decimal | None = Field(None, gt=0)
+    notes: str | None = None
+
+
+class FixedAssetResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    asset_tag: str | None
+    description: str | None
+    acquired_on: date
+    acquisition_cost: Decimal
+    salvage_value: Decimal
+    useful_life_months: int
+    depreciation_method: str
+    declining_balance_rate: Decimal | None
+    asset_account_id: uuid.UUID
+    accumulated_depreciation_account_id: uuid.UUID
+    depreciation_expense_account_id: uuid.UUID
+    status: str
+    disposed_on: date | None
+    disposal_proceeds: Decimal | None
+    disposal_journal_entry_id: uuid.UUID | None
+    notes: str | None
+    book_value: Decimal
+
+
+class DepreciationPostRequest(BaseModel):
+    period_end: date
+    asset_ids: list[uuid.UUID] | None = None
+
+
+class DisposeRequest(BaseModel):
+    disposed_on: date
+    proceeds: Decimal | None = Field(None, ge=0)
+    proceeds_account_id: uuid.UUID | None = None
+
+
+class ScheduleRow(BaseModel):
+    period_end: date
+    amount: Decimal
+
+
+class FixedAssetDetail(FixedAssetResponse):
+    schedule: list[ScheduleRow]
+    posted_periods: list[date]
+
+
+# ---------- helpers ----------
+
+
+async def _hydrate(db, asset: FixedAsset) -> FixedAssetResponse:
+    book = await compute_book_value(db, asset.id)
+    return FixedAssetResponse(
+        id=asset.id,
+        name=asset.name,
+        asset_tag=asset.asset_tag,
+        description=asset.description,
+        acquired_on=asset.acquired_on,
+        acquisition_cost=Decimal(asset.acquisition_cost),
+        salvage_value=Decimal(asset.salvage_value),
+        useful_life_months=asset.useful_life_months,
+        depreciation_method=asset.depreciation_method,
+        declining_balance_rate=Decimal(asset.declining_balance_rate) if asset.declining_balance_rate is not None else None,
+        asset_account_id=asset.asset_account_id,
+        accumulated_depreciation_account_id=asset.accumulated_depreciation_account_id,
+        depreciation_expense_account_id=asset.depreciation_expense_account_id,
+        status=asset.status,
+        disposed_on=asset.disposed_on,
+        disposal_proceeds=Decimal(asset.disposal_proceeds) if asset.disposal_proceeds is not None else None,
+        disposal_journal_entry_id=asset.disposal_journal_entry_id,
+        notes=asset.notes,
+        book_value=book,
+    )
+
+
+async def _resolve_default_account(db, code: str) -> uuid.UUID:
+    a = (await db.execute(select(Account).where(Account.code == code))).scalar_one_or_none()
+    if a is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Account with code {code} not found in chart of accounts; seed it first.",
+        )
+    return a.id
+
+
+# ---------- endpoints ----------
+
+
+@router.get("", response_model=list[FixedAssetResponse], summary="List fixed assets")
+async def list_assets(user: CurrentUser, db: DB, status_filter: str | None = None):
+    stmt = select(FixedAsset).order_by(FixedAsset.acquired_on.desc())
+    if status_filter:
+        stmt = stmt.where(FixedAsset.status == status_filter)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [await _hydrate(db, r) for r in rows]
+
+
+@router.post("", response_model=FixedAssetResponse, status_code=status.HTTP_201_CREATED, summary="Register a new fixed asset")
+async def create_asset(body: FixedAssetCreate, user: CurrentUser, db: DB):
+    asset_account_id = body.asset_account_id or await _resolve_default_account(db, "1700")
+    accum_id = body.accumulated_depreciation_account_id or await _resolve_default_account(db, "1750")
+    expense_id = body.depreciation_expense_account_id or await _resolve_default_account(db, "6700")
+    asset = FixedAsset(
+        name=body.name,
+        asset_tag=body.asset_tag,
+        description=body.description,
+        acquired_on=body.acquired_on,
+        acquisition_cost=body.acquisition_cost,
+        salvage_value=body.salvage_value,
+        useful_life_months=body.useful_life_months,
+        depreciation_method=body.depreciation_method,
+        declining_balance_rate=body.declining_balance_rate,
+        asset_account_id=asset_account_id,
+        accumulated_depreciation_account_id=accum_id,
+        depreciation_expense_account_id=expense_id,
+        acquisition_bill_id=body.acquisition_bill_id,
+        notes=body.notes,
+    )
+    db.add(asset)
+    await db.flush()
+    await db.commit()
+    return await _hydrate(db, asset)
+
+
+@router.get("/{asset_id}", response_model=FixedAssetDetail, summary="Fixed asset detail with schedule")
+async def get_asset(asset_id: uuid.UUID, user: CurrentUser, db: DB):
+    asset = (await db.execute(select(FixedAsset).where(FixedAsset.id == asset_id))).scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=404, detail="Fixed asset not found")
+    base = await _hydrate(db, asset)
+    schedule = [ScheduleRow(period_end=p, amount=a) for p, a in planned_schedule(asset)]
+    posted = [
+        e
+        for e in (
+            await db.execute(
+                select(DepreciationEntry.period_end).where(
+                    DepreciationEntry.fixed_asset_id == asset.id
+                )
+            )
+        ).scalars().all()
+    ]
+    return FixedAssetDetail(**base.model_dump(), schedule=schedule, posted_periods=posted)
+
+
+@router.patch("/{asset_id}", response_model=FixedAssetResponse, summary="Update a fixed asset")
+async def update_asset(asset_id: uuid.UUID, body: FixedAssetUpdate, user: CurrentUser, db: DB):
+    asset = (await db.execute(select(FixedAsset).where(FixedAsset.id == asset_id))).scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=404, detail="Fixed asset not found")
+    if asset.status == "disposed":
+        raise HTTPException(status_code=400, detail="Cannot edit a disposed asset")
+
+    critical_locked = not await can_edit_critical_fields(db, asset.id)
+    payload = body.model_dump(exclude_unset=True)
+    if critical_locked:
+        for k in ("acquisition_cost", "salvage_value", "useful_life_months", "depreciation_method", "declining_balance_rate"):
+            if k in payload:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Cannot edit '{k}' once depreciation has been posted; reverse those entries first.",
+                )
+
+    for k, v in payload.items():
+        setattr(asset, k, v)
+    await db.commit()
+    return await _hydrate(db, asset)
+
+
+@router.post("/post-depreciation", summary="Post depreciation through a period for selected (or all active) assets")
+async def post_dep(body: DepreciationPostRequest, user: CurrentUser, db: DB):
+    if body.asset_ids:
+        assets = (
+            await db.execute(
+                select(FixedAsset).where(FixedAsset.id.in_(body.asset_ids))
+            )
+        ).scalars().all()
+    else:
+        assets = (
+            await db.execute(
+                select(FixedAsset).where(FixedAsset.status == "active")
+            )
+        ).scalars().all()
+
+    posted_count = 0
+    for a in assets:
+        try:
+            new_entries = await post_depreciation(db, asset_id=a.id, through=body.period_end)
+            posted_count += len(new_entries)
+        except FixedAssetError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return {"posted_count": posted_count, "asset_count": len(assets)}
+
+
+@router.post("/{asset_id}/dispose", response_model=FixedAssetResponse, summary="Dispose a fixed asset (sale or write-off)")
+async def dispose(asset_id: uuid.UUID, body: DisposeRequest, user: CurrentUser, db: DB):
+    gain_id = await _resolve_default_account(db, "4910")
+    loss_id = await _resolve_default_account(db, "6710")
+    try:
+        asset = await dispose_asset(
+            db,
+            asset_id=asset_id,
+            disposed_on=body.disposed_on,
+            proceeds=body.proceeds,
+            proceeds_account_id=body.proceeds_account_id,
+            gain_account_id=gain_id,
+            loss_account_id=loss_id,
+        )
+    except FixedAssetError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate(db, asset)
+
+
+@router.delete("/{asset_id}", status_code=204, summary="Delete a fixed asset (only if no entries and not disposed)")
+async def delete_asset(asset_id: uuid.UUID, user: CurrentUser, db: DB):
+    asset = (await db.execute(select(FixedAsset).where(FixedAsset.id == asset_id))).scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=404, detail="Fixed asset not found")
+    if not await can_edit_critical_fields(db, asset.id):
+        raise HTTPException(status_code=400, detail="Cannot delete an asset with depreciation entries")
+    if asset.status == "disposed":
+        raise HTTPException(status_code=400, detail="Cannot delete a disposed asset")
+    await db.delete(asset)
+    await db.commit()

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, audit, auth, banking, cameras, customers, dashboard, email, insights, inventory, invoices, jobs, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, supplies, tax
+from app.api.v1.endpoints import accounting, approvals, audit, auth, banking, cameras, customers, dashboard, email, fixed_assets, insights, inventory, invoices, jobs, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -29,3 +29,4 @@ api_router.include_router(insights.router)
 api_router.include_router(tax.router)
 api_router.include_router(email.router)
 api_router.include_router(banking.router)
+api_router.include_router(fixed_assets.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 from app.models.bank_reconciliation import BankReconciliation, BankReconciliationLine  # noqa: F401
 from app.models.camera import Camera  # noqa: F401
 from app.models.email_delivery import EmailDelivery  # noqa: F401
+from app.models.fixed_asset import DepreciationEntry, FixedAsset  # noqa: F401
 from app.models.product_bom_item import ProductBOMItem  # noqa: F401
 from app.models.reference_sequence import ReferenceSequence  # noqa: F401
 from app.models.supply import Supply  # noqa: F401

--- a/backend/app/models/fixed_asset.py
+++ b/backend/app/models/fixed_asset.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class FixedAsset(Base):
+    """A capital asset on the balance sheet — typically a printer, camera,
+    or computer — with acquisition cost, useful life, depreciation schedule,
+    and disposal accounting (#238).
+
+    Status lifecycle: active → fully_depreciated (auto when book value
+    reaches salvage) → optionally disposed (operator action).
+    """
+
+    __tablename__ = "fixed_assets"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(120), index=True)
+    asset_tag: Mapped[str | None] = mapped_column(String(120), nullable=True, unique=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    acquired_on: Mapped[date] = mapped_column(Date)
+    acquisition_cost: Mapped[Decimal] = mapped_column(Numeric(14, 4))
+    salvage_value: Mapped[Decimal] = mapped_column(Numeric(14, 4), default=0)
+    useful_life_months: Mapped[int] = mapped_column(Integer)
+    # straight_line | declining_balance
+    depreciation_method: Mapped[str] = mapped_column(String(30), default="straight_line")
+    # Optional explicit DB rate as a fraction (e.g. 0.40 for 40%/year).
+    # When None and method=declining_balance, defaults to 2/(life_years) (DDB).
+    declining_balance_rate: Mapped[Decimal | None] = mapped_column(Numeric(8, 6), nullable=True)
+    asset_account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"))
+    accumulated_depreciation_account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"))
+    depreciation_expense_account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"))
+    status: Mapped[str] = mapped_column(String(20), default="active", index=True)
+    disposed_on: Mapped[date | None] = mapped_column(Date, nullable=True)
+    disposal_proceeds: Mapped[Decimal | None] = mapped_column(Numeric(14, 4), nullable=True)
+    disposal_journal_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("journal_entries.id"), nullable=True
+    )
+    acquisition_bill_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("bills.id"), nullable=True
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    depreciation_entries = relationship(
+        "DepreciationEntry",
+        back_populates="fixed_asset",
+        cascade="all, delete-orphan",
+    )
+
+
+class DepreciationEntry(Base):
+    """One month of depreciation for one fixed asset, with the resulting
+    journal entry id for full audit. Idempotent per `(fixed_asset, period_end)`.
+    """
+
+    __tablename__ = "depreciation_entries"
+    __table_args__ = (
+        UniqueConstraint(
+            "fixed_asset_id", "period_end",
+            name="uq_depreciation_entries_asset_period",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    fixed_asset_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("fixed_assets.id", ondelete="CASCADE"), index=True
+    )
+    period_end: Mapped[date] = mapped_column(Date, index=True)
+    amount: Mapped[Decimal] = mapped_column(Numeric(14, 4))
+    journal_entry_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("journal_entries.id")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    fixed_asset = relationship("FixedAsset", back_populates="depreciation_entries")

--- a/backend/app/models/printer.py
+++ b/backend/app/models/printer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -48,6 +48,12 @@ class Printer(Base):
     monitor_ws_last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
     monitor_last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     monitor_last_updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # Optional link to the capital record on the balance sheet (#238).
+    # Nullable; operators link existing printers manually from the printer
+    # detail page rather than auto-seeding.
+    fixed_asset_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("fixed_assets.id"), nullable=True, index=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/backend/app/services/accounting_service.py
+++ b/backend/app/services/accounting_service.py
@@ -39,6 +39,12 @@ STARTER_CHART_OF_ACCOUNTS = [
     ("6300", "Repairs & Maintenance", "expense", "debit"),
     ("6400", "Utilities", "expense", "debit"),
     ("6500", "Office & Supplies", "expense", "debit"),
+    # Fixed assets (#238)
+    ("1700", "Equipment", "asset", "debit"),
+    ("1750", "Accumulated Depreciation — Equipment", "asset", "credit"),
+    ("6700", "Depreciation Expense", "expense", "debit"),
+    ("4910", "Gain on Disposal of Equipment", "revenue", "credit"),
+    ("6710", "Loss on Disposal of Equipment", "expense", "debit"),
 ]
 
 
@@ -57,11 +63,20 @@ def _validate_period_editable(period: AccountingPeriod) -> None:
 
 
 async def seed_chart_of_accounts(db: AsyncSession) -> None:
-    result = await db.execute(select(Account).limit(1))
-    if result.scalar_one_or_none():
-        return
+    """Idempotent seeder. Inserts any of `STARTER_CHART_OF_ACCOUNTS` whose
+    `code` is not already present, leaving existing accounts untouched.
 
+    Originally this was a no-op when any account existed at all. That made
+    it impossible to add new system accounts to the starter list (e.g. for
+    fixed assets in #238) without manual SQL on existing installations.
+    Now every code is checked individually and missing ones are inserted.
+    """
+    existing = (await db.execute(select(Account.code))).scalars().all()
+    have = set(existing)
+    added = False
     for code, name, account_type, normal_balance in STARTER_CHART_OF_ACCOUNTS:
+        if code in have:
+            continue
         db.add(
             Account(
                 code=code,
@@ -71,7 +86,9 @@ async def seed_chart_of_accounts(db: AsyncSession) -> None:
                 is_system=True,
             )
         )
-    await db.commit()
+        added = True
+    if added:
+        await db.commit()
 
 
 async def ensure_accounting_period(

--- a/backend/app/services/fixed_asset_service.py
+++ b/backend/app/services/fixed_asset_service.py
@@ -1,0 +1,401 @@
+"""Fixed asset register lifecycle (#238).
+
+Operations:
+- create / edit a fixed asset (with edit-lock once depreciation has been posted)
+- post depreciation for a single asset, or in bulk for all active assets,
+  through a chosen `period_end` date (idempotent — re-posting through the
+  same period is a no-op).
+- dispose an asset: post any pending depreciation up through `disposed_on`,
+  then post a disposal JE (Cr asset, Dr accumulated, Dr/Cr cash for proceeds,
+  Dr loss / Cr gain for the residual).
+- compute book value for any asset at any point in time.
+
+Math:
+- straight_line: monthly = (cost - salvage) / life_months. Last month rounds
+  to bring book value exactly to salvage.
+- declining_balance: monthly = book_value_start_of_period × rate / 12, where
+  `rate` defaults to 2 / life_years (DDB) when not explicitly set. We switch
+  to straight-line over the remaining life when SL would yield a larger
+  monthly amount, ensuring the asset reaches salvage by end of life.
+"""
+
+from __future__ import annotations
+
+import calendar
+import uuid
+from datetime import date, datetime, timezone
+from decimal import ROUND_HALF_UP, Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.accounting_period import AccountingPeriod
+from app.models.fixed_asset import DepreciationEntry, FixedAsset
+from app.models.journal_entry import JournalEntry
+from app.models.journal_line import JournalLine
+from app.schemas.accounting import JournalEntryCreate, JournalLineCreate
+from app.services.accounting_service import (
+    AccountingValidationError,
+    create_journal_entry,
+)
+
+
+class FixedAssetError(RuntimeError):
+    pass
+
+
+CENTS = Decimal("0.01")
+
+
+def _q(value: Decimal) -> Decimal:
+    return Decimal(value).quantize(CENTS, rounding=ROUND_HALF_UP)
+
+
+def _last_day_of_month(d: date) -> date:
+    return date(d.year, d.month, calendar.monthrange(d.year, d.month)[1])
+
+
+def _add_months(d: date, n: int) -> date:
+    """Return last-day-of-month n months after `d`."""
+    total = d.year * 12 + (d.month - 1) + n
+    y, m = divmod(total, 12)
+    return _last_day_of_month(date(y, m + 1, 1))
+
+
+def _months_between(start: date, end: date) -> int:
+    """Inclusive count of month-ends between start (the month-end of acquisition month)
+    and end (a chosen month-end). Returns 0 if end < start."""
+    if end < start:
+        return 0
+    return (end.year - start.year) * 12 + (end.month - start.month) + 1
+
+
+async def compute_book_value(db: AsyncSession, asset_id: uuid.UUID) -> Decimal:
+    asset = (await db.execute(select(FixedAsset).where(FixedAsset.id == asset_id))).scalar_one_or_none()
+    if asset is None:
+        raise FixedAssetError("Fixed asset not found")
+    posted = (
+        await db.execute(
+            select(DepreciationEntry).where(DepreciationEntry.fixed_asset_id == asset_id)
+        )
+    ).scalars().all()
+    accum = sum((Decimal(e.amount) for e in posted), Decimal("0"))
+    return _q(Decimal(asset.acquisition_cost) - accum)
+
+
+def _ddb_rate_default(life_months: int) -> Decimal:
+    """Double-declining-balance rate as an annual fraction."""
+    life_years = Decimal(life_months) / Decimal(12)
+    return Decimal(2) / life_years
+
+
+def _planned_monthly_amount_sl(asset: FixedAsset) -> Decimal:
+    cost = Decimal(asset.acquisition_cost)
+    salvage = Decimal(asset.salvage_value or 0)
+    return _q((cost - salvage) / Decimal(asset.useful_life_months))
+
+
+def _planned_amounts_db(asset: FixedAsset) -> list[Decimal]:
+    """Generate the full per-period amount schedule for a declining-balance
+    asset across its full useful life, switching to straight-line whenever SL
+    would yield a larger monthly amount over the remaining life. Returns a
+    list of length `useful_life_months` summing exactly to (cost - salvage).
+    """
+    cost = Decimal(asset.acquisition_cost)
+    salvage = Decimal(asset.salvage_value or 0)
+    life = int(asset.useful_life_months)
+    rate_annual = (
+        Decimal(asset.declining_balance_rate)
+        if asset.declining_balance_rate is not None
+        else _ddb_rate_default(life)
+    )
+
+    monthly_rate = rate_annual / Decimal(12)
+    amounts: list[Decimal] = []
+    book = cost
+    for i in range(life):
+        remaining_months = life - i
+        # SL on the residual to-salvage from this period forward
+        sl = _q((book - salvage) / Decimal(remaining_months))
+        db_amt = _q(book * monthly_rate)
+        amt = max(sl, db_amt)
+        # Don't depreciate below salvage
+        amt = min(amt, _q(book - salvage))
+        amounts.append(amt)
+        book -= amt
+    # Force final-period adjustment so the schedule sums to exactly (cost - salvage)
+    target = _q(cost - salvage)
+    diff = target - sum(amounts, Decimal("0"))
+    amounts[-1] = _q(amounts[-1] + diff)
+    return amounts
+
+
+def _planned_amounts_sl(asset: FixedAsset) -> list[Decimal]:
+    cost = Decimal(asset.acquisition_cost)
+    salvage = Decimal(asset.salvage_value or 0)
+    life = int(asset.useful_life_months)
+    monthly = _planned_monthly_amount_sl(asset)
+    amounts = [monthly] * life
+    target = _q(cost - salvage)
+    diff = target - sum(amounts, Decimal("0"))
+    amounts[-1] = _q(amounts[-1] + diff)
+    return amounts
+
+
+def planned_schedule(asset: FixedAsset) -> list[tuple[date, Decimal]]:
+    """Return [(period_end, amount)] schedule across the full useful life.
+    `period_end` is the last day of each successive month after acquisition.
+    """
+    if asset.depreciation_method == "declining_balance":
+        amounts = _planned_amounts_db(asset)
+    else:
+        amounts = _planned_amounts_sl(asset)
+
+    first_period = _last_day_of_month(asset.acquired_on)
+    out = []
+    for i, amt in enumerate(amounts):
+        period_end = _add_months(first_period, i)
+        out.append((period_end, amt))
+    return out
+
+
+async def post_depreciation(
+    db: AsyncSession,
+    *,
+    asset_id: uuid.UUID,
+    through: date,
+) -> list[DepreciationEntry]:
+    """Post any unposted depreciation entries up through the given `through`
+    month-end. Idempotent: existing `(asset, period_end)` rows are skipped.
+    """
+    asset = (await db.execute(select(FixedAsset).where(FixedAsset.id == asset_id))).scalar_one_or_none()
+    if asset is None:
+        raise FixedAssetError("Fixed asset not found")
+    if asset.status == "disposed":
+        raise FixedAssetError("Cannot post depreciation on a disposed asset")
+
+    schedule = planned_schedule(asset)
+    posted_periods = set(
+        (
+            await db.execute(
+                select(DepreciationEntry.period_end).where(
+                    DepreciationEntry.fixed_asset_id == asset_id
+                )
+            )
+        ).scalars().all()
+    )
+
+    new_entries: list[DepreciationEntry] = []
+    for period_end, amount in schedule:
+        if period_end > through:
+            break
+        if period_end in posted_periods:
+            continue
+        if amount <= 0:
+            continue
+
+        # Period-lock guard: refuse if the target month is in a closed period.
+        # If no AccountingPeriod row covers this date we treat it as open.
+        period_row = (
+            await db.execute(
+                select(AccountingPeriod).where(
+                    AccountingPeriod.start_date <= period_end,
+                    AccountingPeriod.end_date >= period_end,
+                )
+            )
+        ).scalar_one_or_none()
+        if period_row is not None and period_row.status != "open":
+            raise FixedAssetError(
+                f"Accounting period containing {period_end.isoformat()} is closed; "
+                f"cannot post depreciation"
+            )
+
+        entry = await create_journal_entry(
+            db,
+            JournalEntryCreate(
+                entry_date=period_end,
+                accounting_period_id=period_row.id if period_row else None,
+                source_type="depreciation",
+                source_id=str(asset.id),
+                memo=f"Depreciation for {asset.name} — {period_end.isoformat()}",
+                lines=[
+                    JournalLineCreate(
+                        account_id=asset.depreciation_expense_account_id,
+                        entry_type="debit",
+                        amount=amount,
+                        description=f"Depreciation Expense — {asset.name}",
+                    ),
+                    JournalLineCreate(
+                        account_id=asset.accumulated_depreciation_account_id,
+                        entry_type="credit",
+                        amount=amount,
+                        description=f"Accum. Depreciation — {asset.name}",
+                    ),
+                ],
+            ),
+        )
+        de = DepreciationEntry(
+            fixed_asset_id=asset.id,
+            period_end=period_end,
+            amount=amount,
+            journal_entry_id=entry.id,
+        )
+        db.add(de)
+        new_entries.append(de)
+
+    # Auto-flip status to fully_depreciated when book value reaches salvage
+    book = await compute_book_value(db, asset.id)
+    if book <= Decimal(asset.salvage_value or 0) and asset.status == "active":
+        asset.status = "fully_depreciated"
+
+    await db.flush()
+    return new_entries
+
+
+async def dispose_asset(
+    db: AsyncSession,
+    *,
+    asset_id: uuid.UUID,
+    disposed_on: date,
+    proceeds: Decimal | None,
+    proceeds_account_id: uuid.UUID | None,
+    gain_account_id: uuid.UUID,
+    loss_account_id: uuid.UUID,
+) -> FixedAsset:
+    """Post the disposal JE for an asset:
+        Cr Equipment (full acquisition cost)
+        Dr Accumulated Depreciation (full accumulated balance)
+        Dr Cash/AR (if proceeds > 0)
+        Dr Loss on Disposal OR Cr Gain on Disposal for the residual.
+    Posts pending depreciation through `disposed_on` first.
+    """
+    asset = (await db.execute(select(FixedAsset).where(FixedAsset.id == asset_id))).scalar_one_or_none()
+    if asset is None:
+        raise FixedAssetError("Fixed asset not found")
+    if asset.status == "disposed":
+        raise FixedAssetError("Asset is already disposed")
+
+    proceeds = Decimal(proceeds or 0)
+    if proceeds < 0:
+        raise FixedAssetError("Disposal proceeds must be non-negative")
+    if proceeds > 0 and proceeds_account_id is None:
+        raise FixedAssetError("proceeds_account_id required when proceeds > 0")
+
+    # Post pending depreciation first
+    await post_depreciation(db, asset_id=asset.id, through=disposed_on)
+
+    posted_total = Decimal("0")
+    for e in (
+        await db.execute(
+            select(DepreciationEntry).where(DepreciationEntry.fixed_asset_id == asset.id)
+        )
+    ).scalars().all():
+        posted_total += Decimal(e.amount)
+
+    cost = Decimal(asset.acquisition_cost)
+    book_value = _q(cost - posted_total)
+    accumulated = _q(posted_total)
+    proceeds_q = _q(proceeds)
+
+    # Gain/loss = proceeds - book_value
+    delta = _q(proceeds_q - book_value)
+
+    lines = [
+        JournalLineCreate(
+            account_id=asset.asset_account_id,
+            entry_type="credit",
+            amount=cost,
+            description=f"Dispose {asset.name} — original cost",
+        ),
+    ]
+    if accumulated > 0:
+        lines.append(
+            JournalLineCreate(
+                account_id=asset.accumulated_depreciation_account_id,
+                entry_type="debit",
+                amount=accumulated,
+                description=f"Dispose {asset.name} — accumulated depreciation",
+            )
+        )
+    if proceeds_q > 0:
+        assert proceeds_account_id is not None
+        lines.append(
+            JournalLineCreate(
+                account_id=proceeds_account_id,
+                entry_type="debit",
+                amount=proceeds_q,
+                description=f"Dispose {asset.name} — proceeds",
+            )
+        )
+    if delta > 0:
+        # Gain
+        lines.append(
+            JournalLineCreate(
+                account_id=gain_account_id,
+                entry_type="credit",
+                amount=delta,
+                description=f"Gain on disposal of {asset.name}",
+            )
+        )
+    elif delta < 0:
+        # Loss
+        lines.append(
+            JournalLineCreate(
+                account_id=loss_account_id,
+                entry_type="debit",
+                amount=-delta,
+                description=f"Loss on disposal of {asset.name}",
+            )
+        )
+
+    period_row = (
+        await db.execute(
+            select(AccountingPeriod).where(
+                AccountingPeriod.start_date <= disposed_on,
+                AccountingPeriod.end_date >= disposed_on,
+            )
+        )
+    ).scalar_one_or_none()
+    if period_row is not None and period_row.status != "open":
+        raise FixedAssetError("Accounting period for disposal date is closed")
+
+    try:
+        entry = await create_journal_entry(
+            db,
+            JournalEntryCreate(
+                entry_date=disposed_on,
+                accounting_period_id=period_row.id if period_row else None,
+                source_type="fixed_asset_disposal",
+                source_id=str(asset.id),
+                memo=f"Disposal of {asset.name}",
+                lines=lines,
+            ),
+        )
+    except AccountingValidationError as e:
+        raise FixedAssetError(str(e)) from e
+
+    asset.status = "disposed"
+    asset.disposed_on = disposed_on
+    asset.disposal_proceeds = proceeds_q if proceeds_q > 0 else None
+    asset.disposal_journal_entry_id = entry.id
+
+    # If a printer is linked, mark inactive — preserve printer history.
+    from app.models.printer import Printer
+    printers = (
+        await db.execute(select(Printer).where(Printer.fixed_asset_id == asset.id))
+    ).scalars().all()
+    for p in printers:
+        p.is_active = False
+
+    await db.flush()
+    return asset
+
+
+async def can_edit_critical_fields(db: AsyncSession, asset_id: uuid.UUID) -> bool:
+    """Cost/method/life are immutable once any depreciation has been posted."""
+    posted = (
+        await db.execute(
+            select(DepreciationEntry).where(DepreciationEntry.fixed_asset_id == asset_id).limit(1)
+        )
+    ).scalar_one_or_none()
+    return posted is None

--- a/backend/tests/test_fixed_asset_service.py
+++ b/backend/tests/test_fixed_asset_service.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.fixed_asset import DepreciationEntry, FixedAsset
+from app.services.fixed_asset_service import (
+    FixedAssetError,
+    can_edit_critical_fields,
+    compute_book_value,
+    dispose_asset,
+    planned_schedule,
+    post_depreciation,
+)
+
+
+# ---------- helpers ----------
+
+
+async def _accounts(db_session):
+    by_code = {}
+    for a in (await db_session.execute(select(Account))).scalars().all():
+        by_code[a.code] = a
+    return by_code
+
+
+async def _make_asset(
+    db_session,
+    *,
+    cost="1200",
+    salvage="0",
+    life_months=12,
+    method="straight_line",
+    rate=None,
+    acquired_on=None,
+):
+    accts = await _accounts(db_session)
+    asset = FixedAsset(
+        name="Test printer",
+        acquired_on=acquired_on or datetime.date(2026, 1, 15),
+        acquisition_cost=Decimal(cost),
+        salvage_value=Decimal(salvage),
+        useful_life_months=life_months,
+        depreciation_method=method,
+        declining_balance_rate=Decimal(rate) if rate is not None else None,
+        asset_account_id=accts["1700"].id,
+        accumulated_depreciation_account_id=accts["1750"].id,
+        depreciation_expense_account_id=accts["6700"].id,
+    )
+    db_session.add(asset)
+    await db_session.flush()
+    return asset
+
+
+# ---------- straight-line ----------
+
+
+@pytest.mark.asyncio
+async def test_sl_schedule_sums_to_cost_minus_salvage(db_session):
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    sched = planned_schedule(a)
+    assert len(sched) == 12
+    total = sum((amt for _, amt in sched), Decimal("0"))
+    assert total == Decimal("1200.00")
+    # Each month roughly equal
+    assert all(amt == Decimal("100.00") for _, amt in sched[:-1])
+
+
+@pytest.mark.asyncio
+async def test_sl_with_salvage(db_session):
+    a = await _make_asset(db_session, cost="1200", salvage="200", life_months=10)
+    sched = planned_schedule(a)
+    total = sum((amt for _, amt in sched), Decimal("0"))
+    assert total == Decimal("1000.00")
+
+
+@pytest.mark.asyncio
+async def test_post_depreciation_through_3_months_idempotent(db_session):
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    # Post through Apr 30 (Jan/Feb/Mar/Apr = 4 month-ends after Jan 15 acquisition)
+    # First period_end is Jan 31 (acquisition month).
+    new_entries = await post_depreciation(db_session, asset_id=a.id, through=datetime.date(2026, 4, 30))
+    assert len(new_entries) == 4
+    # Re-running through the same date is a no-op
+    new_entries2 = await post_depreciation(db_session, asset_id=a.id, through=datetime.date(2026, 4, 30))
+    assert new_entries2 == []
+    book = await compute_book_value(db_session, a.id)
+    assert book == Decimal("800.00")
+
+
+@pytest.mark.asyncio
+async def test_post_depreciation_full_life_brings_book_value_to_salvage(db_session):
+    a = await _make_asset(db_session, cost="1200", salvage="200", life_months=12)
+    await post_depreciation(db_session, asset_id=a.id, through=datetime.date(2027, 12, 31))
+    book = await compute_book_value(db_session, a.id)
+    assert book == Decimal("200.00")
+    # Status auto-flipped
+    refreshed = (await db_session.execute(select(FixedAsset).where(FixedAsset.id == a.id))).scalar_one()
+    assert refreshed.status == "fully_depreciated"
+
+
+# ---------- declining-balance ----------
+
+
+@pytest.mark.asyncio
+async def test_db_schedule_front_loaded_and_reaches_salvage(db_session):
+    a = await _make_asset(
+        db_session,
+        cost="1200",
+        salvage="0",
+        life_months=24,
+        method="declining_balance",
+    )
+    sched = planned_schedule(a)
+    total = sum((amt for _, amt in sched), Decimal("0"))
+    assert total == Decimal("1200.00")
+    # Front-loaded — first month exceeds last month
+    assert sched[0][1] > sched[-1][1]
+
+
+@pytest.mark.asyncio
+async def test_db_explicit_rate(db_session):
+    a = await _make_asset(
+        db_session,
+        cost="1000",
+        salvage="100",
+        life_months=12,
+        method="declining_balance",
+        rate="0.40",
+    )
+    sched = planned_schedule(a)
+    total = sum((amt for _, amt in sched), Decimal("0"))
+    assert total == Decimal("900.00")
+
+
+# ---------- edits ----------
+
+
+@pytest.mark.asyncio
+async def test_critical_fields_locked_after_first_post(db_session):
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    assert await can_edit_critical_fields(db_session, a.id) is True
+    await post_depreciation(db_session, asset_id=a.id, through=datetime.date(2026, 1, 31))
+    assert await can_edit_critical_fields(db_session, a.id) is False
+
+
+# ---------- disposal ----------
+
+
+@pytest.mark.asyncio
+async def test_dispose_with_proceeds_above_book_posts_gain(db_session):
+    accts = await _accounts(db_session)
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    # Post 3 months → book value = 900
+    await post_depreciation(db_session, asset_id=a.id, through=datetime.date(2026, 3, 31))
+    pre_book = await compute_book_value(db_session, a.id)
+    assert pre_book == Decimal("900.00")
+
+    asset = await dispose_asset(
+        db_session,
+        asset_id=a.id,
+        disposed_on=datetime.date(2026, 3, 31),
+        proceeds=Decimal("1000"),
+        proceeds_account_id=accts["1000"].id,
+        gain_account_id=accts["4910"].id,
+        loss_account_id=accts["6710"].id,
+    )
+    assert asset.status == "disposed"
+    assert asset.disposal_journal_entry_id is not None
+
+
+@pytest.mark.asyncio
+async def test_dispose_with_proceeds_below_book_posts_loss(db_session):
+    accts = await _accounts(db_session)
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    await post_depreciation(db_session, asset_id=a.id, through=datetime.date(2026, 3, 31))
+    asset = await dispose_asset(
+        db_session,
+        asset_id=a.id,
+        disposed_on=datetime.date(2026, 3, 31),
+        proceeds=Decimal("500"),
+        proceeds_account_id=accts["1000"].id,
+        gain_account_id=accts["4910"].id,
+        loss_account_id=accts["6710"].id,
+    )
+    assert asset.status == "disposed"
+
+
+@pytest.mark.asyncio
+async def test_dispose_with_no_proceeds_writes_off(db_session):
+    accts = await _accounts(db_session)
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    asset = await dispose_asset(
+        db_session,
+        asset_id=a.id,
+        disposed_on=datetime.date(2026, 6, 30),
+        proceeds=None,
+        proceeds_account_id=None,
+        gain_account_id=accts["4910"].id,
+        loss_account_id=accts["6710"].id,
+    )
+    assert asset.status == "disposed"
+    assert asset.disposal_proceeds is None
+
+
+@pytest.mark.asyncio
+async def test_cannot_dispose_already_disposed(db_session):
+    accts = await _accounts(db_session)
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    await dispose_asset(
+        db_session,
+        asset_id=a.id,
+        disposed_on=datetime.date(2026, 3, 31),
+        proceeds=None,
+        proceeds_account_id=None,
+        gain_account_id=accts["4910"].id,
+        loss_account_id=accts["6710"].id,
+    )
+    with pytest.raises(FixedAssetError):
+        await dispose_asset(
+            db_session,
+            asset_id=a.id,
+            disposed_on=datetime.date(2026, 4, 30),
+            proceeds=None,
+            proceeds_account_id=None,
+            gain_account_id=accts["4910"].id,
+            loss_account_id=accts["6710"].id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_post_depreciation_refused_on_disposed_asset(db_session):
+    accts = await _accounts(db_session)
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    await dispose_asset(
+        db_session,
+        asset_id=a.id,
+        disposed_on=datetime.date(2026, 3, 31),
+        proceeds=None,
+        proceeds_account_id=None,
+        gain_account_id=accts["4910"].id,
+        loss_account_id=accts["6710"].id,
+    )
+    with pytest.raises(FixedAssetError):
+        await post_depreciation(db_session, asset_id=a.id, through=datetime.date(2026, 4, 30))

--- a/docs/fixed_assets.md
+++ b/docs/fixed_assets.md
@@ -1,0 +1,72 @@
+# Fixed Asset Register
+
+Operators capitalize equipment (printers, cameras, computers, post-processing rigs) on the balance sheet, depreciate them on a chosen schedule, and dispose them with gain/loss accounting (#238).
+
+## Concepts
+
+- **FixedAsset** — one capital purchase. Carries `acquisition_cost`, `salvage_value`, `useful_life_months`, `depreciation_method` (`straight_line` or `declining_balance`), and three GL account FKs (asset, accumulated depreciation, depreciation expense). Optional `acquisition_bill_id` traces back to the AP bill that booked the purchase.
+- **DepreciationEntry** — one month of depreciation, with the resulting `journal_entry_id`. Idempotent per `(fixed_asset_id, period_end)`.
+- **Status** — `active` → `fully_depreciated` (auto when book reaches salvage) → optionally `disposed` (operator action).
+
+## COA seed (5 new accounts)
+
+Added to `STARTER_CHART_OF_ACCOUNTS` and the `20260509_04` migration; `seed_chart_of_accounts` is now idempotent and tops up missing codes on existing installations.
+
+| Code | Name | Type |
+|---|---|---|
+| 1700 | Equipment | asset (debit-normal) |
+| 1750 | Accumulated Depreciation — Equipment | asset contra (credit-normal) |
+| 6700 | Depreciation Expense | expense |
+| 4910 | Gain on Disposal of Equipment | revenue |
+| 6710 | Loss on Disposal of Equipment | expense |
+
+These are defaults; operators can pick alternative accounts per asset via the `*_account_id` fields on create.
+
+## Math
+
+**Straight-line.** Monthly amount = `(cost − salvage) / life_months`. The schedule is generated for the full useful life and the final month rounds to bring the schedule's sum to exactly `cost − salvage`.
+
+**Declining-balance.** Monthly amount = `book_value_start_of_period × (rate / 12)`, where `rate` defaults to `2 / life_years` (DDB) when not explicitly set. The service switches to a straight-line floor over the remaining life when SL would yield a larger monthly amount, ensuring the asset reaches salvage by end of life. Final-period adjustment forces the schedule to sum to exactly `cost − salvage`.
+
+## Posting (manual)
+
+`POST /api/v1/fixed-assets/post-depreciation` body: `{ period_end, asset_ids? }`.
+
+Per asset, the service walks the planned schedule and posts a JE for every period that:
+- has not yet been posted (idempotent — re-running is a no-op for already-posted months);
+- is on or before `period_end`;
+- is not in a closed accounting period.
+
+Each post is balanced: Dr Depreciation Expense / Cr Accumulated Depreciation. After posting, the asset auto-flips to `fully_depreciated` if book value ≤ salvage.
+
+## Disposal
+
+`POST /api/v1/fixed-assets/{id}/dispose` body: `{ disposed_on, proceeds?, proceeds_account_id? }`.
+
+1. Posts pending depreciation through `disposed_on`.
+2. Computes `book_value = cost − accumulated`.
+3. Posts the disposal JE:
+   - **Cr** Equipment for `cost`
+   - **Dr** Accumulated Depreciation for the full balance
+   - **Dr** Cash/AR (`proceeds_account_id`) for `proceeds` if > 0
+   - Residual `delta = proceeds − book_value` posts as **Cr** Gain when positive, **Dr** Loss when negative; zero on `delta == 0`.
+4. Sets status `disposed`, stamps `disposed_on`, links the JE.
+5. If a Printer is linked via `Printer.fixed_asset_id`, marks the printer inactive (preserves `printer_history` rows).
+
+## Edit lock
+
+`acquisition_cost`, `salvage_value`, `useful_life_months`, `depreciation_method`, `declining_balance_rate` are immutable once any depreciation is posted. To change them: reverse the posted entries first.
+
+## Linking to a Printer
+
+`Printer.fixed_asset_id` is a nullable FK. Operators link existing printers manually from the printer detail page. No auto-seeding — capitalization is a deliberate accounting decision per asset.
+
+## Phase 2 follow-ups
+
+- Auto-scheduled monthly depreciation posting (cron via n8n, mirroring #247's pattern).
+- Frontend `/finance/fixed-assets` route — list, detail, schedule, disposal modal. Currently API-only.
+- Component depreciation (sub-asset of a printer like a hot-end).
+- Asset categories with shared default policies.
+- Bulk import from prior accounting system.
+- Tax-method depreciation (MACRS) parallel to book depreciation.
+- Linking cameras / non-printer devices to fixed assets in the UI (model is already generic; only Printer has the FK today).


### PR DESCRIPTION
Implements backend slice of [#238](https://github.com/bbengt1/3d-print-sales/issues/238). Capitalize equipment, run SL or DDB depreciation, dispose with gain/loss. Frontend deferred. New system accounts auto-seed. `seed_chart_of_accounts` is now idempotent. 317 tests pass (305 + 12 new). Frontend build clean. Phase 2 follow-ups in `docs/fixed_assets.md`.