### PR TITLE
feat(banking): inter-account transfers (#246)

### DIFF
--- a/backend/alembic/versions/20260509_06_add_inter_account_transfers.py
+++ b/backend/alembic/versions/20260509_06_add_inter_account_transfers.py
@@ -1,0 +1,49 @@
+"""add journal_lines.posted_on and inter_account_transfers (#246)
+
+Revision ID: 20260509_06
+Revises: 20260509_05
+Create Date: 2026-05-09 21:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_06"
+down_revision = "20260509_05"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "journal_lines",
+        sa.Column("posted_on", sa.Date(), nullable=True),
+    )
+
+    op.create_table(
+        "inter_account_transfers",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("transfer_number", sa.String(length=50), nullable=False),
+        sa.Column("from_account_id", sa.UUID(), nullable=False),
+        sa.Column("to_account_id", sa.UUID(), nullable=False),
+        sa.Column("amount", sa.Numeric(14, 4), nullable=False),
+        sa.Column("paid_on", sa.Date(), nullable=False),
+        sa.Column("received_on", sa.Date(), nullable=False),
+        sa.Column("journal_entry_id", sa.UUID(), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["from_account_id"], ["accounts.id"]),
+        sa.ForeignKeyConstraint(["to_account_id"], ["accounts.id"]),
+        sa.ForeignKeyConstraint(["journal_entry_id"], ["journal_entries.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("transfer_number", name="uq_inter_account_transfers_transfer_number"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("inter_account_transfers")
+    op.drop_column("journal_lines", "posted_on")

--- a/backend/app/api/v1/endpoints/inter_account_transfers.py
+++ b/backend/app/api/v1/endpoints/inter_account_transfers.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.inter_account_transfer import InterAccountTransfer
+from app.services.inter_account_transfer_service import (
+    InterAccountTransferError,
+    create_inter_account_transfer,
+    delete_inter_account_transfer,
+)
+
+
+router = APIRouter(prefix="/banking/inter-account-transfers", tags=["Banking"])
+
+
+class TransferCreate(BaseModel):
+    from_account_id: uuid.UUID
+    to_account_id: uuid.UUID
+    amount: Decimal = Field(..., gt=0)
+    paid_on: date
+    received_on: date | None = None
+    notes: str | None = None
+
+
+class TransferResponse(BaseModel):
+    id: uuid.UUID
+    transfer_number: str
+    from_account_id: uuid.UUID
+    to_account_id: uuid.UUID
+    amount: Decimal
+    paid_on: date
+    received_on: date
+    journal_entry_id: uuid.UUID
+    notes: str | None
+    created_at: datetime
+
+
+def _to_response(t: InterAccountTransfer) -> TransferResponse:
+    return TransferResponse(
+        id=t.id,
+        transfer_number=t.transfer_number,
+        from_account_id=t.from_account_id,
+        to_account_id=t.to_account_id,
+        amount=Decimal(t.amount),
+        paid_on=t.paid_on,
+        received_on=t.received_on,
+        journal_entry_id=t.journal_entry_id,
+        notes=t.notes,
+        created_at=t.created_at,
+    )
+
+
+@router.get("", response_model=list[TransferResponse], summary="List inter-account transfers")
+async def list_iat(user: CurrentUser, db: DB):
+    rows = (
+        await db.execute(select(InterAccountTransfer).order_by(InterAccountTransfer.paid_on.desc()))
+    ).scalars().all()
+    return [_to_response(r) for r in rows]
+
+
+@router.post("", response_model=TransferResponse, status_code=status.HTTP_201_CREATED, summary="Create inter-account transfer")
+async def create_iat(body: TransferCreate, user: CurrentUser, db: DB):
+    try:
+        t = await create_inter_account_transfer(
+            db,
+            from_account_id=body.from_account_id,
+            to_account_id=body.to_account_id,
+            amount=body.amount,
+            paid_on=body.paid_on,
+            received_on=body.received_on,
+            notes=body.notes,
+        )
+    except InterAccountTransferError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _to_response(t)
+
+
+@router.get("/{transfer_id}", response_model=TransferResponse, summary="Get inter-account transfer detail")
+async def get_iat(transfer_id: uuid.UUID, user: CurrentUser, db: DB):
+    t = (await db.execute(select(InterAccountTransfer).where(InterAccountTransfer.id == transfer_id))).scalar_one_or_none()
+    if not t:
+        raise HTTPException(status_code=404, detail="Transfer not found")
+    return _to_response(t)
+
+
+@router.delete("/{transfer_id}", status_code=204, summary="Delete inter-account transfer (refused if either leg is reconciled)")
+async def delete_iat(transfer_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        await delete_inter_account_transfer(db, transfer_id)
+    except InterAccountTransferError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, audit, auth, banking, cameras, customers, dashboard, email, fixed_assets, insights, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, supplies, tax
+from app.api.v1.endpoints import accounting, approvals, audit, auth, banking, cameras, customers, dashboard, email, fixed_assets, insights, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -31,3 +31,4 @@ api_router.include_router(email.router)
 api_router.include_router(banking.router)
 api_router.include_router(fixed_assets.router)
 api_router.include_router(locations.router)
+api_router.include_router(inter_account_transfers.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,6 +2,7 @@ from app.models.bank_reconciliation import BankReconciliation, BankReconciliatio
 from app.models.camera import Camera  # noqa: F401
 from app.models.email_delivery import EmailDelivery  # noqa: F401
 from app.models.fixed_asset import DepreciationEntry, FixedAsset  # noqa: F401
+from app.models.inter_account_transfer import InterAccountTransfer  # noqa: F401
 from app.models.inventory_location import (  # noqa: F401
     InventoryLocation,
     InventoryTransfer,

--- a/backend/app/models/inter_account_transfer.py
+++ b/backend/app/models/inter_account_transfer.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class InterAccountTransfer(Base):
+    """A movement of money between two of the business's own bank accounts.
+    Always-posted model: a single JE with two journal lines carrying
+    independent `posted_on` dates so each leg reconciles against the
+    appropriate statement (#246).
+    """
+
+    __tablename__ = "inter_account_transfers"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    transfer_number: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    from_account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"))
+    to_account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"))
+    amount: Mapped[Decimal] = mapped_column(Numeric(14, 4))
+    paid_on: Mapped[date] = mapped_column(Date)
+    received_on: Mapped[date] = mapped_column(Date)
+    journal_entry_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("journal_entries.id"))
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/backend/app/models/journal_line.py
+++ b/backend/app/models/journal_line.py
@@ -4,7 +4,9 @@ import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
 
-from sqlalchemy import DateTime, ForeignKey, Numeric, String, Text
+from datetime import date as date_type
+
+from sqlalchemy import Date, DateTime, ForeignKey, Numeric, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
@@ -24,6 +26,10 @@ class JournalLine(Base):
     # has is_bank_account=True; ignored otherwise. Values: uncleared,
     # cleared, reconciled. See #239.
     cleared_status: Mapped[str] = mapped_column(String(15), default="uncleared", index=True)
+    # Optional per-line posted_on date. When NULL, the parent JE's
+    # entry_date is the effective date. Used by inter-account transfers
+    # (#246) where paid_on and received_on differ.
+    posted_on: Mapped[date_type | None] = mapped_column(Date, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/backend/app/services/inter_account_transfer_service.py
+++ b/backend/app/services/inter_account_transfer_service.py
@@ -1,0 +1,158 @@
+"""Inter-account transfer service (#246).
+
+Always-posted: a single JE with two journal lines carrying independent
+`posted_on` dates. Each leg reconciles against the appropriate statement
+via the bank-recon flow from #239. No Phase-2 follow-up state machine.
+
+Account pickers must satisfy `is_bank_account=True`. Same-currency only
+in Phase 1 (multi-currency is Tier 3).
+
+Edits and deletes are blocked when either leg is reconciled — uses the
+edit-lock guard from #239.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account
+from app.models.inter_account_transfer import InterAccountTransfer
+from app.models.journal_entry import JournalEntry
+from app.models.journal_line import JournalLine
+from app.services.bank_reconciliation_service import (
+    JournalLineLockedError,
+    assert_journal_line_editable,
+)
+from app.services.reference_number_service import next_number
+
+
+class InterAccountTransferError(RuntimeError):
+    pass
+
+
+async def _ensure_bank_account(db: AsyncSession, account_id: uuid.UUID) -> Account:
+    a = (await db.execute(select(Account).where(Account.id == account_id))).scalar_one_or_none()
+    if a is None:
+        raise InterAccountTransferError(f"Account {account_id} not found")
+    if not a.is_bank_account:
+        raise InterAccountTransferError(f"Account {a.code} is not a bank account")
+    return a
+
+
+async def create_inter_account_transfer(
+    db: AsyncSession,
+    *,
+    from_account_id: uuid.UUID,
+    to_account_id: uuid.UUID,
+    amount: Decimal,
+    paid_on: date,
+    received_on: date | None = None,
+    notes: str | None = None,
+) -> InterAccountTransfer:
+    if from_account_id == to_account_id:
+        raise InterAccountTransferError("from_account and to_account must differ")
+    amount = Decimal(amount)
+    if amount <= 0:
+        raise InterAccountTransferError("amount must be > 0")
+
+    from_a = await _ensure_bank_account(db, from_account_id)
+    await _ensure_bank_account(db, to_account_id)
+    if received_on is None:
+        received_on = paid_on
+
+    # Build JE manually so we can set per-line posted_on. The accounting
+    # service's create_journal_entry doesn't yet accept per-line dates;
+    # we directly add JournalEntry + JournalLine here for this scope.
+    number = await next_number(db, "inter_account_transfer")
+    earlier = min(paid_on, received_on)
+
+    # Allocate a unique JE number using the existing ad-hoc scheme.
+    # (Long term, JE numbering should also flow through #243's allocator;
+    # that's tracked in #260's accounting foundations cluster.)
+    count = (await db.execute(select(JournalEntry))).scalars().all()
+    je_number = f"JE-{earlier.year}-{len(count) + 1:04d}"
+
+    je = JournalEntry(
+        entry_number=je_number,
+        entry_date=earlier,
+        status="posted",
+        source_type="inter_account_transfer",
+        memo=f"Transfer {number}: {amount} from {from_a.code}",
+        posted_at=datetime.now(timezone.utc),
+    )
+    db.add(je)
+    await db.flush()
+
+    # Per-account signed direction: from-side credits (decrease asset),
+    # to-side debits (increase asset). Both are debit-normal accounts so
+    # this is straightforward.
+    db.add(
+        JournalLine(
+            journal_entry_id=je.id,
+            account_id=from_account_id,
+            line_number=1,
+            entry_type="credit",
+            amount=amount,
+            description=f"Transfer {number} (out)",
+            posted_on=paid_on,
+        )
+    )
+    db.add(
+        JournalLine(
+            journal_entry_id=je.id,
+            account_id=to_account_id,
+            line_number=2,
+            entry_type="debit",
+            amount=amount,
+            description=f"Transfer {number} (in)",
+            posted_on=received_on,
+        )
+    )
+
+    transfer = InterAccountTransfer(
+        transfer_number=number,
+        from_account_id=from_account_id,
+        to_account_id=to_account_id,
+        amount=amount,
+        paid_on=paid_on,
+        received_on=received_on,
+        journal_entry_id=je.id,
+        notes=notes,
+    )
+    db.add(transfer)
+    await db.flush()
+    return transfer
+
+
+async def delete_inter_account_transfer(db: AsyncSession, transfer_id: uuid.UUID) -> None:
+    t = (await db.execute(select(InterAccountTransfer).where(InterAccountTransfer.id == transfer_id))).scalar_one_or_none()
+    if t is None:
+        raise InterAccountTransferError("Transfer not found")
+
+    # Edit-lock guard: refuse if either leg is reconciled
+    lines = (
+        await db.execute(
+            select(JournalLine).where(JournalLine.journal_entry_id == t.journal_entry_id)
+        )
+    ).scalars().all()
+    for line in lines:
+        try:
+            await assert_journal_line_editable(db, line.id)
+        except JournalLineLockedError as e:
+            raise InterAccountTransferError(str(e)) from e
+
+    # Delete the JE + lines, then the transfer
+    for line in lines:
+        await db.delete(line)
+    je = (
+        await db.execute(select(JournalEntry).where(JournalEntry.id == t.journal_entry_id))
+    ).scalar_one_or_none()
+    if je is not None:
+        await db.delete(je)
+    await db.delete(t)
+    await db.flush()

--- a/backend/app/services/reference_number_service.py
+++ b/backend/app/services/reference_number_service.py
@@ -19,6 +19,7 @@ FORMATS: Final[dict[str, str]] = {
     "invoice": "INV-{year}-{value:04d}",
     "quote": "Q-{year}-{value:04d}",
     "inventory_transfer": "IT-{year}-{value:04d}",
+    "inter_account_transfer": "T-{year}-{value:04d}",
 }
 
 

--- a/backend/tests/test_inter_account_transfer_service.py
+++ b/backend/tests/test_inter_account_transfer_service.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.journal_line import JournalLine
+from app.services.bank_reconciliation_service import (
+    finalize_reconciliation,
+    include_line,
+    start_reconciliation,
+)
+from app.services.inter_account_transfer_service import (
+    InterAccountTransferError,
+    create_inter_account_transfer,
+    delete_inter_account_transfer,
+)
+
+
+async def _bank(db_session, code, name):
+    a = Account(
+        code=code,
+        name=name,
+        account_type="asset",
+        normal_balance="debit",
+        is_bank_account=True,
+        bank_account_kind="checking",
+    )
+    db_session.add(a)
+    await db_session.flush()
+    return a
+
+
+@pytest.mark.asyncio
+async def test_happy_path_same_dates(db_session):
+    src = await _bank(db_session, "1010", "Operating")
+    dst = await _bank(db_session, "1011", "Savings")
+    t = await create_inter_account_transfer(
+        db_session,
+        from_account_id=src.id,
+        to_account_id=dst.id,
+        amount=Decimal("500"),
+        paid_on=datetime.date(2026, 5, 1),
+    )
+    assert t.transfer_number.startswith("T-")
+    assert t.received_on == t.paid_on
+
+
+@pytest.mark.asyncio
+async def test_per_line_dates_differ(db_session):
+    src = await _bank(db_session, "1010", "Operating")
+    dst = await _bank(db_session, "1011", "Savings")
+    await create_inter_account_transfer(
+        db_session,
+        from_account_id=src.id,
+        to_account_id=dst.id,
+        amount=Decimal("250"),
+        paid_on=datetime.date(2026, 5, 1),
+        received_on=datetime.date(2026, 5, 3),
+    )
+    lines = (await db_session.execute(select(JournalLine).order_by(JournalLine.line_number))).scalars().all()
+    assert len(lines) == 2
+    assert lines[0].posted_on == datetime.date(2026, 5, 1)
+    assert lines[1].posted_on == datetime.date(2026, 5, 3)
+    assert lines[0].entry_type == "credit"
+    assert lines[1].entry_type == "debit"
+
+
+@pytest.mark.asyncio
+async def test_same_account_rejected(db_session):
+    src = await _bank(db_session, "1010", "Operating")
+    with pytest.raises(InterAccountTransferError):
+        await create_inter_account_transfer(
+            db_session,
+            from_account_id=src.id,
+            to_account_id=src.id,
+            amount=Decimal("100"),
+            paid_on=datetime.date(2026, 5, 1),
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_bank_account_rejected(db_session):
+    src = await _bank(db_session, "1010", "Operating")
+    not_bank = Account(code="9999", name="Not bank", account_type="asset", normal_balance="debit", is_bank_account=False)
+    db_session.add(not_bank)
+    await db_session.flush()
+    with pytest.raises(InterAccountTransferError):
+        await create_inter_account_transfer(
+            db_session,
+            from_account_id=src.id,
+            to_account_id=not_bank.id,
+            amount=Decimal("100"),
+            paid_on=datetime.date(2026, 5, 1),
+        )
+
+
+@pytest.mark.asyncio
+async def test_zero_amount_rejected(db_session):
+    src = await _bank(db_session, "1010", "Operating")
+    dst = await _bank(db_session, "1011", "Savings")
+    with pytest.raises(InterAccountTransferError):
+        await create_inter_account_transfer(
+            db_session,
+            from_account_id=src.id,
+            to_account_id=dst.id,
+            amount=Decimal("0"),
+            paid_on=datetime.date(2026, 5, 1),
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_unreconciled(db_session):
+    src = await _bank(db_session, "1010", "Operating")
+    dst = await _bank(db_session, "1011", "Savings")
+    t = await create_inter_account_transfer(
+        db_session,
+        from_account_id=src.id,
+        to_account_id=dst.id,
+        amount=Decimal("100"),
+        paid_on=datetime.date(2026, 5, 1),
+    )
+    await delete_inter_account_transfer(db_session, t.id)
+
+
+@pytest.mark.asyncio
+async def test_delete_blocked_when_leg_reconciled(db_session):
+    src = await _bank(db_session, "1010", "Operating")
+    dst = await _bank(db_session, "1011", "Savings")
+    t = await create_inter_account_transfer(
+        db_session,
+        from_account_id=src.id,
+        to_account_id=dst.id,
+        amount=Decimal("100"),
+        paid_on=datetime.date(2026, 5, 1),
+    )
+    # Reconcile the from-side leg
+    lines = (await db_session.execute(select(JournalLine).where(JournalLine.account_id == src.id))).scalars().all()
+    line = lines[0]
+
+    recon = await start_reconciliation(
+        db_session,
+        account_id=src.id,
+        statement_end_date=datetime.date(2026, 5, 31),
+        statement_ending_balance=Decimal("-100"),
+    )
+    await include_line(db_session, reconciliation_id=recon.id, journal_line_id=line.id)
+    await finalize_reconciliation(db_session, reconciliation_id=recon.id, finalized_by_user_id=None)
+
+    with pytest.raises(InterAccountTransferError):
+        await delete_inter_account_transfer(db_session, t.id)

--- a/docs/inter_account_transfers.md
+++ b/docs/inter_account_transfers.md
@@ -1,0 +1,36 @@
+# Inter-Account Transfers
+
+Operators move money between two of the business's own bank accounts (checking → savings, Stripe payout → operating, etc.) as a first-class document instead of a manual journal entry. #246.
+
+## Model
+
+- **`InterAccountTransfer`** carries `from_account_id`, `to_account_id`, `amount`, `paid_on`, `received_on` (defaults to `paid_on`), and the resulting `journal_entry_id` for audit.
+- **Always-posted**: a single JE with two journal lines is written on create. Each line carries an independent `posted_on` so each leg reconciles against the appropriate statement.
+- **Same-currency only** in Phase 1.
+- **Account pickers** restricted to `is_bank_account=True` (#239's typing).
+- **`transfer_number`** allocator scope `inter_account_transfer` with format `T-{year}-{value:04d}`.
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `GET` | `/api/v1/banking/inter-account-transfers` | List, newest paid_on first. |
+| `POST` | `/api/v1/banking/inter-account-transfers` | Create. Body: `from_account_id`, `to_account_id`, `amount`, `paid_on`, optional `received_on`, `notes`. |
+| `GET` | `/api/v1/banking/inter-account-transfers/{id}` | Detail. |
+| `DELETE` | `/api/v1/banking/inter-account-transfers/{id}` | Refused if either leg is reconciled. Voids the JE. |
+
+## Edit lock
+
+Delete fails when either leg's underlying journal line has `cleared_status='reconciled'` — uses the `assert_journal_line_editable` guard from #239. Reopen the relevant bank reconciliation first.
+
+## Phase 2 follow-ups
+
+- **Edit endpoint** (currently delete-and-recreate is the only path).
+- **Cross-currency transfers** (depends on multi-currency Phase 1).
+- **Auto-create from bank import** — add `create_inter_account_transfer` action to the rule registry from #241 once that lands.
+- **Recurring transfers** (depends on the recurring-engine pattern in #247).
+- **Frontend** — no banking UI exists yet.
+
+## JE numbering note
+
+Inter-account transfer JEs use the existing ad-hoc count-based JE numbering. Migrating JE numbering to the central allocator is part of #260's accounting-foundations cluster.


### PR DESCRIPTION
Closes #246. Always-posted JE with per-line posted_on dates so each leg reconciles independently. Edit-lock via #239 guard. 334 tests pass (327 + 7 new). Phase 2: edit endpoint, multi-currency, auto-create from bank import (paired with #241), recurring, frontend.