### PR TITLE
feat(invoices): recurring sales invoices Phase 1 (#247)

### DIFF
--- a/backend/alembic/versions/20260509_08_add_recurring_invoices.py
+++ b/backend/alembic/versions/20260509_08_add_recurring_invoices.py
@@ -1,0 +1,78 @@
+"""add recurring_invoices and recurring_invoice_runs (#247)
+
+Revision ID: 20260509_08
+Revises: 20260509_07
+Create Date: 2026-05-09 23:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_08"
+down_revision = "20260509_07"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "recurring_invoices",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("customer_id", sa.UUID(), nullable=False),
+        sa.Column("cadence", sa.String(length=20), nullable=False, server_default="monthly"),
+        sa.Column("interval_count", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("start_on", sa.Date(), nullable=False),
+        sa.Column("next_run_on", sa.Date(), nullable=False),
+        sa.Column("last_run_on", sa.Date(), nullable=True),
+        sa.Column("end_on", sa.Date(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("auto_email", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("line_items_template", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("due_in_days", sa.Integer(), nullable=False, server_default="30"),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("last_failed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["customer_id"], ["customers.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_recurring_invoices_name", "recurring_invoices", ["name"])
+    op.create_index("ix_recurring_invoices_customer_id", "recurring_invoices", ["customer_id"])
+    op.create_index("ix_recurring_invoices_next_run_on", "recurring_invoices", ["next_run_on"])
+    op.create_index("ix_recurring_invoices_is_active", "recurring_invoices", ["is_active"])
+
+    op.create_table(
+        "recurring_invoice_runs",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("recurring_invoice_id", sa.UUID(), nullable=False),
+        sa.Column("run_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("target_date", sa.Date(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("generated_invoice_id", sa.UUID(), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("triggered_by", sa.String(length=20), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["recurring_invoice_id"], ["recurring_invoices.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["generated_invoice_id"], ["invoices.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_recurring_invoice_runs_recurring_invoice_id",
+        "recurring_invoice_runs",
+        ["recurring_invoice_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_recurring_invoice_runs_recurring_invoice_id", table_name="recurring_invoice_runs")
+    op.drop_table("recurring_invoice_runs")
+    op.drop_index("ix_recurring_invoices_is_active", table_name="recurring_invoices")
+    op.drop_index("ix_recurring_invoices_next_run_on", table_name="recurring_invoices")
+    op.drop_index("ix_recurring_invoices_customer_id", table_name="recurring_invoices")
+    op.drop_index("ix_recurring_invoices_name", table_name="recurring_invoices")
+    op.drop_table("recurring_invoices")

--- a/backend/app/api/v1/endpoints/recurring_invoices.py
+++ b/backend/app/api/v1/endpoints/recurring_invoices.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.recurring_invoice import RecurringInvoice, RecurringInvoiceRun
+from app.services.recurring_invoice_service import (
+    RecurringInvoiceError,
+    run_due,
+    run_one,
+    skip_next,
+)
+
+
+router = APIRouter(prefix="/recurring-invoices", tags=["RecurringInvoices"])
+
+
+class TemplateLine(BaseModel):
+    description: str
+    quantity: int = Field(..., gt=0)
+    unit_price: Decimal = Field(..., ge=0)
+    notes: str | None = None
+
+
+class RecurringInvoiceCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=200)
+    customer_id: uuid.UUID
+    cadence: Literal["daily", "weekly", "monthly", "yearly"] = "monthly"
+    interval_count: int = Field(1, gt=0)
+    start_on: date
+    end_on: date | None = None
+    auto_email: bool = False
+    line_items_template: list[TemplateLine] = Field(..., min_length=1)
+    due_in_days: int = Field(30, gt=0)
+    notes: str | None = None
+
+
+class RecurringInvoiceUpdate(BaseModel):
+    name: str | None = None
+    cadence: Literal["daily", "weekly", "monthly", "yearly"] | None = None
+    interval_count: int | None = Field(None, gt=0)
+    end_on: date | None = None
+    is_active: bool | None = None
+    auto_email: bool | None = None
+    line_items_template: list[TemplateLine] | None = None
+    due_in_days: int | None = Field(None, gt=0)
+    notes: str | None = None
+
+
+class RecurringInvoiceResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    customer_id: uuid.UUID
+    cadence: str
+    interval_count: int
+    start_on: date
+    next_run_on: date
+    last_run_on: date | None
+    end_on: date | None
+    is_active: bool
+    auto_email: bool
+    line_items_template: list[dict]
+    due_in_days: int
+    notes: str | None
+    last_error: str | None
+    last_failed_at: datetime | None
+
+
+class RunResponse(BaseModel):
+    id: uuid.UUID
+    target_date: date
+    status: str
+    generated_invoice_id: uuid.UUID | None
+    error: str | None
+    triggered_by: str
+    run_at: datetime
+
+
+def _to_response(r: RecurringInvoice) -> RecurringInvoiceResponse:
+    return RecurringInvoiceResponse(
+        id=r.id,
+        name=r.name,
+        customer_id=r.customer_id,
+        cadence=r.cadence,
+        interval_count=r.interval_count,
+        start_on=r.start_on,
+        next_run_on=r.next_run_on,
+        last_run_on=r.last_run_on,
+        end_on=r.end_on,
+        is_active=r.is_active,
+        auto_email=r.auto_email,
+        line_items_template=list(r.line_items_template or []),
+        due_in_days=r.due_in_days,
+        notes=r.notes,
+        last_error=r.last_error,
+        last_failed_at=r.last_failed_at,
+    )
+
+
+def _to_run_response(run: RecurringInvoiceRun) -> RunResponse:
+    return RunResponse(
+        id=run.id,
+        target_date=run.target_date,
+        status=run.status,
+        generated_invoice_id=run.generated_invoice_id,
+        error=run.error,
+        triggered_by=run.triggered_by,
+        run_at=run.run_at,
+    )
+
+
+@router.get("", response_model=list[RecurringInvoiceResponse], summary="List recurring invoices")
+async def list_recurring(user: CurrentUser, db: DB, active_only: bool = False):
+    stmt = select(RecurringInvoice).order_by(RecurringInvoice.next_run_on)
+    if active_only:
+        stmt = stmt.where(RecurringInvoice.is_active == True)  # noqa: E712
+    rows = (await db.execute(stmt)).scalars().all()
+    return [_to_response(r) for r in rows]
+
+
+@router.post("", response_model=RecurringInvoiceResponse, status_code=status.HTTP_201_CREATED, summary="Create a recurring invoice rule")
+async def create_recurring(body: RecurringInvoiceCreate, user: CurrentUser, db: DB):
+    r = RecurringInvoice(
+        name=body.name,
+        customer_id=body.customer_id,
+        cadence=body.cadence,
+        interval_count=body.interval_count,
+        start_on=body.start_on,
+        next_run_on=body.start_on,
+        end_on=body.end_on,
+        auto_email=body.auto_email,
+        line_items_template=[l.model_dump(mode="json") for l in body.line_items_template],
+        due_in_days=body.due_in_days,
+        notes=body.notes,
+    )
+    db.add(r)
+    await db.commit()
+    return _to_response(r)
+
+
+@router.get("/{recurring_id}", response_model=RecurringInvoiceResponse, summary="Get recurring invoice")
+async def get_recurring(recurring_id: uuid.UUID, user: CurrentUser, db: DB):
+    r = (await db.execute(select(RecurringInvoice).where(RecurringInvoice.id == recurring_id))).scalar_one_or_none()
+    if not r:
+        raise HTTPException(status_code=404, detail="Recurring invoice not found")
+    return _to_response(r)
+
+
+@router.patch("/{recurring_id}", response_model=RecurringInvoiceResponse, summary="Update a recurring invoice")
+async def update_recurring(recurring_id: uuid.UUID, body: RecurringInvoiceUpdate, user: CurrentUser, db: DB):
+    r = (await db.execute(select(RecurringInvoice).where(RecurringInvoice.id == recurring_id))).scalar_one_or_none()
+    if not r:
+        raise HTTPException(status_code=404, detail="Recurring invoice not found")
+    payload = body.model_dump(exclude_unset=True)
+    if "line_items_template" in payload and payload["line_items_template"] is not None:
+        payload["line_items_template"] = [l for l in payload["line_items_template"]]
+    for k, v in payload.items():
+        setattr(r, k, v)
+    await db.commit()
+    return _to_response(r)
+
+
+@router.delete("/{recurring_id}", status_code=204, summary="Delete a recurring invoice")
+async def delete_recurring(recurring_id: uuid.UUID, user: CurrentUser, db: DB):
+    r = (await db.execute(select(RecurringInvoice).where(RecurringInvoice.id == recurring_id))).scalar_one_or_none()
+    if not r:
+        raise HTTPException(status_code=404, detail="Recurring invoice not found")
+    await db.delete(r)
+    await db.commit()
+
+
+@router.post("/{recurring_id}/run-now", response_model=RunResponse, summary="Generate one invoice immediately and advance the schedule")
+async def run_now_ep(recurring_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        run = await run_one(db, recurring_id=recurring_id, triggered_by="manual_run_now")
+    except RecurringInvoiceError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _to_run_response(run)
+
+
+@router.post("/{recurring_id}/skip-next", response_model=RunResponse, summary="Advance the schedule without generating an invoice")
+async def skip_ep(recurring_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        run = await skip_next(db, recurring_id)
+    except RecurringInvoiceError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _to_run_response(run)
+
+
+@router.post("/run-due", summary="Cron entry point — generate due invoices and advance schedules")
+async def run_due_ep(user: CurrentUser, db: DB):
+    summary = await run_due(db)
+    await db.commit()
+    return summary
+
+
+@router.get("/{recurring_id}/runs", response_model=list[RunResponse], summary="Run history for a recurring invoice")
+async def list_runs(recurring_id: uuid.UUID, user: CurrentUser, db: DB):
+    rows = (
+        await db.execute(
+            select(RecurringInvoiceRun)
+            .where(RecurringInvoiceRun.recurring_invoice_id == recurring_id)
+            .order_by(RecurringInvoiceRun.run_at.desc())
+        )
+    ).scalars().all()
+    return [_to_run_response(r) for r in rows]

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, attachments, audit, auth, banking, cameras, customers, dashboard, email, fixed_assets, insights, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, reports, sales, sales_channels, settlements, settings, supplies, tax
+from app.api.v1.endpoints import accounting, approvals, attachments, audit, auth, banking, cameras, customers, dashboard, email, fixed_assets, insights, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -33,3 +33,4 @@ api_router.include_router(fixed_assets.router)
 api_router.include_router(locations.router)
 api_router.include_router(inter_account_transfers.router)
 api_router.include_router(attachments.router)
+api_router.include_router(recurring_invoices.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -10,5 +10,6 @@ from app.models.inventory_location import (  # noqa: F401
     InventoryTransferLine,
 )
 from app.models.product_bom_item import ProductBOMItem  # noqa: F401
+from app.models.recurring_invoice import RecurringInvoice, RecurringInvoiceRun  # noqa: F401
 from app.models.reference_sequence import ReferenceSequence  # noqa: F401
 from app.models.supply import Supply  # noqa: F401

--- a/backend/app/models/recurring_invoice.py
+++ b/backend/app/models/recurring_invoice.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class RecurringInvoice(Base):
+    """A scheduled rule that auto-generates a sales invoice on a cadence
+    (#247). Mirrors the cron-driven RecurringExpense pattern but on the
+    AR side.
+    """
+
+    __tablename__ = "recurring_invoices"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(200), index=True)
+    customer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("customers.id"), index=True)
+    cadence: Mapped[str] = mapped_column(String(20), default="monthly")
+    interval_count: Mapped[int] = mapped_column(Integer, default=1)
+    start_on: Mapped[date] = mapped_column(Date)
+    next_run_on: Mapped[date] = mapped_column(Date, index=True)
+    last_run_on: Mapped[date | None] = mapped_column(Date, nullable=True)
+    end_on: Mapped[date | None] = mapped_column(Date, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    auto_email: Mapped[bool] = mapped_column(Boolean, default=False)
+    line_items_template: Mapped[list] = mapped_column(JSON, default=list)
+    due_in_days: Mapped[int] = mapped_column(Integer, default=30)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_failed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    runs = relationship("RecurringInvoiceRun", back_populates="recurring_invoice", cascade="all, delete-orphan")
+
+
+class RecurringInvoiceRun(Base):
+    """Audit row for each cron / manual run of a RecurringInvoice."""
+
+    __tablename__ = "recurring_invoice_runs"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    recurring_invoice_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("recurring_invoices.id", ondelete="CASCADE"), index=True
+    )
+    run_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    target_date: Mapped[date] = mapped_column(Date)
+    status: Mapped[str] = mapped_column(String(20))  # succeeded | failed | skipped
+    generated_invoice_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("invoices.id"), nullable=True
+    )
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    triggered_by: Mapped[str] = mapped_column(String(20))  # cron | manual_run_now | manual_skip
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    recurring_invoice = relationship("RecurringInvoice", back_populates="runs")

--- a/backend/app/services/recurring_invoice_service.py
+++ b/backend/app/services/recurring_invoice_service.py
@@ -1,0 +1,215 @@
+"""Recurring sales invoice service (#247).
+
+Cron-driven (external n8n calls /run-due daily). Snapshot pricing:
+each generated invoice copies `line_items_template` verbatim. On
+generation failure the schedule does NOT advance, surfacing the error
+on the recurring-invoice row until the operator fixes the underlying
+issue and clicks Run-Now.
+"""
+
+from __future__ import annotations
+
+import calendar
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invoice import Invoice
+from app.models.invoice_line import InvoiceLine
+from app.models.recurring_invoice import RecurringInvoice, RecurringInvoiceRun
+from app.services.reference_number_service import next_number
+
+
+class RecurringInvoiceError(RuntimeError):
+    pass
+
+
+def _last_day_of_month(d: date) -> date:
+    return date(d.year, d.month, calendar.monthrange(d.year, d.month)[1])
+
+
+def advance_date(d: date, cadence: str, interval_count: int) -> date:
+    """Compute next-run date per cadence math.
+
+    monthly + N: add N months, preserving day-of-month with month-end fallback.
+    yearly + N: add N years, with Feb 29 → Feb 28 in non-leap years.
+    weekly + N: add N*7 days.
+    daily + N: add N days.
+    """
+    if cadence == "daily":
+        from datetime import timedelta
+        return d + timedelta(days=interval_count)
+    if cadence == "weekly":
+        from datetime import timedelta
+        return d + timedelta(weeks=interval_count)
+    if cadence == "monthly":
+        total = d.year * 12 + (d.month - 1) + interval_count
+        y, m = divmod(total, 12)
+        last = calendar.monthrange(y, m + 1)[1]
+        return date(y, m + 1, min(d.day, last))
+    if cadence == "yearly":
+        target_year = d.year + interval_count
+        last = calendar.monthrange(target_year, d.month)[1]
+        return date(target_year, d.month, min(d.day, last))
+    raise RecurringInvoiceError(f"Unknown cadence: {cadence}")
+
+
+async def run_one(
+    db: AsyncSession,
+    *,
+    recurring_id: uuid.UUID,
+    triggered_by: str = "manual_run_now",
+) -> RecurringInvoiceRun:
+    """Generate one invoice for the given recurring rule and advance the
+    schedule on success. Persist a `RecurringInvoiceRun` audit row.
+    """
+    ri = (await db.execute(select(RecurringInvoice).where(RecurringInvoice.id == recurring_id))).scalar_one_or_none()
+    if ri is None:
+        raise RecurringInvoiceError("Recurring invoice not found")
+    if not ri.is_active:
+        raise RecurringInvoiceError("Recurring invoice is paused")
+
+    target_date = ri.next_run_on
+    try:
+        invoice = await _generate_invoice(db, ri, target_date)
+    except Exception as e:  # noqa: BLE001
+        ri.last_error = f"{type(e).__name__}: {e}"
+        ri.last_failed_at = datetime.now(timezone.utc)
+        run = RecurringInvoiceRun(
+            recurring_invoice_id=ri.id,
+            target_date=target_date,
+            status="failed",
+            error=ri.last_error,
+            triggered_by=triggered_by,
+        )
+        db.add(run)
+        await db.flush()
+        return run
+
+    next_due = advance_date(target_date, ri.cadence, ri.interval_count)
+    ri.last_run_on = target_date
+    ri.next_run_on = next_due
+    ri.last_error = None
+    ri.last_failed_at = None
+    if ri.end_on is not None and next_due > ri.end_on:
+        ri.is_active = False
+
+    run = RecurringInvoiceRun(
+        recurring_invoice_id=ri.id,
+        target_date=target_date,
+        status="succeeded",
+        generated_invoice_id=invoice.id,
+        triggered_by=triggered_by,
+    )
+    db.add(run)
+    await db.flush()
+    return run
+
+
+async def skip_next(db: AsyncSession, recurring_id: uuid.UUID) -> RecurringInvoiceRun:
+    ri = (await db.execute(select(RecurringInvoice).where(RecurringInvoice.id == recurring_id))).scalar_one_or_none()
+    if ri is None:
+        raise RecurringInvoiceError("Recurring invoice not found")
+    target_date = ri.next_run_on
+    next_due = advance_date(target_date, ri.cadence, ri.interval_count)
+    ri.last_run_on = target_date
+    ri.next_run_on = next_due
+    if ri.end_on is not None and next_due > ri.end_on:
+        ri.is_active = False
+    run = RecurringInvoiceRun(
+        recurring_invoice_id=ri.id,
+        target_date=target_date,
+        status="skipped",
+        triggered_by="manual_skip",
+    )
+    db.add(run)
+    await db.flush()
+    return run
+
+
+async def run_due(db: AsyncSession, *, today: date | None = None) -> dict:
+    """Cron entry point. Generates invoices for every active rule whose
+    `next_run_on` has come due. Idempotent within a day on success: a
+    second call finds nothing further due. Failures stay due so the next
+    cron tick retries.
+    """
+    today = today or datetime.now(timezone.utc).date()
+    rules = (
+        await db.execute(
+            select(RecurringInvoice).where(
+                RecurringInvoice.is_active == True,  # noqa: E712
+                RecurringInvoice.next_run_on <= today,
+            )
+        )
+    ).scalars().all()
+
+    succeeded = 0
+    failed = 0
+    for r in rules:
+        run = await run_one(db, recurring_id=r.id, triggered_by="cron")
+        if run.status == "succeeded":
+            succeeded += 1
+        else:
+            failed += 1
+    return {"succeeded": succeeded, "failed": failed, "considered": len(rules)}
+
+
+async def _generate_invoice(
+    db: AsyncSession, ri: RecurringInvoice, issue_date: date
+) -> Invoice:
+    """Build a real Invoice from the recurring template."""
+    from datetime import timedelta
+
+    template_lines = list(ri.line_items_template or [])
+    if not template_lines:
+        raise RecurringInvoiceError("Template has no line items")
+
+    invoice_number = await next_number(db, "invoice")
+    due_date = issue_date + timedelta(days=int(ri.due_in_days or 30))
+
+    # Pre-compute totals so we don't depend on the post-flush invoice
+    # service helpers.
+    subtotal = Decimal("0")
+    for line in template_lines:
+        qty = Decimal(str(line.get("quantity", 0)))
+        price = Decimal(str(line.get("unit_price", 0)))
+        subtotal += qty * price
+    subtotal = subtotal.quantize(Decimal("0.01"))
+    total_due = subtotal  # tax/shipping deferred to manual edit
+
+    invoice = Invoice(
+        invoice_number=invoice_number,
+        customer_id=ri.customer_id,
+        issue_date=issue_date,
+        due_date=due_date,
+        subtotal=subtotal,
+        tax_amount=Decimal("0"),
+        shipping_amount=Decimal("0"),
+        credits_applied=Decimal("0"),
+        total_due=total_due,
+        amount_paid=Decimal("0"),
+        balance_due=total_due,
+        notes=ri.notes,
+        status="draft",
+    )
+    db.add(invoice)
+    await db.flush()
+
+    for line in template_lines:
+        qty_int = int(line.get("quantity", 0))
+        price = Decimal(str(line.get("unit_price", 0)))
+        db.add(
+            InvoiceLine(
+                invoice_id=invoice.id,
+                description=line.get("description", ""),
+                quantity=qty_int,
+                unit_price=price,
+                line_total=Decimal(qty_int) * price,
+                notes=line.get("notes"),
+            )
+        )
+    await db.flush()
+    return invoice

--- a/backend/tests/test_recurring_invoice_service.py
+++ b/backend/tests/test_recurring_invoice_service.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.customer import Customer
+from app.models.invoice import Invoice
+from app.models.recurring_invoice import RecurringInvoice, RecurringInvoiceRun
+from app.services.recurring_invoice_service import (
+    RecurringInvoiceError,
+    advance_date,
+    run_due,
+    run_one,
+    skip_next,
+)
+
+
+async def _customer(db_session, name="Acme") -> Customer:
+    c = Customer(name=name, email="customer@example.com")
+    db_session.add(c)
+    await db_session.flush()
+    return c
+
+
+async def _rule(
+    db_session,
+    customer_id,
+    *,
+    cadence="monthly",
+    interval=1,
+    start=datetime.date(2026, 1, 15),
+    end=None,
+):
+    r = RecurringInvoice(
+        name="Monthly retainer",
+        customer_id=customer_id,
+        cadence=cadence,
+        interval_count=interval,
+        start_on=start,
+        next_run_on=start,
+        end_on=end,
+        line_items_template=[
+            {"description": "Retainer", "quantity": 1, "unit_price": "100.00"},
+        ],
+        due_in_days=30,
+    )
+    db_session.add(r)
+    await db_session.flush()
+    return r
+
+
+def test_advance_date_monthly():
+    assert advance_date(datetime.date(2026, 1, 15), "monthly", 1) == datetime.date(2026, 2, 15)
+    # End-of-month wrap: Jan 31 → Feb 28 (non-leap) but 2028 is leap
+    assert advance_date(datetime.date(2026, 1, 31), "monthly", 1) == datetime.date(2026, 2, 28)
+    assert advance_date(datetime.date(2026, 1, 31), "monthly", 13) == datetime.date(2027, 2, 28)
+
+
+def test_advance_date_weekly():
+    assert advance_date(datetime.date(2026, 1, 1), "weekly", 1) == datetime.date(2026, 1, 8)
+    assert advance_date(datetime.date(2026, 1, 1), "weekly", 4) == datetime.date(2026, 1, 29)
+
+
+def test_advance_date_daily():
+    assert advance_date(datetime.date(2026, 1, 1), "daily", 7) == datetime.date(2026, 1, 8)
+
+
+def test_advance_date_yearly_leap_handling():
+    # Feb 29 (in 2024 leap year) → Feb 28 next year
+    assert advance_date(datetime.date(2024, 2, 29), "yearly", 1) == datetime.date(2025, 2, 28)
+    # Feb 29 → Feb 29 next leap year
+    assert advance_date(datetime.date(2024, 2, 29), "yearly", 4) == datetime.date(2028, 2, 29)
+
+
+def test_advance_date_unknown_cadence():
+    with pytest.raises(RecurringInvoiceError):
+        advance_date(datetime.date(2026, 1, 1), "biweekly", 1)
+
+
+@pytest.mark.asyncio
+async def test_run_one_generates_invoice_and_advances(db_session):
+    c = await _customer(db_session)
+    r = await _rule(db_session, c.id)
+
+    run = await run_one(db_session, recurring_id=r.id)
+    assert run.status == "succeeded"
+    assert run.generated_invoice_id is not None
+
+    refreshed = (await db_session.execute(select(RecurringInvoice).where(RecurringInvoice.id == r.id))).scalar_one()
+    assert refreshed.last_run_on == datetime.date(2026, 1, 15)
+    assert refreshed.next_run_on == datetime.date(2026, 2, 15)
+
+    # The invoice exists
+    invoice = (await db_session.execute(select(Invoice).where(Invoice.id == run.generated_invoice_id))).scalar_one()
+    assert invoice.subtotal == Decimal("100.00")
+    assert invoice.total_due == Decimal("100.00")
+    assert invoice.invoice_number.startswith("INV-")
+
+
+@pytest.mark.asyncio
+async def test_skip_next_advances_without_invoice(db_session):
+    c = await _customer(db_session)
+    r = await _rule(db_session, c.id)
+    run = await skip_next(db_session, r.id)
+    assert run.status == "skipped"
+    assert run.generated_invoice_id is None
+    refreshed = (await db_session.execute(select(RecurringInvoice).where(RecurringInvoice.id == r.id))).scalar_one()
+    assert refreshed.next_run_on == datetime.date(2026, 2, 15)
+
+
+@pytest.mark.asyncio
+async def test_paused_rule_run_one_rejected(db_session):
+    c = await _customer(db_session)
+    r = await _rule(db_session, c.id)
+    r.is_active = False
+    await db_session.flush()
+    with pytest.raises(RecurringInvoiceError):
+        await run_one(db_session, recurring_id=r.id)
+
+
+@pytest.mark.asyncio
+async def test_failure_does_not_advance(db_session):
+    c = await _customer(db_session)
+    r = await _rule(db_session, c.id)
+    # Wipe template so generation raises
+    r.line_items_template = []
+    await db_session.flush()
+
+    run = await run_one(db_session, recurring_id=r.id)
+    assert run.status == "failed"
+    refreshed = (await db_session.execute(select(RecurringInvoice).where(RecurringInvoice.id == r.id))).scalar_one()
+    # next_run_on unchanged
+    assert refreshed.next_run_on == datetime.date(2026, 1, 15)
+    assert refreshed.last_error is not None
+
+
+@pytest.mark.asyncio
+async def test_end_on_auto_deactivates(db_session):
+    c = await _customer(db_session)
+    r = await _rule(
+        db_session, c.id,
+        start=datetime.date(2026, 1, 15),
+        end=datetime.date(2026, 2, 1),
+    )
+    run = await run_one(db_session, recurring_id=r.id)
+    assert run.status == "succeeded"
+    refreshed = (await db_session.execute(select(RecurringInvoice).where(RecurringInvoice.id == r.id))).scalar_one()
+    # next_run_on (2026-02-15) > end_on → auto-deactivated
+    assert refreshed.is_active is False
+
+
+@pytest.mark.asyncio
+async def test_run_due_picks_up_due_rules(db_session):
+    c = await _customer(db_session)
+    # Two due, one not yet due
+    await _rule(db_session, c.id, start=datetime.date(2026, 1, 1))
+    await _rule(db_session, c.id, start=datetime.date(2026, 1, 10))
+    await _rule(db_session, c.id, start=datetime.date(2026, 6, 1))  # future
+    summary = await run_due(db_session, today=datetime.date(2026, 1, 31))
+    assert summary["considered"] == 2
+    assert summary["succeeded"] == 2
+    assert summary["failed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_due_idempotent_within_day(db_session):
+    c = await _customer(db_session)
+    await _rule(db_session, c.id, start=datetime.date(2026, 1, 15))
+    s1 = await run_due(db_session, today=datetime.date(2026, 1, 15))
+    s2 = await run_due(db_session, today=datetime.date(2026, 1, 15))
+    assert s1["succeeded"] == 1
+    assert s2["considered"] == 0

--- a/docs/recurring_invoices.md
+++ b/docs/recurring_invoices.md
@@ -1,0 +1,51 @@
+# Recurring Sales Invoices
+
+Operators schedule a sales invoice to auto-generate on a cadence — monthly retainer, weekly consignment statement, quarterly maintenance contract, etc. Cron-driven via the same n8n pattern used elsewhere. #247.
+
+## Model
+
+- **`RecurringInvoice`** — the rule. Carries customer, cadence, snapshot `line_items_template` (JSONB), `next_run_on`, optional `end_on`, audit fields (`last_error`, `last_failed_at`).
+- **`RecurringInvoiceRun`** — one row per cron / manual run, linking the generated invoice (or recording the failure / skip).
+
+## Cadence math
+
+| Cadence | Behavior |
+|---|---|
+| `daily` + `interval_count=N` | add N days |
+| `weekly` + `interval_count=N` | add N×7 days |
+| `monthly` + `interval_count=N` | add N months, preserving day-of-month with month-end clamp (Jan 31 → Feb 28/29) |
+| `yearly` + `interval_count=N` | add N years, with Feb 29 → Feb 28 in non-leap years |
+
+## Lifecycle
+
+- `start_on` is the first scheduled run; `next_run_on` defaults to it on create.
+- `run_one` succeeds → invoice created (using #243's allocator for the number) → schedule advances. Fails → schedule does **not** advance, `last_error` is recorded.
+- `skip_next` advances without generating an invoice.
+- `run_due` (cron) picks up every active rule with `next_run_on <= today` and runs each. **Idempotent within a day** on success: a second call finds nothing further due.
+- When `next_run_on > end_on` after an advance, `is_active` flips false automatically.
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `GET` | `/api/v1/recurring-invoices` | Filter `?active_only=true`. |
+| `POST` | `/api/v1/recurring-invoices` | Create. |
+| `GET` | `/api/v1/recurring-invoices/{id}` | Detail. |
+| `PATCH` | `/api/v1/recurring-invoices/{id}` | Edit (template + cadence + state). |
+| `DELETE` | `/api/v1/recurring-invoices/{id}` | Hard delete. |
+| `POST` | `/api/v1/recurring-invoices/{id}/run-now` | Generate one immediately. |
+| `POST` | `/api/v1/recurring-invoices/{id}/skip-next` | Advance without generating. |
+| `POST` | `/api/v1/recurring-invoices/run-due` | Cron entry point. |
+| `GET` | `/api/v1/recurring-invoices/{id}/runs` | Run history. |
+
+## Cron wiring (operator runbook)
+
+Set up a daily n8n workflow (mirror of `ops/n8n/web01-deploy.json`'s pattern) that POSTs to `https://web01.bengtson.local/api/v1/recurring-invoices/run-due` with the operator's service-account bearer token. Run early-morning UTC. The endpoint is idempotent within a day.
+
+## Phase 2 follow-ups
+
+- **Auto-email integration** with #244 — toggle is wired but the actual email send is a no-op until a Phase 2 follow-up turns the `auto_email=true` path into a `send_email` call. WeasyPrint PDF for invoice attachment is needed first.
+- **Per-line "use latest price"** toggle. Phase 1 is snapshot-only.
+- **Frontend** — no recurring-invoices UI yet; rule management is API-only today.
+- **n8n workflow JSON** — `ops/n8n/recurring-invoices-daily.json` deferred until the cron is actually wired up by the operator.
+- **Tax / shipping** in the template (currently zero in v1).


### PR DESCRIPTION
Closes #247. Cron-driven via `/run-due`, snapshot pricing, future-only template propagation, failure-no-advance. Auto-email + frontend deferred. 360 tests pass (348 + 12 new). Doc: `docs/recurring_invoices.md`.