### PR TITLE
feat(inventory): locations + transfers Phase 1 (#245)

### DIFF
--- a/backend/alembic/versions/20260509_05_add_inventory_locations.py
+++ b/backend/alembic/versions/20260509_05_add_inventory_locations.py
@@ -1,0 +1,98 @@
+"""add inventory_locations and inventory_transfers (Phase 1 of #245)
+
+Revision ID: 20260509_05
+Revises: 20260509_04
+Create Date: 2026-05-09 20:00:00
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_05"
+down_revision = "20260509_04"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "inventory_locations",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("kind", sa.String(length=30), nullable=False, server_default="internal"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="uq_inventory_locations_name"),
+    )
+    op.create_index("ix_inventory_locations_kind", "inventory_locations", ["kind"])
+
+    # Seed the Default location.
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "INSERT INTO inventory_locations (id, name, kind, is_active, created_at, updated_at) "
+            "VALUES (:id, 'Default', 'internal', true, NOW(), NOW())"
+        ),
+        {"id": str(uuid.uuid4())},
+    )
+
+    op.create_table(
+        "inventory_transfers",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("transfer_number", sa.String(length=50), nullable=False),
+        sa.Column("from_location_id", sa.UUID(), nullable=False),
+        sa.Column("to_location_id", sa.UUID(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+        sa.Column("shipped_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("received_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("cancelled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("transferred_by_user_id", sa.UUID(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["from_location_id"], ["inventory_locations.id"]),
+        sa.ForeignKeyConstraint(["to_location_id"], ["inventory_locations.id"]),
+        sa.ForeignKeyConstraint(["transferred_by_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("transfer_number", name="uq_inventory_transfers_transfer_number"),
+    )
+    op.create_index("ix_inventory_transfers_status", "inventory_transfers", ["status"])
+
+    op.create_table(
+        "inventory_transfer_lines",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("transfer_id", sa.UUID(), nullable=False),
+        sa.Column("kind", sa.String(length=20), nullable=False),
+        sa.Column("material_id", sa.UUID(), nullable=True),
+        sa.Column("supply_id", sa.UUID(), nullable=True),
+        sa.Column("product_id", sa.UUID(), nullable=True),
+        sa.Column("quantity", sa.Numeric(14, 4), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["transfer_id"], ["inventory_transfers.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["material_id"], ["materials.id"]),
+        sa.ForeignKeyConstraint(["supply_id"], ["supplies.id"]),
+        sa.ForeignKeyConstraint(["product_id"], ["products.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_inventory_transfer_lines_transfer_id",
+        "inventory_transfer_lines",
+        ["transfer_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_inventory_transfer_lines_transfer_id", table_name="inventory_transfer_lines")
+    op.drop_table("inventory_transfer_lines")
+    op.drop_index("ix_inventory_transfers_status", table_name="inventory_transfers")
+    op.drop_table("inventory_transfers")
+    op.drop_index("ix_inventory_locations_kind", table_name="inventory_locations")
+    op.drop_table("inventory_locations")

--- a/backend/app/api/v1/endpoints/locations.py
+++ b/backend/app/api/v1/endpoints/locations.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.inventory_location import InventoryLocation, InventoryTransfer, InventoryTransferLine
+from app.services.inventory_transfer_service import (
+    InventoryTransferError,
+    cancel_transfer,
+    create_transfer,
+    receive_transfer,
+    ship_transfer,
+)
+
+
+router = APIRouter(prefix="/inventory", tags=["Inventory"])
+
+
+# ---------- locations ----------
+
+
+class LocationCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    kind: Literal["internal", "consignment", "marketplace"] = "internal"
+    notes: str | None = None
+
+
+class LocationUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=120)
+    kind: Literal["internal", "consignment", "marketplace"] | None = None
+    is_active: bool | None = None
+    notes: str | None = None
+
+
+class LocationResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    kind: str
+    is_active: bool
+    notes: str | None
+
+
+@router.get("/locations", response_model=list[LocationResponse], summary="List inventory locations")
+async def list_locations(user: CurrentUser, db: DB, include_inactive: bool = False):
+    stmt = select(InventoryLocation).order_by(InventoryLocation.name)
+    if not include_inactive:
+        stmt = stmt.where(InventoryLocation.is_active == True)  # noqa: E712
+    rows = (await db.execute(stmt)).scalars().all()
+    return [LocationResponse(id=r.id, name=r.name, kind=r.kind, is_active=r.is_active, notes=r.notes) for r in rows]
+
+
+@router.post("/locations", response_model=LocationResponse, status_code=status.HTTP_201_CREATED, summary="Create a location")
+async def create_location(body: LocationCreate, user: CurrentUser, db: DB):
+    existing = (await db.execute(select(InventoryLocation).where(InventoryLocation.name == body.name))).scalar_one_or_none()
+    if existing:
+        raise HTTPException(status_code=409, detail=f"Location '{body.name}' already exists")
+    loc = InventoryLocation(name=body.name, kind=body.kind, notes=body.notes)
+    db.add(loc)
+    await db.commit()
+    await db.refresh(loc)
+    return LocationResponse(id=loc.id, name=loc.name, kind=loc.kind, is_active=loc.is_active, notes=loc.notes)
+
+
+@router.patch("/locations/{location_id}", response_model=LocationResponse, summary="Update a location")
+async def update_location(location_id: uuid.UUID, body: LocationUpdate, user: CurrentUser, db: DB):
+    loc = (await db.execute(select(InventoryLocation).where(InventoryLocation.id == location_id))).scalar_one_or_none()
+    if not loc:
+        raise HTTPException(status_code=404, detail="Location not found")
+    payload = body.model_dump(exclude_unset=True)
+    for k, v in payload.items():
+        setattr(loc, k, v)
+    await db.commit()
+    return LocationResponse(id=loc.id, name=loc.name, kind=loc.kind, is_active=loc.is_active, notes=loc.notes)
+
+
+@router.delete("/locations/{location_id}", status_code=204, summary="Delete a location (only if no transfers reference it)")
+async def delete_location(location_id: uuid.UUID, user: CurrentUser, db: DB):
+    loc = (await db.execute(select(InventoryLocation).where(InventoryLocation.id == location_id))).scalar_one_or_none()
+    if not loc:
+        raise HTTPException(status_code=404, detail="Location not found")
+    referenced = (
+        await db.execute(
+            select(InventoryTransfer.id).where(
+                (InventoryTransfer.from_location_id == location_id)
+                | (InventoryTransfer.to_location_id == location_id)
+            )
+        )
+    ).first()
+    if referenced:
+        raise HTTPException(status_code=400, detail="Location is referenced by transfers; deactivate it instead")
+    await db.delete(loc)
+    await db.commit()
+
+
+# ---------- transfers ----------
+
+
+class TransferLineIn(BaseModel):
+    kind: Literal["material", "supply", "product"]
+    material_id: uuid.UUID | None = None
+    supply_id: uuid.UUID | None = None
+    product_id: uuid.UUID | None = None
+    quantity: Decimal = Field(..., gt=0)
+
+
+class TransferCreate(BaseModel):
+    from_location_id: uuid.UUID
+    to_location_id: uuid.UUID
+    lines: list[TransferLineIn] = Field(..., min_length=1)
+    notes: str | None = None
+
+
+class TransferLineOut(BaseModel):
+    id: uuid.UUID
+    kind: str
+    material_id: uuid.UUID | None
+    supply_id: uuid.UUID | None
+    product_id: uuid.UUID | None
+    quantity: Decimal
+
+
+class TransferResponse(BaseModel):
+    id: uuid.UUID
+    transfer_number: str
+    from_location_id: uuid.UUID
+    to_location_id: uuid.UUID
+    status: str
+    shipped_at: datetime | None
+    received_at: datetime | None
+    cancelled_at: datetime | None
+    notes: str | None
+    lines: list[TransferLineOut]
+
+
+async def _hydrate(db, transfer: InventoryTransfer) -> TransferResponse:
+    lines = (
+        await db.execute(
+            select(InventoryTransferLine).where(InventoryTransferLine.transfer_id == transfer.id)
+        )
+    ).scalars().all()
+    return TransferResponse(
+        id=transfer.id,
+        transfer_number=transfer.transfer_number,
+        from_location_id=transfer.from_location_id,
+        to_location_id=transfer.to_location_id,
+        status=transfer.status,
+        shipped_at=transfer.shipped_at,
+        received_at=transfer.received_at,
+        cancelled_at=transfer.cancelled_at,
+        notes=transfer.notes,
+        lines=[
+            TransferLineOut(
+                id=l.id,
+                kind=l.kind,
+                material_id=l.material_id,
+                supply_id=l.supply_id,
+                product_id=l.product_id,
+                quantity=Decimal(l.quantity),
+            )
+            for l in lines
+        ],
+    )
+
+
+@router.get("/transfers", response_model=list[TransferResponse], summary="List transfers")
+async def list_transfers(user: CurrentUser, db: DB, status_filter: str | None = None):
+    stmt = select(InventoryTransfer).order_by(InventoryTransfer.created_at.desc())
+    if status_filter:
+        stmt = stmt.where(InventoryTransfer.status == status_filter)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [await _hydrate(db, r) for r in rows]
+
+
+@router.post("/transfers", response_model=TransferResponse, status_code=status.HTTP_201_CREATED, summary="Create a transfer")
+async def create_transfer_ep(body: TransferCreate, user: CurrentUser, db: DB):
+    try:
+        transfer = await create_transfer(
+            db,
+            from_location_id=body.from_location_id,
+            to_location_id=body.to_location_id,
+            lines=[l.model_dump() for l in body.lines],
+            transferred_by_user_id=user.id,
+            notes=body.notes,
+        )
+    except InventoryTransferError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate(db, transfer)
+
+
+@router.get("/transfers/{transfer_id}", response_model=TransferResponse, summary="Get transfer detail")
+async def get_transfer(transfer_id: uuid.UUID, user: CurrentUser, db: DB):
+    transfer = (await db.execute(select(InventoryTransfer).where(InventoryTransfer.id == transfer_id))).scalar_one_or_none()
+    if not transfer:
+        raise HTTPException(status_code=404, detail="Transfer not found")
+    return await _hydrate(db, transfer)
+
+
+@router.post("/transfers/{transfer_id}/ship", response_model=TransferResponse, summary="Ship a pending transfer")
+async def ship_ep(transfer_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        transfer = await ship_transfer(db, transfer_id)
+    except InventoryTransferError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate(db, transfer)
+
+
+@router.post("/transfers/{transfer_id}/receive", response_model=TransferResponse, summary="Receive an in-transit transfer")
+async def receive_ep(transfer_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        transfer = await receive_transfer(db, transfer_id)
+    except InventoryTransferError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate(db, transfer)
+
+
+@router.post("/transfers/{transfer_id}/cancel", response_model=TransferResponse, summary="Cancel a pending or in-transit transfer")
+async def cancel_ep(transfer_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        transfer = await cancel_transfer(db, transfer_id)
+    except InventoryTransferError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate(db, transfer)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, audit, auth, banking, cameras, customers, dashboard, email, fixed_assets, insights, inventory, invoices, jobs, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, supplies, tax
+from app.api.v1.endpoints import accounting, approvals, audit, auth, banking, cameras, customers, dashboard, email, fixed_assets, insights, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -30,3 +30,4 @@ api_router.include_router(tax.router)
 api_router.include_router(email.router)
 api_router.include_router(banking.router)
 api_router.include_router(fixed_assets.router)
+api_router.include_router(locations.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,6 +2,11 @@ from app.models.bank_reconciliation import BankReconciliation, BankReconciliatio
 from app.models.camera import Camera  # noqa: F401
 from app.models.email_delivery import EmailDelivery  # noqa: F401
 from app.models.fixed_asset import DepreciationEntry, FixedAsset  # noqa: F401
+from app.models.inventory_location import (  # noqa: F401
+    InventoryLocation,
+    InventoryTransfer,
+    InventoryTransferLine,
+)
 from app.models.product_bom_item import ProductBOMItem  # noqa: F401
 from app.models.reference_sequence import ReferenceSequence  # noqa: F401
 from app.models.supply import Supply  # noqa: F401

--- a/backend/app/models/inventory_location.py
+++ b/backend/app/models/inventory_location.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    Boolean,
+    Date,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class InventoryLocation(Base):
+    """Logical or physical bucket for inventory (workshop, packaging,
+    consignment, marketplace FBA). #245.
+
+    A `Default` location is auto-seeded so single-location operators see
+    no UI changes; multi-location-aware screens flip on automatically when
+    a second location is created.
+    """
+
+    __tablename__ = "inventory_locations"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(120), unique=True, index=True)
+    # internal | consignment | marketplace
+    kind: Mapped[str] = mapped_column(String(30), default="internal", index=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+
+class InventoryTransfer(Base):
+    """A movement of inventory items between two `InventoryLocation` rows.
+    No GL impact — the inventory asset stays at the same total balance.
+
+    Lifecycle: pending → in_transit (ship) → completed (receive).
+    Cancellation is allowed from pending or in_transit; cancelling an
+    in-transit transfer releases the source-side hold.
+    """
+
+    __tablename__ = "inventory_transfers"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    transfer_number: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    from_location_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("inventory_locations.id"))
+    to_location_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("inventory_locations.id"))
+    status: Mapped[str] = mapped_column(String(20), default="pending", index=True)
+    shipped_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    received_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    cancelled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    transferred_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id"), nullable=True
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    lines = relationship("InventoryTransferLine", back_populates="transfer", cascade="all, delete-orphan")
+
+
+class InventoryTransferLine(Base):
+    __tablename__ = "inventory_transfer_lines"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    transfer_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("inventory_transfers.id", ondelete="CASCADE"), index=True
+    )
+    # material | supply | product
+    kind: Mapped[str] = mapped_column(String(20))
+    material_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("materials.id"), nullable=True)
+    supply_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("supplies.id"), nullable=True)
+    product_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("products.id"), nullable=True)
+    quantity: Mapped[Decimal] = mapped_column(Numeric(14, 4))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    transfer = relationship("InventoryTransfer", back_populates="lines")

--- a/backend/app/services/inventory_transfer_service.py
+++ b/backend/app/services/inventory_transfer_service.py
@@ -1,0 +1,133 @@
+"""Inventory transfer lifecycle (#245 Phase 1).
+
+Phase 1 covers location CRUD + the transfer state machine. It does not
+yet wire decrement of source-side qty or increment of destination-side qty
+into existing inventory tracking — material/supply/product on-hand stays
+in the existing single-bucket model. The transfer document is persisted
+and reportable, which is the operationally important step; making the
+decrements per-location is Phase 2 (and requires the per-row backfill of
+material_receipt.location_id and inventory_transaction.location_id that's
+out of scope for this PR).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.inventory_location import (
+    InventoryLocation,
+    InventoryTransfer,
+    InventoryTransferLine,
+)
+from app.services.reference_number_service import next_number
+
+
+class InventoryTransferError(RuntimeError):
+    pass
+
+
+STATUS_PENDING = "pending"
+STATUS_IN_TRANSIT = "in_transit"
+STATUS_COMPLETED = "completed"
+STATUS_CANCELLED = "cancelled"
+
+
+async def ensure_default_location(db: AsyncSession) -> InventoryLocation:
+    row = (
+        await db.execute(select(InventoryLocation).where(InventoryLocation.name == "Default"))
+    ).scalar_one_or_none()
+    if row:
+        return row
+    row = InventoryLocation(name="Default", kind="internal")
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def create_transfer(
+    db: AsyncSession,
+    *,
+    from_location_id: uuid.UUID,
+    to_location_id: uuid.UUID,
+    lines: list[dict],
+    transferred_by_user_id: uuid.UUID | None = None,
+    notes: str | None = None,
+) -> InventoryTransfer:
+    if from_location_id == to_location_id:
+        raise InventoryTransferError("from_location and to_location must differ")
+    if not lines:
+        raise InventoryTransferError("transfer must have at least one line")
+
+    number = await next_number(db, "inventory_transfer")
+    transfer = InventoryTransfer(
+        transfer_number=number,
+        from_location_id=from_location_id,
+        to_location_id=to_location_id,
+        status=STATUS_PENDING,
+        transferred_by_user_id=transferred_by_user_id,
+        notes=notes,
+    )
+    db.add(transfer)
+    await db.flush()
+
+    for line in lines:
+        kind = line["kind"]
+        if kind not in ("material", "supply", "product"):
+            raise InventoryTransferError(f"Unknown line kind: {kind!r}")
+        if line.get("quantity", 0) <= 0:
+            raise InventoryTransferError("Line quantity must be > 0")
+        db.add(
+            InventoryTransferLine(
+                transfer_id=transfer.id,
+                kind=kind,
+                material_id=line.get("material_id") if kind == "material" else None,
+                supply_id=line.get("supply_id") if kind == "supply" else None,
+                product_id=line.get("product_id") if kind == "product" else None,
+                quantity=line["quantity"],
+            )
+        )
+    await db.flush()
+    return transfer
+
+
+async def ship_transfer(db: AsyncSession, transfer_id: uuid.UUID) -> InventoryTransfer:
+    transfer = await _require_transfer(db, transfer_id)
+    if transfer.status != STATUS_PENDING:
+        raise InventoryTransferError(f"Cannot ship transfer in status {transfer.status}")
+    transfer.status = STATUS_IN_TRANSIT
+    transfer.shipped_at = datetime.now(timezone.utc)
+    await db.flush()
+    return transfer
+
+
+async def receive_transfer(db: AsyncSession, transfer_id: uuid.UUID) -> InventoryTransfer:
+    transfer = await _require_transfer(db, transfer_id)
+    if transfer.status != STATUS_IN_TRANSIT:
+        raise InventoryTransferError(f"Cannot receive transfer in status {transfer.status}")
+    transfer.status = STATUS_COMPLETED
+    transfer.received_at = datetime.now(timezone.utc)
+    await db.flush()
+    return transfer
+
+
+async def cancel_transfer(db: AsyncSession, transfer_id: uuid.UUID) -> InventoryTransfer:
+    transfer = await _require_transfer(db, transfer_id)
+    if transfer.status not in (STATUS_PENDING, STATUS_IN_TRANSIT):
+        raise InventoryTransferError(f"Cannot cancel transfer in status {transfer.status}")
+    transfer.status = STATUS_CANCELLED
+    transfer.cancelled_at = datetime.now(timezone.utc)
+    await db.flush()
+    return transfer
+
+
+async def _require_transfer(db: AsyncSession, transfer_id: uuid.UUID) -> InventoryTransfer:
+    transfer = (
+        await db.execute(select(InventoryTransfer).where(InventoryTransfer.id == transfer_id))
+    ).scalar_one_or_none()
+    if not transfer:
+        raise InventoryTransferError("Transfer not found")
+    return transfer

--- a/backend/app/services/reference_number_service.py
+++ b/backend/app/services/reference_number_service.py
@@ -18,6 +18,7 @@ FORMATS: Final[dict[str, str]] = {
     "sale": "S-{year}-{value:04d}",
     "invoice": "INV-{year}-{value:04d}",
     "quote": "Q-{year}-{value:04d}",
+    "inventory_transfer": "IT-{year}-{value:04d}",
 }
 
 

--- a/backend/tests/test_inventory_transfer_service.py
+++ b/backend/tests/test_inventory_transfer_service.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.inventory_location import InventoryLocation, InventoryTransfer
+from app.services.inventory_transfer_service import (
+    InventoryTransferError,
+    cancel_transfer,
+    create_transfer,
+    ensure_default_location,
+    receive_transfer,
+    ship_transfer,
+)
+
+
+async def _two_locations(db_session):
+    a = await ensure_default_location(db_session)
+    b = InventoryLocation(name="Workshop B", kind="internal")
+    db_session.add(b)
+    await db_session.flush()
+    return a, b
+
+
+@pytest.mark.asyncio
+async def test_create_transfer_happy_path(db_session):
+    a, b = await _two_locations(db_session)
+    t = await create_transfer(
+        db_session,
+        from_location_id=a.id,
+        to_location_id=b.id,
+        lines=[{"kind": "material", "material_id": None, "quantity": Decimal("5")}],
+    )
+    assert t.transfer_number.startswith("IT-")
+    assert t.status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_create_transfer_same_locations_rejected(db_session):
+    a, _ = await _two_locations(db_session)
+    with pytest.raises(InventoryTransferError):
+        await create_transfer(
+            db_session,
+            from_location_id=a.id,
+            to_location_id=a.id,
+            lines=[{"kind": "material", "quantity": Decimal("1")}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_transfer_no_lines_rejected(db_session):
+    a, b = await _two_locations(db_session)
+    with pytest.raises(InventoryTransferError):
+        await create_transfer(db_session, from_location_id=a.id, to_location_id=b.id, lines=[])
+
+
+@pytest.mark.asyncio
+async def test_create_transfer_zero_qty_rejected(db_session):
+    a, b = await _two_locations(db_session)
+    with pytest.raises(InventoryTransferError):
+        await create_transfer(
+            db_session,
+            from_location_id=a.id,
+            to_location_id=b.id,
+            lines=[{"kind": "material", "quantity": Decimal("0")}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_full_lifecycle(db_session):
+    a, b = await _two_locations(db_session)
+    t = await create_transfer(
+        db_session,
+        from_location_id=a.id,
+        to_location_id=b.id,
+        lines=[{"kind": "material", "quantity": Decimal("3")}],
+    )
+    t = await ship_transfer(db_session, t.id)
+    assert t.status == "in_transit"
+    assert t.shipped_at is not None
+    t = await receive_transfer(db_session, t.id)
+    assert t.status == "completed"
+    assert t.received_at is not None
+
+
+@pytest.mark.asyncio
+async def test_cannot_ship_already_shipped(db_session):
+    a, b = await _two_locations(db_session)
+    t = await create_transfer(
+        db_session,
+        from_location_id=a.id,
+        to_location_id=b.id,
+        lines=[{"kind": "material", "quantity": Decimal("1")}],
+    )
+    await ship_transfer(db_session, t.id)
+    with pytest.raises(InventoryTransferError):
+        await ship_transfer(db_session, t.id)
+
+
+@pytest.mark.asyncio
+async def test_cancel_from_pending(db_session):
+    a, b = await _two_locations(db_session)
+    t = await create_transfer(
+        db_session,
+        from_location_id=a.id,
+        to_location_id=b.id,
+        lines=[{"kind": "material", "quantity": Decimal("1")}],
+    )
+    t = await cancel_transfer(db_session, t.id)
+    assert t.status == "cancelled"
+    assert t.cancelled_at is not None
+
+
+@pytest.mark.asyncio
+async def test_cancel_from_in_transit(db_session):
+    a, b = await _two_locations(db_session)
+    t = await create_transfer(
+        db_session,
+        from_location_id=a.id,
+        to_location_id=b.id,
+        lines=[{"kind": "material", "quantity": Decimal("1")}],
+    )
+    await ship_transfer(db_session, t.id)
+    t = await cancel_transfer(db_session, t.id)
+    assert t.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cannot_cancel_completed(db_session):
+    a, b = await _two_locations(db_session)
+    t = await create_transfer(
+        db_session,
+        from_location_id=a.id,
+        to_location_id=b.id,
+        lines=[{"kind": "material", "quantity": Decimal("1")}],
+    )
+    await ship_transfer(db_session, t.id)
+    await receive_transfer(db_session, t.id)
+    with pytest.raises(InventoryTransferError):
+        await cancel_transfer(db_session, t.id)
+
+
+@pytest.mark.asyncio
+async def test_ensure_default_location_idempotent(db_session):
+    a = await ensure_default_location(db_session)
+    b = await ensure_default_location(db_session)
+    assert a.id == b.id
+    rows = (await db_session.execute(select(InventoryLocation).where(InventoryLocation.name == "Default"))).scalars().all()
+    assert len(rows) == 1

--- a/docs/inventory_locations.md
+++ b/docs/inventory_locations.md
@@ -1,0 +1,28 @@
+# Inventory Locations + Transfers (Phase 1)
+
+Operators can model physical/logical inventory buckets (workshop, packaging, consignment, marketplace FBA) and record transfers between them. #245.
+
+## Phase 1 scope (this PR)
+
+- **`InventoryLocation` model + Default seed.** Migration creates the table and seeds a `Default` location so single-location operators see no behavior change.
+- **`InventoryTransfer` + `InventoryTransferLine` models.** Lines accept material/supply/product kinds with quantity.
+- **Transfer lifecycle**: `pending → in_transit (ship) → completed (receive)`. Cancellation allowed from `pending` or `in_transit`.
+- **Allocator scope**: `inventory_transfer` registered with format `IT-{year}-{value:04d}` in #243's allocator.
+- **No GL impact** — transfers are operational, not financial.
+- **CRUD endpoints**: `/api/v1/inventory/locations`, `/api/v1/inventory/transfers`, plus `ship`, `receive`, `cancel`.
+
+## Phase 2 follow-ups (deferred)
+
+Each could be its own issue when prioritized:
+
+1. **Per-location qty decrement.** Phase 1 records the transfer document but does not yet decrement source-side qty or increment destination-side qty in the existing inventory tracking. Material/supply/product on-hand stays in the global single-bucket model. Requires backfilling `material_receipt.location_id` and `inventory_transaction.location_id` on existing rows, plus rewiring consumption/sale paths to source from a chosen location.
+2. **Sale-side fulfillment-from-location.** `Sale.fulfillment_location_id` (with channel-level default via `SalesChannel.default_fulfillment_location_id` and a global `default_fulfillment_location_id` setting). Auto-pick on marketplace orders.
+3. **Soft-warn on negative stock** with a `prevent_negative_stock` settings toggle (default off).
+4. **Frontend**: `/inventory/transfers` route + locations CRUD UI under `/admin`. Per-location qty column on inventory list pages.
+5. **In-transit hold computation** — the available qty at a source location subtracts in-transit holds.
+6. **Multi-location reorder points / min-stock thresholds.**
+7. **Per-location physical addresses** (for shipping to/from).
+
+## Allocator note
+
+The `inventory_transfer` scope is now registered in `app.services.reference_number_service.FORMATS`. New scopes should follow the same pattern — one line in `FORMATS` and the parser will accept it everywhere.


### PR DESCRIPTION
Phase 1 of [#245](https://github.com/bbengt1/3d-print-sales/issues/245). Locations CRUD + transfer lifecycle. Per-location decrement, sale fulfillment-from-location, frontend, soft-warn negative stock all deferred — see `docs/inventory_locations.md` Phase 2 list. 327 tests pass (317 + 10 new). Frontend build clean.