### PR TITLE
feat(intangibles): asset register with amortization (#252)

### DIFF
--- a/backend/alembic/versions/20260509_10_add_intangible_assets.py
+++ b/backend/alembic/versions/20260509_10_add_intangible_assets.py
@@ -1,0 +1,115 @@
+"""add intangible_assets, amortization_entries, and IA-related COA seed (#252)
+
+Revision ID: 20260509_10
+Revises: 20260509_09
+Create Date: 2026-05-09 23:45:00
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_10"
+down_revision = "20260509_09"
+branch_labels = None
+depends_on = None
+
+
+NEW_ACCOUNTS = [
+    ("1800", "Intangible Assets", "asset", "debit"),
+    ("1850", "Accumulated Amortization", "asset", "credit"),
+    ("6750", "Amortization Expense", "expense", "debit"),
+    ("4920", "Gain on Disposal of Intangibles", "revenue", "credit"),
+    ("6760", "Loss on Disposal of Intangibles", "expense", "debit"),
+]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "intangible_assets",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("asset_tag", sa.String(length=120), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("acquired_on", sa.Date(), nullable=False),
+        sa.Column("acquisition_cost", sa.Numeric(14, 4), nullable=False),
+        sa.Column("salvage_value", sa.Numeric(14, 4), nullable=False, server_default="0"),
+        sa.Column("useful_life_months", sa.Integer(), nullable=False),
+        sa.Column("amortization_method", sa.String(length=30), nullable=False, server_default="straight_line"),
+        sa.Column("declining_balance_rate", sa.Numeric(8, 6), nullable=True),
+        sa.Column("asset_account_id", sa.UUID(), nullable=False),
+        sa.Column("accumulated_amortization_account_id", sa.UUID(), nullable=False),
+        sa.Column("amortization_expense_account_id", sa.UUID(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="active"),
+        sa.Column("disposed_on", sa.Date(), nullable=True),
+        sa.Column("disposal_proceeds", sa.Numeric(14, 4), nullable=True),
+        sa.Column("disposal_journal_entry_id", sa.UUID(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["asset_account_id"], ["accounts.id"]),
+        sa.ForeignKeyConstraint(["accumulated_amortization_account_id"], ["accounts.id"]),
+        sa.ForeignKeyConstraint(["amortization_expense_account_id"], ["accounts.id"]),
+        sa.ForeignKeyConstraint(["disposal_journal_entry_id"], ["journal_entries.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("asset_tag", name="uq_intangible_assets_asset_tag"),
+    )
+    op.create_index("ix_intangible_assets_name", "intangible_assets", ["name"])
+    op.create_index("ix_intangible_assets_status", "intangible_assets", ["status"])
+
+    op.create_table(
+        "amortization_entries",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("intangible_asset_id", sa.UUID(), nullable=False),
+        sa.Column("period_end", sa.Date(), nullable=False),
+        sa.Column("amount", sa.Numeric(14, 4), nullable=False),
+        sa.Column("journal_entry_id", sa.UUID(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["intangible_asset_id"], ["intangible_assets.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["journal_entry_id"], ["journal_entries.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "intangible_asset_id", "period_end",
+            name="uq_amortization_entries_asset_period",
+        ),
+    )
+    op.create_index(
+        "ix_amortization_entries_intangible_asset_id",
+        "amortization_entries",
+        ["intangible_asset_id"],
+    )
+
+    bind = op.get_bind()
+    for code, name, account_type, normal_balance in NEW_ACCOUNTS:
+        existing = bind.execute(
+            sa.text("SELECT 1 FROM accounts WHERE code = :code"),
+            {"code": code},
+        ).first()
+        if existing:
+            continue
+        bind.execute(
+            sa.text(
+                "INSERT INTO accounts (id, code, name, account_type, normal_balance, "
+                "is_active, is_system, is_bank_account, created_at, updated_at) "
+                "VALUES (:id, :code, :name, :type, :normal, true, true, false, NOW(), NOW())"
+            ),
+            {
+                "id": str(uuid.uuid4()),
+                "code": code,
+                "name": name,
+                "type": account_type,
+                "normal": normal_balance,
+            },
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_amortization_entries_intangible_asset_id", table_name="amortization_entries")
+    op.drop_table("amortization_entries")
+    op.drop_index("ix_intangible_assets_status", table_name="intangible_assets")
+    op.drop_index("ix_intangible_assets_name", table_name="intangible_assets")
+    op.drop_table("intangible_assets")

--- a/backend/app/api/v1/endpoints/intangible_assets.py
+++ b/backend/app/api/v1/endpoints/intangible_assets.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.account import Account
+from app.models.intangible_asset import AmortizationEntry, IntangibleAsset
+from app.services.intangible_asset_service import (
+    IntangibleAssetError,
+    can_edit_critical_fields,
+    compute_book_value,
+    dispose_asset,
+    planned_schedule,
+    post_amortization,
+)
+
+
+router = APIRouter(prefix="/intangible-assets", tags=["IntangibleAssets"])
+
+
+class IntangibleAssetCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    asset_tag: str | None = Field(None, max_length=120)
+    description: str | None = None
+    acquired_on: date
+    acquisition_cost: Decimal = Field(..., gt=0)
+    salvage_value: Decimal = Field(0, ge=0)
+    useful_life_months: int = Field(..., gt=0)
+    amortization_method: Literal["straight_line", "declining_balance"] = "straight_line"
+    declining_balance_rate: Decimal | None = Field(None, gt=0)
+    asset_account_id: uuid.UUID | None = None
+    accumulated_amortization_account_id: uuid.UUID | None = None
+    amortization_expense_account_id: uuid.UUID | None = None
+    notes: str | None = None
+
+
+class IntangibleAssetUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=120)
+    asset_tag: str | None = Field(None, max_length=120)
+    description: str | None = None
+    acquisition_cost: Decimal | None = Field(None, gt=0)
+    salvage_value: Decimal | None = Field(None, ge=0)
+    useful_life_months: int | None = Field(None, gt=0)
+    amortization_method: Literal["straight_line", "declining_balance"] | None = None
+    declining_balance_rate: Decimal | None = Field(None, gt=0)
+    notes: str | None = None
+
+
+class IntangibleAssetResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    asset_tag: str | None
+    description: str | None
+    acquired_on: date
+    acquisition_cost: Decimal
+    salvage_value: Decimal
+    useful_life_months: int
+    amortization_method: str
+    declining_balance_rate: Decimal | None
+    asset_account_id: uuid.UUID
+    accumulated_amortization_account_id: uuid.UUID
+    amortization_expense_account_id: uuid.UUID
+    status: str
+    disposed_on: date | None
+    disposal_proceeds: Decimal | None
+    disposal_journal_entry_id: uuid.UUID | None
+    notes: str | None
+    book_value: Decimal
+
+
+class AmortizationPostRequest(BaseModel):
+    period_end: date
+    asset_ids: list[uuid.UUID] | None = None
+
+
+class DisposeRequest(BaseModel):
+    disposed_on: date
+    proceeds: Decimal | None = Field(None, ge=0)
+    proceeds_account_id: uuid.UUID | None = None
+
+
+class ScheduleRow(BaseModel):
+    period_end: date
+    amount: Decimal
+
+
+class IntangibleAssetDetail(IntangibleAssetResponse):
+    schedule: list[ScheduleRow]
+    posted_periods: list[date]
+
+
+async def _hydrate(db, asset: IntangibleAsset) -> IntangibleAssetResponse:
+    book = await compute_book_value(db, asset.id)
+    return IntangibleAssetResponse(
+        id=asset.id,
+        name=asset.name,
+        asset_tag=asset.asset_tag,
+        description=asset.description,
+        acquired_on=asset.acquired_on,
+        acquisition_cost=Decimal(asset.acquisition_cost),
+        salvage_value=Decimal(asset.salvage_value),
+        useful_life_months=asset.useful_life_months,
+        amortization_method=asset.amortization_method,
+        declining_balance_rate=Decimal(asset.declining_balance_rate) if asset.declining_balance_rate is not None else None,
+        asset_account_id=asset.asset_account_id,
+        accumulated_amortization_account_id=asset.accumulated_amortization_account_id,
+        amortization_expense_account_id=asset.amortization_expense_account_id,
+        status=asset.status,
+        disposed_on=asset.disposed_on,
+        disposal_proceeds=Decimal(asset.disposal_proceeds) if asset.disposal_proceeds is not None else None,
+        disposal_journal_entry_id=asset.disposal_journal_entry_id,
+        notes=asset.notes,
+        book_value=book,
+    )
+
+
+async def _resolve_default_account(db, code: str) -> uuid.UUID:
+    a = (await db.execute(select(Account).where(Account.code == code))).scalar_one_or_none()
+    if a is None:
+        raise HTTPException(status_code=400, detail=f"Account with code {code} not found in chart of accounts")
+    return a.id
+
+
+@router.get("", response_model=list[IntangibleAssetResponse], summary="List intangible assets")
+async def list_assets(user: CurrentUser, db: DB, status_filter: str | None = None):
+    stmt = select(IntangibleAsset).order_by(IntangibleAsset.acquired_on.desc())
+    if status_filter:
+        stmt = stmt.where(IntangibleAsset.status == status_filter)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [await _hydrate(db, r) for r in rows]
+
+
+@router.post("", response_model=IntangibleAssetResponse, status_code=status.HTTP_201_CREATED, summary="Register a new intangible asset")
+async def create_asset(body: IntangibleAssetCreate, user: CurrentUser, db: DB):
+    asset_account_id = body.asset_account_id or await _resolve_default_account(db, "1800")
+    accum_id = body.accumulated_amortization_account_id or await _resolve_default_account(db, "1850")
+    expense_id = body.amortization_expense_account_id or await _resolve_default_account(db, "6750")
+    asset = IntangibleAsset(
+        name=body.name,
+        asset_tag=body.asset_tag,
+        description=body.description,
+        acquired_on=body.acquired_on,
+        acquisition_cost=body.acquisition_cost,
+        salvage_value=body.salvage_value,
+        useful_life_months=body.useful_life_months,
+        amortization_method=body.amortization_method,
+        declining_balance_rate=body.declining_balance_rate,
+        asset_account_id=asset_account_id,
+        accumulated_amortization_account_id=accum_id,
+        amortization_expense_account_id=expense_id,
+        notes=body.notes,
+    )
+    db.add(asset)
+    await db.commit()
+    return await _hydrate(db, asset)
+
+
+@router.get("/{asset_id}", response_model=IntangibleAssetDetail, summary="Intangible asset detail with schedule")
+async def get_asset(asset_id: uuid.UUID, user: CurrentUser, db: DB):
+    asset = (await db.execute(select(IntangibleAsset).where(IntangibleAsset.id == asset_id))).scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=404, detail="Intangible asset not found")
+    base = await _hydrate(db, asset)
+    schedule = [ScheduleRow(period_end=p, amount=a) for p, a in planned_schedule(asset)]
+    posted = [
+        e
+        for e in (
+            await db.execute(
+                select(AmortizationEntry.period_end).where(
+                    AmortizationEntry.intangible_asset_id == asset.id
+                )
+            )
+        ).scalars().all()
+    ]
+    return IntangibleAssetDetail(**base.model_dump(), schedule=schedule, posted_periods=posted)
+
+
+@router.patch("/{asset_id}", response_model=IntangibleAssetResponse, summary="Update an intangible asset")
+async def update_asset(asset_id: uuid.UUID, body: IntangibleAssetUpdate, user: CurrentUser, db: DB):
+    asset = (await db.execute(select(IntangibleAsset).where(IntangibleAsset.id == asset_id))).scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=404, detail="Intangible asset not found")
+    if asset.status == "disposed":
+        raise HTTPException(status_code=400, detail="Cannot edit a disposed asset")
+
+    critical_locked = not await can_edit_critical_fields(db, asset.id)
+    payload = body.model_dump(exclude_unset=True)
+    if critical_locked:
+        for k in ("acquisition_cost", "salvage_value", "useful_life_months", "amortization_method", "declining_balance_rate"):
+            if k in payload:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Cannot edit '{k}' once amortization has been posted",
+                )
+    for k, v in payload.items():
+        setattr(asset, k, v)
+    await db.commit()
+    return await _hydrate(db, asset)
+
+
+@router.post("/post-amortization", summary="Post amortization through a period for selected (or all active) assets")
+async def post_amort(body: AmortizationPostRequest, user: CurrentUser, db: DB):
+    if body.asset_ids:
+        assets = (
+            await db.execute(select(IntangibleAsset).where(IntangibleAsset.id.in_(body.asset_ids)))
+        ).scalars().all()
+    else:
+        assets = (
+            await db.execute(select(IntangibleAsset).where(IntangibleAsset.status == "active"))
+        ).scalars().all()
+
+    posted_count = 0
+    for a in assets:
+        try:
+            new_entries = await post_amortization(db, asset_id=a.id, through=body.period_end)
+            posted_count += len(new_entries)
+        except IntangibleAssetError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return {"posted_count": posted_count, "asset_count": len(assets)}
+
+
+@router.post("/{asset_id}/dispose", response_model=IntangibleAssetResponse, summary="Dispose an intangible asset")
+async def dispose(asset_id: uuid.UUID, body: DisposeRequest, user: CurrentUser, db: DB):
+    gain_id = await _resolve_default_account(db, "4920")
+    loss_id = await _resolve_default_account(db, "6760")
+    try:
+        asset = await dispose_asset(
+            db,
+            asset_id=asset_id,
+            disposed_on=body.disposed_on,
+            proceeds=body.proceeds,
+            proceeds_account_id=body.proceeds_account_id,
+            gain_account_id=gain_id,
+            loss_account_id=loss_id,
+        )
+    except IntangibleAssetError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return await _hydrate(db, asset)
+
+
+@router.delete("/{asset_id}", status_code=204, summary="Delete an intangible asset (only if no entries and not disposed)")
+async def delete_asset(asset_id: uuid.UUID, user: CurrentUser, db: DB):
+    asset = (await db.execute(select(IntangibleAsset).where(IntangibleAsset.id == asset_id))).scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=404, detail="Intangible asset not found")
+    if not await can_edit_critical_fields(db, asset.id):
+        raise HTTPException(status_code=400, detail="Cannot delete an asset with amortization entries")
+    if asset.status == "disposed":
+        raise HTTPException(status_code=400, detail="Cannot delete a disposed asset")
+    await db.delete(asset)
+    await db.commit()

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, attachments, audit, auth, banking, cameras, customers, dashboard, email, expense_claims, fixed_assets, insights, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, supplies, tax
+from app.api.v1.endpoints import accounting, approvals, attachments, audit, auth, banking, cameras, customers, dashboard, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -35,3 +35,4 @@ api_router.include_router(inter_account_transfers.router)
 api_router.include_router(attachments.router)
 api_router.include_router(recurring_invoices.router)
 api_router.include_router(expense_claims.router)
+api_router.include_router(intangible_assets.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.email_delivery import EmailDelivery  # noqa: F401
 from app.models.expense_claim import ExpenseClaim, ExpenseClaimLine  # noqa: F401
 from app.models.fixed_asset import DepreciationEntry, FixedAsset  # noqa: F401
 from app.models.inter_account_transfer import InterAccountTransfer  # noqa: F401
+from app.models.intangible_asset import AmortizationEntry, IntangibleAsset  # noqa: F401
 from app.models.inventory_location import (  # noqa: F401
     InventoryLocation,
     InventoryTransfer,

--- a/backend/app/models/intangible_asset.py
+++ b/backend/app/models/intangible_asset.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class IntangibleAsset(Base):
+    """Symmetric mirror of FixedAsset for intangibles — CAD/slicer
+    subscriptions amortized over their term, asset packs, brand/domain
+    purchases, multi-year listing fees. #252.
+
+    Same lifecycle: active → fully_amortized (auto when book reaches 0)
+    → optionally disposed.
+    """
+
+    __tablename__ = "intangible_assets"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(120), index=True)
+    asset_tag: Mapped[str | None] = mapped_column(String(120), nullable=True, unique=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    acquired_on: Mapped[date] = mapped_column(Date)
+    acquisition_cost: Mapped[Decimal] = mapped_column(Numeric(14, 4))
+    salvage_value: Mapped[Decimal] = mapped_column(Numeric(14, 4), default=0)
+    useful_life_months: Mapped[int] = mapped_column(Integer)
+    amortization_method: Mapped[str] = mapped_column(String(30), default="straight_line")
+    declining_balance_rate: Mapped[Decimal | None] = mapped_column(Numeric(8, 6), nullable=True)
+    asset_account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"))
+    accumulated_amortization_account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"))
+    amortization_expense_account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"))
+    status: Mapped[str] = mapped_column(String(20), default="active", index=True)
+    disposed_on: Mapped[date | None] = mapped_column(Date, nullable=True)
+    disposal_proceeds: Mapped[Decimal | None] = mapped_column(Numeric(14, 4), nullable=True)
+    disposal_journal_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("journal_entries.id"), nullable=True
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    amortization_entries = relationship(
+        "AmortizationEntry",
+        back_populates="intangible_asset",
+        cascade="all, delete-orphan",
+    )
+
+
+class AmortizationEntry(Base):
+    __tablename__ = "amortization_entries"
+    __table_args__ = (
+        UniqueConstraint(
+            "intangible_asset_id", "period_end",
+            name="uq_amortization_entries_asset_period",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    intangible_asset_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("intangible_assets.id", ondelete="CASCADE"), index=True
+    )
+    period_end: Mapped[date] = mapped_column(Date, index=True)
+    amount: Mapped[Decimal] = mapped_column(Numeric(14, 4))
+    journal_entry_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("journal_entries.id")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    intangible_asset = relationship("IntangibleAsset", back_populates="amortization_entries")

--- a/backend/app/services/accounting_service.py
+++ b/backend/app/services/accounting_service.py
@@ -47,6 +47,12 @@ STARTER_CHART_OF_ACCOUNTS = [
     ("6710", "Loss on Disposal of Equipment", "expense", "debit"),
     # Expense claims (#251)
     ("2300", "Owner Reimbursable Liability", "liability", "credit"),
+    # Intangible assets (#252)
+    ("1800", "Intangible Assets", "asset", "debit"),
+    ("1850", "Accumulated Amortization", "asset", "credit"),
+    ("6750", "Amortization Expense", "expense", "debit"),
+    ("4920", "Gain on Disposal of Intangibles", "revenue", "credit"),
+    ("6760", "Loss on Disposal of Intangibles", "expense", "debit"),
 ]
 
 

--- a/backend/app/services/intangible_asset_service.py
+++ b/backend/app/services/intangible_asset_service.py
@@ -1,0 +1,322 @@
+"""Intangible asset register lifecycle (#252).
+
+Symmetric mirror of fixed_asset_service. Same straight-line and
+declining-balance math, same idempotent post-through-period semantics,
+same disposal flow with gain/loss accounting. Different field names
+(amortization vs depreciation) and different default COA accounts.
+"""
+
+from __future__ import annotations
+
+import calendar
+import uuid
+from datetime import date, datetime, timezone
+from decimal import ROUND_HALF_UP, Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.accounting_period import AccountingPeriod
+from app.models.intangible_asset import AmortizationEntry, IntangibleAsset
+from app.schemas.accounting import JournalEntryCreate, JournalLineCreate
+from app.services.accounting_service import (
+    AccountingValidationError,
+    create_journal_entry,
+)
+
+
+class IntangibleAssetError(RuntimeError):
+    pass
+
+
+CENTS = Decimal("0.01")
+
+
+def _q(value: Decimal) -> Decimal:
+    return Decimal(value).quantize(CENTS, rounding=ROUND_HALF_UP)
+
+
+def _last_day_of_month(d: date) -> date:
+    return date(d.year, d.month, calendar.monthrange(d.year, d.month)[1])
+
+
+def _add_months(d: date, n: int) -> date:
+    total = d.year * 12 + (d.month - 1) + n
+    y, m = divmod(total, 12)
+    return _last_day_of_month(date(y, m + 1, 1))
+
+
+def _planned_amounts_sl(asset: IntangibleAsset) -> list[Decimal]:
+    cost = Decimal(asset.acquisition_cost)
+    salvage = Decimal(asset.salvage_value or 0)
+    life = int(asset.useful_life_months)
+    monthly = _q((cost - salvage) / Decimal(life))
+    amounts = [monthly] * life
+    target = _q(cost - salvage)
+    diff = target - sum(amounts, Decimal("0"))
+    amounts[-1] = _q(amounts[-1] + diff)
+    return amounts
+
+
+def _planned_amounts_db(asset: IntangibleAsset) -> list[Decimal]:
+    cost = Decimal(asset.acquisition_cost)
+    salvage = Decimal(asset.salvage_value or 0)
+    life = int(asset.useful_life_months)
+    rate_annual = (
+        Decimal(asset.declining_balance_rate)
+        if asset.declining_balance_rate is not None
+        else Decimal(2) / (Decimal(life) / Decimal(12))
+    )
+    monthly_rate = rate_annual / Decimal(12)
+    amounts: list[Decimal] = []
+    book = cost
+    for i in range(life):
+        remaining_months = life - i
+        sl = _q((book - salvage) / Decimal(remaining_months))
+        db_amt = _q(book * monthly_rate)
+        amt = max(sl, db_amt)
+        amt = min(amt, _q(book - salvage))
+        amounts.append(amt)
+        book -= amt
+    target = _q(cost - salvage)
+    diff = target - sum(amounts, Decimal("0"))
+    amounts[-1] = _q(amounts[-1] + diff)
+    return amounts
+
+
+def planned_schedule(asset: IntangibleAsset) -> list[tuple[date, Decimal]]:
+    if asset.amortization_method == "declining_balance":
+        amounts = _planned_amounts_db(asset)
+    else:
+        amounts = _planned_amounts_sl(asset)
+    first_period = _last_day_of_month(asset.acquired_on)
+    out = []
+    for i, amt in enumerate(amounts):
+        out.append((_add_months(first_period, i), amt))
+    return out
+
+
+async def compute_book_value(db: AsyncSession, asset_id: uuid.UUID) -> Decimal:
+    asset = (await db.execute(select(IntangibleAsset).where(IntangibleAsset.id == asset_id))).scalar_one_or_none()
+    if asset is None:
+        raise IntangibleAssetError("Intangible asset not found")
+    posted = (
+        await db.execute(
+            select(AmortizationEntry).where(AmortizationEntry.intangible_asset_id == asset_id)
+        )
+    ).scalars().all()
+    accum = sum((Decimal(e.amount) for e in posted), Decimal("0"))
+    return _q(Decimal(asset.acquisition_cost) - accum)
+
+
+async def post_amortization(
+    db: AsyncSession,
+    *,
+    asset_id: uuid.UUID,
+    through: date,
+) -> list[AmortizationEntry]:
+    asset = (await db.execute(select(IntangibleAsset).where(IntangibleAsset.id == asset_id))).scalar_one_or_none()
+    if asset is None:
+        raise IntangibleAssetError("Intangible asset not found")
+    if asset.status == "disposed":
+        raise IntangibleAssetError("Cannot post amortization on a disposed asset")
+
+    schedule = planned_schedule(asset)
+    posted_periods = set(
+        (
+            await db.execute(
+                select(AmortizationEntry.period_end).where(
+                    AmortizationEntry.intangible_asset_id == asset_id
+                )
+            )
+        ).scalars().all()
+    )
+
+    new_entries: list[AmortizationEntry] = []
+    for period_end, amount in schedule:
+        if period_end > through:
+            break
+        if period_end in posted_periods:
+            continue
+        if amount <= 0:
+            continue
+
+        period_row = (
+            await db.execute(
+                select(AccountingPeriod).where(
+                    AccountingPeriod.start_date <= period_end,
+                    AccountingPeriod.end_date >= period_end,
+                )
+            )
+        ).scalar_one_or_none()
+        if period_row is not None and period_row.status != "open":
+            raise IntangibleAssetError(
+                f"Accounting period containing {period_end.isoformat()} is closed"
+            )
+
+        entry = await create_journal_entry(
+            db,
+            JournalEntryCreate(
+                entry_date=period_end,
+                accounting_period_id=period_row.id if period_row else None,
+                source_type="amortization",
+                source_id=str(asset.id),
+                memo=f"Amortization for {asset.name} — {period_end.isoformat()}",
+                lines=[
+                    JournalLineCreate(
+                        account_id=asset.amortization_expense_account_id,
+                        entry_type="debit",
+                        amount=amount,
+                        description=f"Amortization Expense — {asset.name}",
+                    ),
+                    JournalLineCreate(
+                        account_id=asset.accumulated_amortization_account_id,
+                        entry_type="credit",
+                        amount=amount,
+                        description=f"Accum. Amortization — {asset.name}",
+                    ),
+                ],
+            ),
+        )
+        ae = AmortizationEntry(
+            intangible_asset_id=asset.id,
+            period_end=period_end,
+            amount=amount,
+            journal_entry_id=entry.id,
+        )
+        db.add(ae)
+        new_entries.append(ae)
+
+    book = await compute_book_value(db, asset.id)
+    if book <= Decimal(asset.salvage_value or 0) and asset.status == "active":
+        asset.status = "fully_amortized"
+
+    await db.flush()
+    return new_entries
+
+
+async def dispose_asset(
+    db: AsyncSession,
+    *,
+    asset_id: uuid.UUID,
+    disposed_on: date,
+    proceeds: Decimal | None,
+    proceeds_account_id: uuid.UUID | None,
+    gain_account_id: uuid.UUID,
+    loss_account_id: uuid.UUID,
+) -> IntangibleAsset:
+    asset = (await db.execute(select(IntangibleAsset).where(IntangibleAsset.id == asset_id))).scalar_one_or_none()
+    if asset is None:
+        raise IntangibleAssetError("Intangible asset not found")
+    if asset.status == "disposed":
+        raise IntangibleAssetError("Asset is already disposed")
+
+    proceeds = Decimal(proceeds or 0)
+    if proceeds < 0:
+        raise IntangibleAssetError("Disposal proceeds must be non-negative")
+    if proceeds > 0 and proceeds_account_id is None:
+        raise IntangibleAssetError("proceeds_account_id required when proceeds > 0")
+
+    await post_amortization(db, asset_id=asset.id, through=disposed_on)
+
+    posted_total = Decimal("0")
+    for e in (
+        await db.execute(
+            select(AmortizationEntry).where(AmortizationEntry.intangible_asset_id == asset.id)
+        )
+    ).scalars().all():
+        posted_total += Decimal(e.amount)
+
+    cost = Decimal(asset.acquisition_cost)
+    book_value = _q(cost - posted_total)
+    accumulated = _q(posted_total)
+    proceeds_q = _q(proceeds)
+    delta = _q(proceeds_q - book_value)
+
+    lines = [
+        JournalLineCreate(
+            account_id=asset.asset_account_id,
+            entry_type="credit",
+            amount=cost,
+            description=f"Dispose {asset.name} — original cost",
+        ),
+    ]
+    if accumulated > 0:
+        lines.append(
+            JournalLineCreate(
+                account_id=asset.accumulated_amortization_account_id,
+                entry_type="debit",
+                amount=accumulated,
+                description=f"Dispose {asset.name} — accumulated amortization",
+            )
+        )
+    if proceeds_q > 0:
+        assert proceeds_account_id is not None
+        lines.append(
+            JournalLineCreate(
+                account_id=proceeds_account_id,
+                entry_type="debit",
+                amount=proceeds_q,
+                description=f"Dispose {asset.name} — proceeds",
+            )
+        )
+    if delta > 0:
+        lines.append(
+            JournalLineCreate(
+                account_id=gain_account_id,
+                entry_type="credit",
+                amount=delta,
+                description=f"Gain on disposal of {asset.name}",
+            )
+        )
+    elif delta < 0:
+        lines.append(
+            JournalLineCreate(
+                account_id=loss_account_id,
+                entry_type="debit",
+                amount=-delta,
+                description=f"Loss on disposal of {asset.name}",
+            )
+        )
+
+    period_row = (
+        await db.execute(
+            select(AccountingPeriod).where(
+                AccountingPeriod.start_date <= disposed_on,
+                AccountingPeriod.end_date >= disposed_on,
+            )
+        )
+    ).scalar_one_or_none()
+    if period_row is not None and period_row.status != "open":
+        raise IntangibleAssetError("Accounting period for disposal date is closed")
+
+    try:
+        entry = await create_journal_entry(
+            db,
+            JournalEntryCreate(
+                entry_date=disposed_on,
+                accounting_period_id=period_row.id if period_row else None,
+                source_type="intangible_asset_disposal",
+                source_id=str(asset.id),
+                memo=f"Disposal of {asset.name}",
+                lines=lines,
+            ),
+        )
+    except AccountingValidationError as e:
+        raise IntangibleAssetError(str(e)) from e
+
+    asset.status = "disposed"
+    asset.disposed_on = disposed_on
+    asset.disposal_proceeds = proceeds_q if proceeds_q > 0 else None
+    asset.disposal_journal_entry_id = entry.id
+    await db.flush()
+    return asset
+
+
+async def can_edit_critical_fields(db: AsyncSession, asset_id: uuid.UUID) -> bool:
+    posted = (
+        await db.execute(
+            select(AmortizationEntry).where(AmortizationEntry.intangible_asset_id == asset_id).limit(1)
+        )
+    ).scalar_one_or_none()
+    return posted is None

--- a/backend/tests/test_intangible_asset_service.py
+++ b/backend/tests/test_intangible_asset_service.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.intangible_asset import IntangibleAsset
+from app.services.intangible_asset_service import (
+    IntangibleAssetError,
+    can_edit_critical_fields,
+    compute_book_value,
+    dispose_asset,
+    planned_schedule,
+    post_amortization,
+)
+
+
+async def _accounts(db_session):
+    return {a.code: a for a in (await db_session.execute(select(Account))).scalars().all()}
+
+
+async def _make_asset(
+    db_session,
+    *,
+    cost="1200",
+    salvage="0",
+    life_months=12,
+    method="straight_line",
+    rate=None,
+    acquired_on=None,
+):
+    accts = await _accounts(db_session)
+    asset = IntangibleAsset(
+        name="CAD subscription",
+        acquired_on=acquired_on or datetime.date(2026, 1, 15),
+        acquisition_cost=Decimal(cost),
+        salvage_value=Decimal(salvage),
+        useful_life_months=life_months,
+        amortization_method=method,
+        declining_balance_rate=Decimal(rate) if rate is not None else None,
+        asset_account_id=accts["1800"].id,
+        accumulated_amortization_account_id=accts["1850"].id,
+        amortization_expense_account_id=accts["6750"].id,
+    )
+    db_session.add(asset)
+    await db_session.flush()
+    return asset
+
+
+@pytest.mark.asyncio
+async def test_sl_schedule_sums_to_cost(db_session):
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    sched = planned_schedule(a)
+    assert len(sched) == 12
+    total = sum((amt for _, amt in sched), Decimal("0"))
+    assert total == Decimal("1200.00")
+
+
+@pytest.mark.asyncio
+async def test_db_schedule_front_loaded(db_session):
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=24, method="declining_balance")
+    sched = planned_schedule(a)
+    assert sched[0][1] > sched[-1][1]
+    total = sum((amt for _, amt in sched), Decimal("0"))
+    assert total == Decimal("1200.00")
+
+
+@pytest.mark.asyncio
+async def test_post_then_book_value(db_session):
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    new_entries = await post_amortization(db_session, asset_id=a.id, through=datetime.date(2026, 4, 30))
+    assert len(new_entries) == 4
+    book = await compute_book_value(db_session, a.id)
+    assert book == Decimal("800.00")
+
+
+@pytest.mark.asyncio
+async def test_idempotent_reposting(db_session):
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    await post_amortization(db_session, asset_id=a.id, through=datetime.date(2026, 4, 30))
+    new = await post_amortization(db_session, asset_id=a.id, through=datetime.date(2026, 4, 30))
+    assert new == []
+
+
+@pytest.mark.asyncio
+async def test_full_life_reaches_salvage(db_session):
+    a = await _make_asset(db_session, cost="1200", salvage="200", life_months=12)
+    await post_amortization(db_session, asset_id=a.id, through=datetime.date(2027, 12, 31))
+    assert (await compute_book_value(db_session, a.id)) == Decimal("200.00")
+    refreshed = (await db_session.execute(select(IntangibleAsset).where(IntangibleAsset.id == a.id))).scalar_one()
+    assert refreshed.status == "fully_amortized"
+
+
+@pytest.mark.asyncio
+async def test_critical_fields_locked_after_first_post(db_session):
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    assert await can_edit_critical_fields(db_session, a.id) is True
+    await post_amortization(db_session, asset_id=a.id, through=datetime.date(2026, 1, 31))
+    assert await can_edit_critical_fields(db_session, a.id) is False
+
+
+@pytest.mark.asyncio
+async def test_dispose_with_gain(db_session):
+    accts = await _accounts(db_session)
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    await post_amortization(db_session, asset_id=a.id, through=datetime.date(2026, 3, 31))
+    asset = await dispose_asset(
+        db_session,
+        asset_id=a.id,
+        disposed_on=datetime.date(2026, 3, 31),
+        proceeds=Decimal("1000"),
+        proceeds_account_id=accts["1000"].id,
+        gain_account_id=accts["4920"].id,
+        loss_account_id=accts["6760"].id,
+    )
+    assert asset.status == "disposed"
+
+
+@pytest.mark.asyncio
+async def test_dispose_with_no_proceeds_loss(db_session):
+    accts = await _accounts(db_session)
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    asset = await dispose_asset(
+        db_session,
+        asset_id=a.id,
+        disposed_on=datetime.date(2026, 6, 30),
+        proceeds=None,
+        proceeds_account_id=None,
+        gain_account_id=accts["4920"].id,
+        loss_account_id=accts["6760"].id,
+    )
+    assert asset.status == "disposed"
+
+
+@pytest.mark.asyncio
+async def test_cannot_dispose_already_disposed(db_session):
+    accts = await _accounts(db_session)
+    a = await _make_asset(db_session, cost="1200", salvage="0", life_months=12)
+    await dispose_asset(
+        db_session,
+        asset_id=a.id,
+        disposed_on=datetime.date(2026, 3, 31),
+        proceeds=None,
+        proceeds_account_id=None,
+        gain_account_id=accts["4920"].id,
+        loss_account_id=accts["6760"].id,
+    )
+    with pytest.raises(IntangibleAssetError):
+        await dispose_asset(
+            db_session,
+            asset_id=a.id,
+            disposed_on=datetime.date(2026, 4, 30),
+            proceeds=None,
+            proceeds_account_id=None,
+            gain_account_id=accts["4920"].id,
+            loss_account_id=accts["6760"].id,
+        )

--- a/docs/intangible_assets.md
+++ b/docs/intangible_assets.md
@@ -1,0 +1,33 @@
+# Intangible Assets
+
+Symmetric mirror of [docs/fixed_assets.md](fixed_assets.md) for intangibles — CAD/slicer subscriptions, asset packs, brand/domain purchases, multi-year listing fees. #252.
+
+## What's the same
+
+- **Models**: `IntangibleAsset` + `AmortizationEntry` mirror `FixedAsset` + `DepreciationEntry`.
+- **Math**: identical SL and DDB schedule generation with SL crossover.
+- **Posting**: idempotent through a chosen month-end via `POST /api/v1/intangible-assets/post-amortization`.
+- **Disposal**: same flow — post pending, then Cr asset / Dr accumulated / Dr cash / gain-or-loss.
+- **Edit-lock**: critical fields immutable after first amortization post.
+
+## What's different
+
+- **Field naming**: `amortization_method`, `amortization_expense_account_id`, `accumulated_amortization_account_id`. (FA uses `depreciation_*`.)
+- **No printer link**: intangibles aren't equipment.
+- **Account codes** (auto-seeded by migration `20260509_10`):
+  - `1800` Intangible Assets
+  - `1850` Accumulated Amortization
+  - `6750` Amortization Expense
+  - `4920` Gain on Disposal of Intangibles
+  - `6760` Loss on Disposal of Intangibles
+
+## API
+
+`/api/v1/intangible-assets` mirrors `/api/v1/fixed-assets` exactly — `list`, `create`, detail (with schedule), `patch`, `post-amortization`, `dispose`, `delete`.
+
+## Phase 2 follow-ups
+
+- Auto-monthly cron (n8n) — same gap as #238's Phase 2.
+- Frontend `/finance/intangible-assets` route.
+- Bulk import from prior accounting system.
+- Tax-method amortization parallel to book.


### PR DESCRIPTION
Closes #252. Symmetric mirror of #238 for intangibles. Same SL+DDB math, posting, and disposal flow. 5 new COA accounts auto-seeded. 378 tests pass (369 + 9 new). Doc: `docs/intangible_assets.md`.