### PR TITLE
feat(expenses): expense claims for owner-paid reimbursable expenses (#251)

### DIFF
--- a/backend/alembic/versions/20260509_09_add_expense_claims.py
+++ b/backend/alembic/versions/20260509_09_add_expense_claims.py
@@ -1,0 +1,80 @@
+"""add expense_claims and Owner Reimbursable Liability seed (#251)
+
+Revision ID: 20260509_09
+Revises: 20260509_08
+Create Date: 2026-05-09 23:30:00
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_09"
+down_revision = "20260509_08"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "expense_claims",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("claim_number", sa.String(length=50), nullable=False),
+        sa.Column("payer_kind", sa.String(length=30), nullable=False, server_default="owner"),
+        sa.Column("payer_name", sa.String(length=200), nullable=False),
+        sa.Column("submitted_on", sa.Date(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="draft"),
+        sa.Column("total_amount", sa.Numeric(12, 2), nullable=False, server_default="0"),
+        sa.Column("journal_entry_id", sa.UUID(), nullable=True),
+        sa.Column("reimbursement_journal_entry_id", sa.UUID(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["journal_entry_id"], ["journal_entries.id"]),
+        sa.ForeignKeyConstraint(["reimbursement_journal_entry_id"], ["journal_entries.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("claim_number", name="uq_expense_claims_claim_number"),
+    )
+    op.create_index("ix_expense_claims_status", "expense_claims", ["status"])
+
+    op.create_table(
+        "expense_claim_lines",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("claim_id", sa.UUID(), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=False),
+        sa.Column("expense_account_id", sa.UUID(), nullable=False),
+        sa.Column("amount", sa.Numeric(12, 2), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["claim_id"], ["expense_claims.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["expense_account_id"], ["accounts.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_expense_claim_lines_claim_id", "expense_claim_lines", ["claim_id"])
+
+    # Seed Owner Reimbursable Liability (idempotent)
+    bind = op.get_bind()
+    existing = bind.execute(
+        sa.text("SELECT 1 FROM accounts WHERE code = '2300'")
+    ).first()
+    if not existing:
+        bind.execute(
+            sa.text(
+                "INSERT INTO accounts (id, code, name, account_type, normal_balance, "
+                "is_active, is_system, is_bank_account, created_at, updated_at) "
+                "VALUES (:id, '2300', 'Owner Reimbursable Liability', 'liability', 'credit', "
+                "true, true, false, NOW(), NOW())"
+            ),
+            {"id": str(uuid.uuid4())},
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_expense_claim_lines_claim_id", table_name="expense_claim_lines")
+    op.drop_table("expense_claim_lines")
+    op.drop_index("ix_expense_claims_status", table_name="expense_claims")
+    op.drop_table("expense_claims")

--- a/backend/app/api/v1/endpoints/expense_claims.py
+++ b/backend/app/api/v1/endpoints/expense_claims.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.expense_claim import ExpenseClaim, ExpenseClaimLine
+from app.services.expense_claim_service import (
+    ExpenseClaimError,
+    approve_claim,
+    cancel_claim,
+    create_claim,
+    reimburse_claim,
+    submit_claim,
+)
+
+
+router = APIRouter(prefix="/expense-claims", tags=["ExpenseClaims"])
+
+
+class LineIn(BaseModel):
+    description: str = Field(..., min_length=1, max_length=255)
+    expense_account_id: uuid.UUID
+    amount: Decimal = Field(..., gt=0)
+    notes: str | None = None
+
+
+class ClaimCreate(BaseModel):
+    payer_kind: Literal["owner", "employee", "contractor"] = "owner"
+    payer_name: str = Field(..., min_length=1, max_length=200)
+    notes: str | None = None
+    lines: list[LineIn] = Field(..., min_length=1)
+
+
+class LineOut(BaseModel):
+    id: uuid.UUID
+    description: str
+    expense_account_id: uuid.UUID
+    amount: Decimal
+    notes: str | None
+
+
+class ClaimResponse(BaseModel):
+    id: uuid.UUID
+    claim_number: str
+    payer_kind: str
+    payer_name: str
+    submitted_on: date | None
+    status: str
+    total_amount: Decimal
+    journal_entry_id: uuid.UUID | None
+    reimbursement_journal_entry_id: uuid.UUID | None
+    notes: str | None
+    created_at: datetime
+    lines: list[LineOut]
+
+
+class ApproveRequest(BaseModel):
+    approve_date: date | None = None
+
+
+class ReimburseRequest(BaseModel):
+    cash_account_id: uuid.UUID
+    paid_on: date | None = None
+
+
+async def _hydrate(db, claim: ExpenseClaim) -> ClaimResponse:
+    lines = (
+        await db.execute(
+            select(ExpenseClaimLine).where(ExpenseClaimLine.claim_id == claim.id)
+        )
+    ).scalars().all()
+    return ClaimResponse(
+        id=claim.id,
+        claim_number=claim.claim_number,
+        payer_kind=claim.payer_kind,
+        payer_name=claim.payer_name,
+        submitted_on=claim.submitted_on,
+        status=claim.status,
+        total_amount=Decimal(claim.total_amount),
+        journal_entry_id=claim.journal_entry_id,
+        reimbursement_journal_entry_id=claim.reimbursement_journal_entry_id,
+        notes=claim.notes,
+        created_at=claim.created_at,
+        lines=[
+            LineOut(
+                id=l.id,
+                description=l.description,
+                expense_account_id=l.expense_account_id,
+                amount=Decimal(l.amount),
+                notes=l.notes,
+            )
+            for l in lines
+        ],
+    )
+
+
+@router.get("", response_model=list[ClaimResponse], summary="List expense claims")
+async def list_claims(user: CurrentUser, db: DB, status_filter: str | None = None):
+    stmt = select(ExpenseClaim).order_by(ExpenseClaim.created_at.desc())
+    if status_filter:
+        stmt = stmt.where(ExpenseClaim.status == status_filter)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [await _hydrate(db, r) for r in rows]
+
+
+@router.post("", response_model=ClaimResponse, status_code=status.HTTP_201_CREATED, summary="Create an expense claim")
+async def create(body: ClaimCreate, user: CurrentUser, db: DB):
+    try:
+        claim = await create_claim(
+            db,
+            payer_kind=body.payer_kind,
+            payer_name=body.payer_name,
+            notes=body.notes,
+            lines=[l.model_dump() for l in body.lines],
+        )
+    except ExpenseClaimError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate(db, claim)
+
+
+@router.get("/{claim_id}", response_model=ClaimResponse, summary="Get claim detail")
+async def get_one(claim_id: uuid.UUID, user: CurrentUser, db: DB):
+    claim = (await db.execute(select(ExpenseClaim).where(ExpenseClaim.id == claim_id))).scalar_one_or_none()
+    if not claim:
+        raise HTTPException(status_code=404, detail="Expense claim not found")
+    return await _hydrate(db, claim)
+
+
+@router.post("/{claim_id}/submit", response_model=ClaimResponse, summary="Submit a draft claim")
+async def submit_ep(claim_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        claim = await submit_claim(db, claim_id)
+    except ExpenseClaimError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate(db, claim)
+
+
+@router.post("/{claim_id}/approve", response_model=ClaimResponse, summary="Approve a claim and post the JE")
+async def approve_ep(claim_id: uuid.UUID, body: ApproveRequest, user: CurrentUser, db: DB):
+    try:
+        claim = await approve_claim(db, claim_id, approve_date=body.approve_date)
+    except ExpenseClaimError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate(db, claim)
+
+
+@router.post("/{claim_id}/reimburse", response_model=ClaimResponse, summary="Reimburse an approved claim")
+async def reimburse_ep(claim_id: uuid.UUID, body: ReimburseRequest, user: CurrentUser, db: DB):
+    try:
+        claim = await reimburse_claim(
+            db, claim_id, cash_account_id=body.cash_account_id, paid_on=body.paid_on
+        )
+    except ExpenseClaimError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate(db, claim)
+
+
+@router.post("/{claim_id}/cancel", response_model=ClaimResponse, summary="Cancel a claim")
+async def cancel_ep(claim_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        claim = await cancel_claim(db, claim_id)
+    except ExpenseClaimError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate(db, claim)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, attachments, audit, auth, banking, cameras, customers, dashboard, email, fixed_assets, insights, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, supplies, tax
+from app.api.v1.endpoints import accounting, approvals, attachments, audit, auth, banking, cameras, customers, dashboard, email, expense_claims, fixed_assets, insights, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -34,3 +34,4 @@ api_router.include_router(locations.router)
 api_router.include_router(inter_account_transfers.router)
 api_router.include_router(attachments.router)
 api_router.include_router(recurring_invoices.router)
+api_router.include_router(expense_claims.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,6 +2,7 @@ from app.models.attachment import Attachment  # noqa: F401
 from app.models.bank_reconciliation import BankReconciliation, BankReconciliationLine  # noqa: F401
 from app.models.camera import Camera  # noqa: F401
 from app.models.email_delivery import EmailDelivery  # noqa: F401
+from app.models.expense_claim import ExpenseClaim, ExpenseClaimLine  # noqa: F401
 from app.models.fixed_asset import DepreciationEntry, FixedAsset  # noqa: F401
 from app.models.inter_account_transfer import InterAccountTransfer  # noqa: F401
 from app.models.inventory_location import (  # noqa: F401

--- a/backend/app/models/expense_claim.py
+++ b/backend/app/models/expense_claim.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class ExpenseClaim(Base):
+    """An owner-paid (or contractor-fronted) reimbursable expense claim
+    (#251). Lifecycle: draft → submitted → approved → reimbursed →
+    cancelled. JE posts on approve.
+    """
+
+    __tablename__ = "expense_claims"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    claim_number: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    payer_kind: Mapped[str] = mapped_column(String(30), default="owner")  # owner | employee | contractor
+    payer_name: Mapped[str] = mapped_column(String(200))
+    submitted_on: Mapped[date | None] = mapped_column(Date, nullable=True)
+    status: Mapped[str] = mapped_column(String(20), default="draft", index=True)
+    total_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    journal_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("journal_entries.id"), nullable=True
+    )
+    reimbursement_journal_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("journal_entries.id"), nullable=True
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    lines = relationship("ExpenseClaimLine", back_populates="claim", cascade="all, delete-orphan")
+
+
+class ExpenseClaimLine(Base):
+    __tablename__ = "expense_claim_lines"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    claim_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("expense_claims.id", ondelete="CASCADE"), index=True
+    )
+    description: Mapped[str] = mapped_column(String(255))
+    expense_account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"))
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    claim = relationship("ExpenseClaim", back_populates="lines")

--- a/backend/app/services/accounting_service.py
+++ b/backend/app/services/accounting_service.py
@@ -45,6 +45,8 @@ STARTER_CHART_OF_ACCOUNTS = [
     ("6700", "Depreciation Expense", "expense", "debit"),
     ("4910", "Gain on Disposal of Equipment", "revenue", "credit"),
     ("6710", "Loss on Disposal of Equipment", "expense", "debit"),
+    # Expense claims (#251)
+    ("2300", "Owner Reimbursable Liability", "liability", "credit"),
 ]
 
 

--- a/backend/app/services/expense_claim_service.py
+++ b/backend/app/services/expense_claim_service.py
@@ -1,0 +1,227 @@
+"""Expense claim lifecycle (#251).
+
+Lifecycle: draft → submitted → approved → reimbursed → cancelled.
+Approve posts JE: Dr expense lines, Cr Owner Reimbursable Liability.
+Reimburse posts JE: Dr Owner Reimbursable Liability, Cr cash.
+Cancel after approve reverses the approve JE.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account
+from app.models.expense_claim import ExpenseClaim, ExpenseClaimLine
+from app.schemas.accounting import JournalEntryCreate, JournalLineCreate
+from app.services.accounting_service import (
+    AccountingValidationError,
+    create_journal_entry,
+    reverse_journal_entry,
+)
+from app.services.reference_number_service import next_number
+
+
+class ExpenseClaimError(RuntimeError):
+    pass
+
+
+STATUS_DRAFT = "draft"
+STATUS_SUBMITTED = "submitted"
+STATUS_APPROVED = "approved"
+STATUS_REIMBURSED = "reimbursed"
+STATUS_CANCELLED = "cancelled"
+
+
+async def _liability_account(db: AsyncSession) -> Account:
+    a = (await db.execute(select(Account).where(Account.code == "2300"))).scalar_one_or_none()
+    if a is None:
+        raise ExpenseClaimError("Owner Reimbursable Liability account (2300) is missing from COA")
+    return a
+
+
+async def create_claim(
+    db: AsyncSession,
+    *,
+    payer_kind: str = "owner",
+    payer_name: str,
+    notes: str | None = None,
+    lines: list[dict],
+) -> ExpenseClaim:
+    if not lines:
+        raise ExpenseClaimError("Claim must have at least one line")
+    number = await next_number(db, "expense_claim")
+    total = Decimal("0")
+    claim = ExpenseClaim(
+        claim_number=number,
+        payer_kind=payer_kind,
+        payer_name=payer_name,
+        notes=notes,
+        status=STATUS_DRAFT,
+    )
+    db.add(claim)
+    await db.flush()
+    for line in lines:
+        amt = Decimal(str(line["amount"]))
+        if amt <= 0:
+            raise ExpenseClaimError("Line amount must be > 0")
+        total += amt
+        db.add(
+            ExpenseClaimLine(
+                claim_id=claim.id,
+                description=line["description"],
+                expense_account_id=line["expense_account_id"],
+                amount=amt,
+                notes=line.get("notes"),
+            )
+        )
+    claim.total_amount = total.quantize(Decimal("0.01"))
+    await db.flush()
+    return claim
+
+
+async def submit_claim(db: AsyncSession, claim_id: uuid.UUID) -> ExpenseClaim:
+    claim = await _require(db, claim_id)
+    if claim.status != STATUS_DRAFT:
+        raise ExpenseClaimError(f"Cannot submit claim in status {claim.status}")
+    claim.status = STATUS_SUBMITTED
+    claim.submitted_on = datetime.now(timezone.utc).date()
+    await db.flush()
+    return claim
+
+
+async def approve_claim(db: AsyncSession, claim_id: uuid.UUID, *, approve_date: date | None = None) -> ExpenseClaim:
+    claim = await _require(db, claim_id)
+    if claim.status not in (STATUS_DRAFT, STATUS_SUBMITTED):
+        raise ExpenseClaimError(f"Cannot approve claim in status {claim.status}")
+
+    liability = await _liability_account(db)
+    lines = (
+        await db.execute(select(ExpenseClaimLine).where(ExpenseClaimLine.claim_id == claim.id))
+    ).scalars().all()
+
+    je_lines: list[JournalLineCreate] = []
+    for line in lines:
+        je_lines.append(
+            JournalLineCreate(
+                account_id=line.expense_account_id,
+                entry_type="debit",
+                amount=Decimal(line.amount),
+                description=f"Expense claim {claim.claim_number}: {line.description}",
+            )
+        )
+    je_lines.append(
+        JournalLineCreate(
+            account_id=liability.id,
+            entry_type="credit",
+            amount=Decimal(claim.total_amount),
+            description=f"Expense claim {claim.claim_number} payable to {claim.payer_name}",
+        )
+    )
+
+    try:
+        entry = await create_journal_entry(
+            db,
+            JournalEntryCreate(
+                entry_date=approve_date or datetime.now(timezone.utc).date(),
+                source_type="expense_claim_approval",
+                source_id=str(claim.id),
+                memo=f"Approve expense claim {claim.claim_number}",
+                lines=je_lines,
+            ),
+        )
+    except AccountingValidationError as e:
+        raise ExpenseClaimError(str(e)) from e
+
+    claim.status = STATUS_APPROVED
+    claim.journal_entry_id = entry.id
+    await db.flush()
+    return claim
+
+
+async def reimburse_claim(
+    db: AsyncSession,
+    claim_id: uuid.UUID,
+    *,
+    cash_account_id: uuid.UUID,
+    paid_on: date | None = None,
+) -> ExpenseClaim:
+    claim = await _require(db, claim_id)
+    if claim.status != STATUS_APPROVED:
+        raise ExpenseClaimError(f"Cannot reimburse claim in status {claim.status}")
+
+    liability = await _liability_account(db)
+    cash = (await db.execute(select(Account).where(Account.id == cash_account_id))).scalar_one_or_none()
+    if cash is None:
+        raise ExpenseClaimError("Cash account not found")
+
+    try:
+        entry = await create_journal_entry(
+            db,
+            JournalEntryCreate(
+                entry_date=paid_on or datetime.now(timezone.utc).date(),
+                source_type="expense_claim_reimbursement",
+                source_id=str(claim.id),
+                memo=f"Reimburse expense claim {claim.claim_number} to {claim.payer_name}",
+                lines=[
+                    JournalLineCreate(
+                        account_id=liability.id,
+                        entry_type="debit",
+                        amount=Decimal(claim.total_amount),
+                        description=f"Reimbursement {claim.claim_number}",
+                    ),
+                    JournalLineCreate(
+                        account_id=cash.id,
+                        entry_type="credit",
+                        amount=Decimal(claim.total_amount),
+                        description=f"Reimbursement {claim.claim_number}",
+                    ),
+                ],
+            ),
+        )
+    except AccountingValidationError as e:
+        raise ExpenseClaimError(str(e)) from e
+
+    claim.status = STATUS_REIMBURSED
+    claim.reimbursement_journal_entry_id = entry.id
+    await db.flush()
+    return claim
+
+
+async def cancel_claim(db: AsyncSession, claim_id: uuid.UUID) -> ExpenseClaim:
+    claim = await _require(db, claim_id)
+    if claim.status == STATUS_CANCELLED:
+        return claim
+    if claim.status == STATUS_REIMBURSED:
+        raise ExpenseClaimError("Cannot cancel a reimbursed claim; reverse the reimbursement first")
+
+    # Reverse the approve JE if posted
+    if claim.status == STATUS_APPROVED and claim.journal_entry_id is not None:
+        from app.schemas.accounting import JournalEntryReverse
+
+        try:
+            await reverse_journal_entry(
+                db,
+                entry_id=claim.journal_entry_id,
+                payload=JournalEntryReverse(
+                    reversal_date=datetime.now(timezone.utc).date(),
+                    memo=f"Reverse approval — cancelled expense claim {claim.claim_number}",
+                ),
+            )
+        except AccountingValidationError as e:
+            raise ExpenseClaimError(str(e)) from e
+
+    claim.status = STATUS_CANCELLED
+    await db.flush()
+    return claim
+
+
+async def _require(db: AsyncSession, claim_id: uuid.UUID) -> ExpenseClaim:
+    claim = (await db.execute(select(ExpenseClaim).where(ExpenseClaim.id == claim_id))).scalar_one_or_none()
+    if claim is None:
+        raise ExpenseClaimError("Expense claim not found")
+    return claim

--- a/backend/app/services/reference_number_service.py
+++ b/backend/app/services/reference_number_service.py
@@ -20,6 +20,7 @@ FORMATS: Final[dict[str, str]] = {
     "quote": "Q-{year}-{value:04d}",
     "inventory_transfer": "IT-{year}-{value:04d}",
     "inter_account_transfer": "T-{year}-{value:04d}",
+    "expense_claim": "EC-{year}-{value:04d}",
 }
 
 

--- a/backend/tests/test_expense_claim_service.py
+++ b/backend/tests/test_expense_claim_service.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.expense_claim import ExpenseClaim
+from app.services.expense_claim_service import (
+    ExpenseClaimError,
+    approve_claim,
+    cancel_claim,
+    create_claim,
+    reimburse_claim,
+    submit_claim,
+)
+
+
+async def _accounts(db_session):
+    return {a.code: a for a in (await db_session.execute(select(Account))).scalars().all()}
+
+
+async def _make_claim(db_session, accts, *, amount=Decimal("100")):
+    return await create_claim(
+        db_session,
+        payer_kind="owner",
+        payer_name="Brent",
+        lines=[{"description": "Filament", "expense_account_id": accts["6500"].id, "amount": amount}],
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_assigns_number_and_total(db_session):
+    accts = await _accounts(db_session)
+    claim = await _make_claim(db_session, accts)
+    assert claim.claim_number.startswith("EC-")
+    assert claim.total_amount == Decimal("100.00")
+    assert claim.status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_create_no_lines_rejected(db_session):
+    with pytest.raises(ExpenseClaimError):
+        await create_claim(db_session, payer_kind="owner", payer_name="x", lines=[])
+
+
+@pytest.mark.asyncio
+async def test_create_zero_amount_rejected(db_session):
+    accts = await _accounts(db_session)
+    with pytest.raises(ExpenseClaimError):
+        await create_claim(
+            db_session,
+            payer_kind="owner",
+            payer_name="x",
+            lines=[{"description": "x", "expense_account_id": accts["6500"].id, "amount": Decimal("0")}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_submit_approve_reimburse(db_session):
+    accts = await _accounts(db_session)
+    claim = await _make_claim(db_session, accts)
+
+    claim = await submit_claim(db_session, claim.id)
+    assert claim.status == "submitted"
+    assert claim.submitted_on is not None
+
+    claim = await approve_claim(db_session, claim.id)
+    assert claim.status == "approved"
+    assert claim.journal_entry_id is not None
+
+    claim = await reimburse_claim(db_session, claim.id, cash_account_id=accts["1000"].id)
+    assert claim.status == "reimbursed"
+    assert claim.reimbursement_journal_entry_id is not None
+
+
+@pytest.mark.asyncio
+async def test_approve_skips_submit(db_session):
+    """Operator can approve a draft directly without submit."""
+    accts = await _accounts(db_session)
+    claim = await _make_claim(db_session, accts)
+    claim = await approve_claim(db_session, claim.id)
+    assert claim.status == "approved"
+
+
+@pytest.mark.asyncio
+async def test_cancel_from_draft(db_session):
+    accts = await _accounts(db_session)
+    claim = await _make_claim(db_session, accts)
+    claim = await cancel_claim(db_session, claim.id)
+    assert claim.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cancel_from_approved_reverses_je(db_session):
+    accts = await _accounts(db_session)
+    claim = await _make_claim(db_session, accts)
+    claim = await approve_claim(db_session, claim.id)
+    claim = await cancel_claim(db_session, claim.id)
+    assert claim.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cannot_reimburse_unapproved(db_session):
+    accts = await _accounts(db_session)
+    claim = await _make_claim(db_session, accts)
+    with pytest.raises(ExpenseClaimError):
+        await reimburse_claim(db_session, claim.id, cash_account_id=accts["1000"].id)
+
+
+@pytest.mark.asyncio
+async def test_cannot_cancel_after_reimburse(db_session):
+    accts = await _accounts(db_session)
+    claim = await _make_claim(db_session, accts)
+    await approve_claim(db_session, claim.id)
+    await reimburse_claim(db_session, claim.id, cash_account_id=accts["1000"].id)
+    with pytest.raises(ExpenseClaimError):
+        await cancel_claim(db_session, claim.id)

--- a/docs/expense_claims.md
+++ b/docs/expense_claims.md
@@ -1,0 +1,45 @@
+# Expense Claims
+
+Owner-paid (or contractor-fronted) business expenses that the business
+reimburses. #251.
+
+## Lifecycle
+
+`draft → submitted → approved → reimbursed → cancelled`
+
+- **draft**: claim with lines but no GL impact yet.
+- **submitted**: operator pushed it for review (no GL change).
+- **approved**: posts JE
+  - Dr each line's expense account
+  - Cr Owner Reimbursable Liability (account `2300`)
+- **reimbursed**: posts JE
+  - Dr Owner Reimbursable Liability
+  - Cr the chosen cash account
+- **cancelled**: from any non-reimbursed state. If the approve JE was already posted, it's reversed automatically.
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `GET` | `/api/v1/expense-claims` | List, optional `?status_filter=...`. |
+| `POST` | `/api/v1/expense-claims` | Create (one or more lines). |
+| `GET` | `/api/v1/expense-claims/{id}` | Detail. |
+| `POST` | `/api/v1/expense-claims/{id}/submit` | Draft → submitted. |
+| `POST` | `/api/v1/expense-claims/{id}/approve` | Submitted (or draft) → approved + JE. |
+| `POST` | `/api/v1/expense-claims/{id}/reimburse` | Approved → reimbursed + cash JE. |
+| `POST` | `/api/v1/expense-claims/{id}/cancel` | Any non-reimbursed state → cancelled. |
+
+`claim_number` allocator scope `expense_claim` with format `EC-{year}-{value:04d}` via #243.
+
+## COA seed
+
+Migration `20260509_09` adds account `2300` "Owner Reimbursable Liability" (idempotent — re-runs against existing installs are safe).
+
+## Phase 2 follow-ups
+
+- **Receipt attachments** via #250 — wire `attachment_service.upload_attachment` calls to expense-claim line forms once the frontend exists.
+- **Approval workflow** integration with `approval_request.py` for two-step submit-approve.
+- **Reimbursement-as-Bill**: optionally create a real Bill against the payer (treated as a vendor) so the existing AP/payment flow handles cash-out instead of a direct cash-account JE.
+- **Frontend**: no expense-claims UI today.
+- **Mileage** lines with rate × distance.
+- **Multi-payer** claims, recurring claims.


### PR DESCRIPTION
Closes #251. ExpenseClaim/Line + lifecycle + JE postings on approve & reimburse + auto-reversal on cancel-after-approve. New COA account 2300 'Owner Reimbursable Liability'. 369 tests pass (360 + 9 new). Doc: `docs/expense_claims.md`.