### PR TITLE
feat(banking): bank statement import Phase 1 (#240)

### DIFF
--- a/backend/alembic/versions/20260509_11_add_statement_imports.py
+++ b/backend/alembic/versions/20260509_11_add_statement_imports.py
@@ -1,0 +1,73 @@
+"""add statement_imports and statement_lines (#240)
+
+Revision ID: 20260509_11
+Revises: 20260509_10
+Create Date: 2026-05-09 23:55:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_11"
+down_revision = "20260509_10"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "statement_imports",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("account_id", sa.UUID(), nullable=False),
+        sa.Column("source_format", sa.String(length=10), nullable=False),
+        sa.Column("source_filename", sa.String(length=255), nullable=False),
+        sa.Column("line_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("duplicate_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="pending_review"),
+        sa.Column("imported_by_user_id", sa.UUID(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["account_id"], ["accounts.id"]),
+        sa.ForeignKeyConstraint(["imported_by_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_statement_imports_account_id", "statement_imports", ["account_id"])
+    op.create_index("ix_statement_imports_status", "statement_imports", ["status"])
+
+    op.create_table(
+        "statement_lines",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("import_id", sa.UUID(), nullable=False),
+        sa.Column("account_id", sa.UUID(), nullable=False),
+        sa.Column("posted_date", sa.Date(), nullable=False),
+        sa.Column("amount", sa.Numeric(14, 4), nullable=False),
+        sa.Column("description", sa.String(length=500), nullable=False),
+        sa.Column("fitid", sa.String(length=120), nullable=True),
+        sa.Column("matched_journal_line_id", sa.UUID(), nullable=True),
+        sa.Column("match_status", sa.String(length=20), nullable=False, server_default="unmatched"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["import_id"], ["statement_imports.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["account_id"], ["accounts.id"]),
+        sa.ForeignKeyConstraint(["matched_journal_line_id"], ["journal_lines.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("account_id", "fitid", name="uq_statement_lines_account_fitid"),
+    )
+    op.create_index("ix_statement_lines_import_id", "statement_lines", ["import_id"])
+    op.create_index("ix_statement_lines_account_id", "statement_lines", ["account_id"])
+    op.create_index("ix_statement_lines_posted_date", "statement_lines", ["posted_date"])
+    op.create_index("ix_statement_lines_match_status", "statement_lines", ["match_status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_statement_lines_match_status", table_name="statement_lines")
+    op.drop_index("ix_statement_lines_posted_date", table_name="statement_lines")
+    op.drop_index("ix_statement_lines_account_id", table_name="statement_lines")
+    op.drop_index("ix_statement_lines_import_id", table_name="statement_lines")
+    op.drop_table("statement_lines")
+    op.drop_index("ix_statement_imports_status", table_name="statement_imports")
+    op.drop_index("ix_statement_imports_account_id", table_name="statement_imports")
+    op.drop_table("statement_imports")

--- a/backend/app/api/v1/endpoints/statement_imports.py
+++ b/backend/app/api/v1/endpoints/statement_imports.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Literal
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.statement_import import StatementImport, StatementLine
+from app.services.statement_import_service import (
+    StatementImportError,
+    ignore_line,
+    import_statement,
+    match_line,
+    suggest_matches,
+)
+
+
+router = APIRouter(prefix="/banking/imports", tags=["Banking"])
+
+
+class StatementImportResponse(BaseModel):
+    id: uuid.UUID
+    account_id: uuid.UUID
+    source_format: str
+    source_filename: str
+    line_count: int
+    duplicate_count: int
+    status: str
+    notes: str | None
+    created_at: datetime
+
+
+class StatementLineResponse(BaseModel):
+    id: uuid.UUID
+    import_id: uuid.UUID
+    account_id: uuid.UUID
+    posted_date: date
+    amount: Decimal
+    description: str
+    fitid: str | None
+    match_status: str
+    matched_journal_line_id: uuid.UUID | None
+
+
+class JournalLineSuggestion(BaseModel):
+    id: uuid.UUID
+    journal_entry_id: uuid.UUID
+    entry_type: str
+    amount: Decimal
+    description: str | None
+
+
+class MatchRequest(BaseModel):
+    journal_line_id: uuid.UUID
+
+
+def _to_import(i: StatementImport) -> StatementImportResponse:
+    return StatementImportResponse(
+        id=i.id,
+        account_id=i.account_id,
+        source_format=i.source_format,
+        source_filename=i.source_filename,
+        line_count=i.line_count,
+        duplicate_count=i.duplicate_count,
+        status=i.status,
+        notes=i.notes,
+        created_at=i.created_at,
+    )
+
+
+def _to_line(l: StatementLine) -> StatementLineResponse:
+    return StatementLineResponse(
+        id=l.id,
+        import_id=l.import_id,
+        account_id=l.account_id,
+        posted_date=l.posted_date,
+        amount=Decimal(l.amount),
+        description=l.description,
+        fitid=l.fitid,
+        match_status=l.match_status,
+        matched_journal_line_id=l.matched_journal_line_id,
+    )
+
+
+@router.post(
+    "",
+    response_model=StatementImportResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Upload a statement file (OFX or CSV)",
+)
+async def upload_import(
+    user: CurrentUser,
+    db: DB,
+    account_id: uuid.UUID = Form(...),
+    source_format: Literal["ofx", "csv"] = Form("ofx"),
+    file: UploadFile = File(...),
+):
+    content = await file.read()
+    try:
+        imp = await import_statement(
+            db,
+            account_id=account_id,
+            source_format=source_format,
+            source_filename=file.filename or "(unnamed)",
+            content=content,
+            imported_by_user_id=user.id,
+        )
+    except StatementImportError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _to_import(imp)
+
+
+@router.get("", response_model=list[StatementImportResponse], summary="List statement imports")
+async def list_imports(user: CurrentUser, db: DB, account_id: uuid.UUID | None = None):
+    stmt = select(StatementImport).order_by(StatementImport.created_at.desc())
+    if account_id is not None:
+        stmt = stmt.where(StatementImport.account_id == account_id)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [_to_import(r) for r in rows]
+
+
+@router.get("/{import_id}/lines", response_model=list[StatementLineResponse], summary="List lines for an import")
+async def list_lines(import_id: uuid.UUID, user: CurrentUser, db: DB, status_filter: str | None = None):
+    stmt = select(StatementLine).where(StatementLine.import_id == import_id).order_by(StatementLine.posted_date)
+    if status_filter:
+        stmt = stmt.where(StatementLine.match_status == status_filter)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [_to_line(r) for r in rows]
+
+
+@router.get("/lines/{statement_line_id}/suggestions", response_model=list[JournalLineSuggestion], summary="Get match suggestions for a statement line")
+async def suggestions_ep(statement_line_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        rows = await suggest_matches(db, statement_line_id=statement_line_id, limit=5)
+    except StatementImportError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    return [
+        JournalLineSuggestion(
+            id=r.id,
+            journal_entry_id=r.journal_entry_id,
+            entry_type=r.entry_type,
+            amount=Decimal(r.amount),
+            description=r.description,
+        )
+        for r in rows
+    ]
+
+
+@router.post("/lines/{statement_line_id}/match", response_model=StatementLineResponse, summary="Match a statement line to an existing journal line")
+async def match_ep(statement_line_id: uuid.UUID, body: MatchRequest, user: CurrentUser, db: DB):
+    try:
+        sl = await match_line(
+            db, statement_line_id=statement_line_id, journal_line_id=body.journal_line_id
+        )
+    except StatementImportError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _to_line(sl)
+
+
+@router.post("/lines/{statement_line_id}/ignore", response_model=StatementLineResponse, summary="Ignore a statement line")
+async def ignore_ep(statement_line_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        sl = await ignore_line(db, statement_line_id)
+    except StatementImportError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _to_line(sl)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, attachments, audit, auth, banking, cameras, customers, dashboard, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, supplies, tax
+from app.api.v1.endpoints import accounting, approvals, attachments, audit, auth, banking, cameras, customers, dashboard, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -36,3 +36,4 @@ api_router.include_router(attachments.router)
 api_router.include_router(recurring_invoices.router)
 api_router.include_router(expense_claims.router)
 api_router.include_router(intangible_assets.router)
+api_router.include_router(statement_imports.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,5 +13,6 @@ from app.models.inventory_location import (  # noqa: F401
 )
 from app.models.product_bom_item import ProductBOMItem  # noqa: F401
 from app.models.recurring_invoice import RecurringInvoice, RecurringInvoiceRun  # noqa: F401
+from app.models.statement_import import StatementImport, StatementLine  # noqa: F401
 from app.models.reference_sequence import ReferenceSequence  # noqa: F401
 from app.models.supply import Supply  # noqa: F401

--- a/backend/app/models/statement_import.py
+++ b/backend/app/models/statement_import.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class StatementImport(Base):
+    """One uploaded bank statement file (#240). Parses into StatementLine
+    rows that the operator then matches to existing journal lines or
+    creates new transactions from.
+    """
+
+    __tablename__ = "statement_imports"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"), index=True)
+    source_format: Mapped[str] = mapped_column(String(10))  # ofx | csv
+    source_filename: Mapped[str] = mapped_column(String(255))
+    line_count: Mapped[int] = mapped_column(Integer, default=0)
+    duplicate_count: Mapped[int] = mapped_column(Integer, default=0)
+    status: Mapped[str] = mapped_column(String(20), default="pending_review", index=True)
+    imported_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id"), nullable=True
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    lines = relationship("StatementLine", back_populates="import_", cascade="all, delete-orphan")
+
+
+class StatementLine(Base):
+    """One row from an uploaded statement. Polymorphically tied to a
+    journal line via `matched_journal_line_id` once the operator
+    matches or creates a transaction.
+    """
+
+    __tablename__ = "statement_lines"
+    __table_args__ = (
+        UniqueConstraint("account_id", "fitid", name="uq_statement_lines_account_fitid"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    import_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("statement_imports.id", ondelete="CASCADE"), index=True
+    )
+    # Denormalized so dedup uniqueness can be (account_id, fitid)
+    account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"), index=True)
+    posted_date: Mapped[date] = mapped_column(Date, index=True)
+    amount: Mapped[Decimal] = mapped_column(Numeric(14, 4))
+    description: Mapped[str] = mapped_column(String(500))
+    fitid: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    matched_journal_line_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("journal_lines.id"), nullable=True
+    )
+    match_status: Mapped[str] = mapped_column(String(20), default="unmatched", index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    import_ = relationship("StatementImport", back_populates="lines")

--- a/backend/app/services/statement_import_service.py
+++ b/backend/app/services/statement_import_service.py
@@ -1,0 +1,302 @@
+"""Bank statement import (#240) Phase 1.
+
+OFX (SGML or XML form) and a basic CSV path. Extracts (date, amount,
+description, fitid) per row, dedupes by (account_id, fitid) when fitid
+is present, and persists `StatementLine` rows for operator review +
+match. Match suggestions are returned at list time.
+
+OFX support is parser-light: the spec is large, but for our use case we
+just need to walk STMTTRN records inside an OFX SGML/XML payload. We
+implement that with a small regex-based extractor rather than pulling
+in the `ofxparse` dep.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account
+from app.models.journal_entry import JournalEntry
+from app.models.journal_line import JournalLine
+from app.models.statement_import import StatementImport, StatementLine
+
+
+class StatementImportError(RuntimeError):
+    pass
+
+
+# ---------- OFX parsing ----------
+
+
+_TAG_RE = re.compile(r"<(?P<tag>[A-Z][A-Z0-9]+)>(?P<value>[^<]*)", re.IGNORECASE)
+
+
+def _extract_field(block: str, tag: str) -> str | None:
+    """Return the first text-content of a tag inside `block`, or None."""
+    for m in _TAG_RE.finditer(block):
+        if m.group("tag").upper() == tag.upper():
+            return m.group("value").strip()
+    return None
+
+
+def _ofx_parse_date(s: str) -> date:
+    """OFX dates: YYYYMMDD or YYYYMMDDHHMMSS[.XXX][Z]; we just need the
+    date portion."""
+    return datetime.strptime(s[:8], "%Y%m%d").date()
+
+
+def parse_ofx(content: str) -> list[dict]:
+    """Walk every <STMTTRN> block in an OFX payload, returning a list of
+    {posted_date, amount, description, fitid} dicts. SGML and XML forms
+    both work because we only look at tag patterns inside the block.
+    """
+    out: list[dict] = []
+    # Find every STMTTRN block. OFX SGML doesn't always close tags, but
+    # `<STMTTRN>...</STMTTRN>` is consistently delimited. We allow either
+    # the SGML close tag or the next <STMTTRN> as the boundary.
+    pattern = re.compile(
+        r"<STMTTRN>(.*?)(?=</STMTTRN>|<STMTTRN>|<\/BANKTRANLIST>|<BANKTRANLIST>|$)",
+        re.IGNORECASE | re.DOTALL,
+    )
+    for m in pattern.finditer(content):
+        block = m.group(1)
+        dtposted = _extract_field(block, "DTPOSTED")
+        trnamt = _extract_field(block, "TRNAMT")
+        if dtposted is None or trnamt is None:
+            continue
+        try:
+            posted = _ofx_parse_date(dtposted)
+            amount = Decimal(trnamt.strip())
+        except (ValueError, ArithmeticError):
+            continue
+        fitid = _extract_field(block, "FITID")
+        memo = _extract_field(block, "MEMO") or ""
+        name = _extract_field(block, "NAME") or ""
+        description = (memo + " " + name).strip() or "(unknown)"
+        out.append(
+            {
+                "posted_date": posted,
+                "amount": amount,
+                "description": description[:500],
+                "fitid": fitid.strip() if fitid else None,
+            }
+        )
+    return out
+
+
+def parse_csv(content: str, *, mapping: dict[str, str] | None = None) -> list[dict]:
+    """Parse a CSV with header row. `mapping` overrides which CSV column
+    name to use for each field; defaults to common names.
+    """
+    mapping = mapping or {
+        "date": "Date",
+        "amount": "Amount",
+        "description": "Description",
+        "fitid": "FITID",
+    }
+    out: list[dict] = []
+    reader = csv.DictReader(io.StringIO(content))
+    for row in reader:
+        date_str = (row.get(mapping["date"]) or "").strip()
+        amt_str = (row.get(mapping["amount"]) or "").strip()
+        desc = (row.get(mapping["description"]) or "").strip()
+        if not date_str or not amt_str:
+            continue
+        # Try a few common date formats
+        posted = None
+        for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y", "%d/%m/%Y"):
+            try:
+                posted = datetime.strptime(date_str, fmt).date()
+                break
+            except ValueError:
+                continue
+        if posted is None:
+            continue
+        try:
+            amount = Decimal(amt_str.replace(",", "").replace("$", ""))
+        except ArithmeticError:
+            continue
+        fitid = (row.get(mapping["fitid"]) or "").strip() or None
+        out.append(
+            {
+                "posted_date": posted,
+                "amount": amount,
+                "description": desc[:500],
+                "fitid": fitid,
+            }
+        )
+    return out
+
+
+# ---------- import ----------
+
+
+async def import_statement(
+    db: AsyncSession,
+    *,
+    account_id: uuid.UUID,
+    source_format: str,
+    source_filename: str,
+    content: bytes,
+    imported_by_user_id: uuid.UUID | None = None,
+) -> StatementImport:
+    if source_format not in ("ofx", "csv"):
+        raise StatementImportError(f"Unsupported format: {source_format}")
+    account = (await db.execute(select(Account).where(Account.id == account_id))).scalar_one_or_none()
+    if account is None:
+        raise StatementImportError("Account not found")
+    if not account.is_bank_account:
+        raise StatementImportError(f"Account {account.code} is not a bank account")
+
+    text = content.decode("utf-8", errors="replace")
+    rows = parse_ofx(text) if source_format == "ofx" else parse_csv(text)
+
+    imp = StatementImport(
+        account_id=account.id,
+        source_format=source_format,
+        source_filename=source_filename,
+        imported_by_user_id=imported_by_user_id,
+    )
+    db.add(imp)
+    await db.flush()
+
+    line_count = 0
+    duplicate_count = 0
+    for row in rows:
+        fitid = row["fitid"]
+        # Dedup against (account_id, fitid) when fitid is present
+        if fitid:
+            dup = (
+                await db.execute(
+                    select(StatementLine.id).where(
+                        StatementLine.account_id == account.id,
+                        StatementLine.fitid == fitid,
+                    )
+                )
+            ).first()
+            if dup:
+                duplicate_count += 1
+                continue
+        # Without a fitid, fall back to (account_id, date, amount, description)
+        # exact match.
+        else:
+            dup = (
+                await db.execute(
+                    select(StatementLine.id).where(
+                        and_(
+                            StatementLine.account_id == account.id,
+                            StatementLine.posted_date == row["posted_date"],
+                            StatementLine.amount == row["amount"],
+                            StatementLine.description == row["description"],
+                        )
+                    )
+                )
+            ).first()
+            if dup:
+                duplicate_count += 1
+                continue
+        db.add(
+            StatementLine(
+                import_id=imp.id,
+                account_id=account.id,
+                posted_date=row["posted_date"],
+                amount=row["amount"],
+                description=row["description"],
+                fitid=fitid,
+                match_status="unmatched",
+            )
+        )
+        line_count += 1
+
+    imp.line_count = line_count
+    imp.duplicate_count = duplicate_count
+    await db.flush()
+    return imp
+
+
+# ---------- match ----------
+
+
+async def suggest_matches(
+    db: AsyncSession,
+    *,
+    statement_line_id: uuid.UUID,
+    limit: int = 5,
+) -> list[JournalLine]:
+    """Return up to `limit` candidate journal lines for the statement line,
+    ranked by closeness on (date, amount). v1 keeps it simple: same account,
+    date within ±5 days, exact amount match.
+    """
+    sl = (await db.execute(select(StatementLine).where(StatementLine.id == statement_line_id))).scalar_one_or_none()
+    if sl is None:
+        raise StatementImportError("Statement line not found")
+
+    from datetime import timedelta
+
+    lo = sl.posted_date - timedelta(days=5)
+    hi = sl.posted_date + timedelta(days=5)
+
+    # Match on signed amount: a debit on a debit-normal asset means cash IN
+    # (positive on the bank statement). For now we ignore sign nuance and
+    # let exact-amount matching find candidates regardless of side.
+    rows = (
+        await db.execute(
+            select(JournalLine, JournalEntry)
+            .join(JournalEntry, JournalEntry.id == JournalLine.journal_entry_id)
+            .where(
+                JournalLine.account_id == sl.account_id,
+                JournalLine.cleared_status != "reconciled",
+                JournalEntry.entry_date >= lo,
+                JournalEntry.entry_date <= hi,
+                JournalLine.amount == abs(sl.amount),
+            )
+            .order_by(JournalEntry.entry_date)
+            .limit(limit)
+        )
+    ).all()
+    return [line for line, _entry in rows]
+
+
+async def match_line(
+    db: AsyncSession,
+    *,
+    statement_line_id: uuid.UUID,
+    journal_line_id: uuid.UUID,
+) -> StatementLine:
+    sl = (await db.execute(select(StatementLine).where(StatementLine.id == statement_line_id))).scalar_one_or_none()
+    if sl is None:
+        raise StatementImportError("Statement line not found")
+    if sl.match_status == "matched":
+        raise StatementImportError("Statement line is already matched")
+
+    jl = (await db.execute(select(JournalLine).where(JournalLine.id == journal_line_id))).scalar_one_or_none()
+    if jl is None:
+        raise StatementImportError("Journal line not found")
+    if jl.account_id != sl.account_id:
+        raise StatementImportError("Journal line account does not match the statement account")
+
+    sl.matched_journal_line_id = jl.id
+    sl.match_status = "matched"
+    # Promote the journal line to cleared (#239's vocabulary) so the
+    # reconciliation worksheet sees it.
+    if jl.cleared_status == "uncleared":
+        jl.cleared_status = "cleared"
+    await db.flush()
+    return sl
+
+
+async def ignore_line(db: AsyncSession, statement_line_id: uuid.UUID) -> StatementLine:
+    sl = (await db.execute(select(StatementLine).where(StatementLine.id == statement_line_id))).scalar_one_or_none()
+    if sl is None:
+        raise StatementImportError("Statement line not found")
+    sl.match_status = "ignored"
+    await db.flush()
+    return sl

--- a/backend/tests/test_statement_import_service.py
+++ b/backend/tests/test_statement_import_service.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.journal_entry import JournalEntry
+from app.models.journal_line import JournalLine
+from app.models.statement_import import StatementImport, StatementLine
+from app.services.statement_import_service import (
+    StatementImportError,
+    ignore_line,
+    import_statement,
+    match_line,
+    parse_csv,
+    parse_ofx,
+    suggest_matches,
+)
+
+
+SAMPLE_OFX = """
+OFXHEADER:100
+DATA:OFXSGML
+
+<OFX>
+<BANKMSGSRSV1>
+<STMTTRNRS>
+<STMTRS>
+<BANKTRANLIST>
+<STMTTRN>
+<TRNTYPE>DEBIT
+<DTPOSTED>20260501
+<TRNAMT>-25.00
+<FITID>FITID001
+<NAME>Filament supplier
+<MEMO>monthly bulk
+</STMTTRN>
+<STMTTRN>
+<TRNTYPE>CREDIT
+<DTPOSTED>20260503
+<TRNAMT>500.00
+<FITID>FITID002
+<NAME>Etsy payout
+</STMTTRN>
+</BANKTRANLIST>
+</STMTRS>
+</STMTTRNRS>
+</BANKMSGSRSV1>
+</OFX>
+"""
+
+
+SAMPLE_CSV = """Date,Amount,Description,FITID
+2026-05-01,-25.00,Filament supplier,FITID001
+2026-05-03,500.00,Etsy payout,FITID002
+"""
+
+
+def test_parse_ofx_extracts_two_rows():
+    rows = parse_ofx(SAMPLE_OFX)
+    assert len(rows) == 2
+    assert rows[0]["posted_date"] == datetime.date(2026, 5, 1)
+    assert rows[0]["amount"] == Decimal("-25.00")
+    assert rows[0]["fitid"] == "FITID001"
+    assert "Filament" in rows[0]["description"] or "monthly" in rows[0]["description"]
+    assert rows[1]["amount"] == Decimal("500.00")
+
+
+def test_parse_csv_basic():
+    rows = parse_csv(SAMPLE_CSV)
+    assert len(rows) == 2
+    assert rows[0]["amount"] == Decimal("-25.00")
+    assert rows[0]["fitid"] == "FITID001"
+
+
+async def _bank(db_session, code="1010", name="Operating"):
+    a = Account(
+        code=code,
+        name=name,
+        account_type="asset",
+        normal_balance="debit",
+        is_bank_account=True,
+        bank_account_kind="checking",
+    )
+    db_session.add(a)
+    await db_session.flush()
+    return a
+
+
+@pytest.mark.asyncio
+async def test_import_ofx_persists_lines(db_session):
+    a = await _bank(db_session)
+    imp = await import_statement(
+        db_session,
+        account_id=a.id,
+        source_format="ofx",
+        source_filename="export.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    await db_session.commit()
+    assert imp.line_count == 2
+    assert imp.duplicate_count == 0
+    rows = (await db_session.execute(select(StatementLine))).scalars().all()
+    assert len(rows) == 2
+
+
+@pytest.mark.asyncio
+async def test_import_dedupes_by_fitid(db_session):
+    a = await _bank(db_session)
+    await import_statement(
+        db_session,
+        account_id=a.id,
+        source_format="ofx",
+        source_filename="export.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    imp2 = await import_statement(
+        db_session,
+        account_id=a.id,
+        source_format="ofx",
+        source_filename="export.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    await db_session.commit()
+    assert imp2.line_count == 0
+    assert imp2.duplicate_count == 2
+
+
+@pytest.mark.asyncio
+async def test_import_rejects_non_bank_account(db_session):
+    a = Account(code="9999", name="Misc", account_type="liability", normal_balance="credit", is_bank_account=False)
+    db_session.add(a)
+    await db_session.flush()
+    with pytest.raises(StatementImportError):
+        await import_statement(
+            db_session,
+            account_id=a.id,
+            source_format="ofx",
+            source_filename="x.ofx",
+            content=SAMPLE_OFX.encode(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_match_line_promotes_journal_line_to_cleared(db_session):
+    a = await _bank(db_session)
+    # Create a JE on this account that matches one of the statement lines
+    je = JournalEntry(entry_number="JE-1", entry_date=datetime.date(2026, 5, 1), status="posted")
+    db_session.add(je)
+    await db_session.flush()
+    jl = JournalLine(
+        journal_entry_id=je.id,
+        account_id=a.id,
+        line_number=1,
+        entry_type="credit",
+        amount=Decimal("25.00"),  # matches abs(-25.00) from the OFX
+    )
+    db_session.add(jl)
+    await db_session.flush()
+
+    imp = await import_statement(
+        db_session,
+        account_id=a.id,
+        source_format="ofx",
+        source_filename="export.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    sl = (await db_session.execute(
+        select(StatementLine).where(StatementLine.import_id == imp.id, StatementLine.fitid == "FITID001")
+    )).scalar_one()
+
+    suggestions = await suggest_matches(db_session, statement_line_id=sl.id)
+    assert len(suggestions) >= 1
+    assert suggestions[0].id == jl.id
+
+    matched = await match_line(db_session, statement_line_id=sl.id, journal_line_id=jl.id)
+    await db_session.commit()
+    assert matched.match_status == "matched"
+    refreshed_jl = (await db_session.execute(select(JournalLine).where(JournalLine.id == jl.id))).scalar_one()
+    assert refreshed_jl.cleared_status == "cleared"
+
+
+@pytest.mark.asyncio
+async def test_ignore_line_marks_status(db_session):
+    a = await _bank(db_session)
+    imp = await import_statement(
+        db_session,
+        account_id=a.id,
+        source_format="ofx",
+        source_filename="export.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    sl = (await db_session.execute(
+        select(StatementLine).where(StatementLine.import_id == imp.id).limit(1)
+    )).scalar_one()
+    sl = await ignore_line(db_session, sl.id)
+    await db_session.commit()
+    assert sl.match_status == "ignored"
+
+
+@pytest.mark.asyncio
+async def test_match_rejects_already_matched(db_session):
+    a = await _bank(db_session)
+    je = JournalEntry(entry_number="JE-1", entry_date=datetime.date(2026, 5, 1), status="posted")
+    db_session.add(je)
+    await db_session.flush()
+    jl = JournalLine(
+        journal_entry_id=je.id,
+        account_id=a.id,
+        line_number=1,
+        entry_type="credit",
+        amount=Decimal("25.00"),
+    )
+    db_session.add(jl)
+    await db_session.flush()
+
+    imp = await import_statement(
+        db_session,
+        account_id=a.id,
+        source_format="ofx",
+        source_filename="export.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    sl = (await db_session.execute(
+        select(StatementLine).where(StatementLine.import_id == imp.id, StatementLine.fitid == "FITID001")
+    )).scalar_one()
+    await match_line(db_session, statement_line_id=sl.id, journal_line_id=jl.id)
+    with pytest.raises(StatementImportError):
+        await match_line(db_session, statement_line_id=sl.id, journal_line_id=jl.id)

--- a/docs/statement_import.md
+++ b/docs/statement_import.md
@@ -1,0 +1,35 @@
+# Bank Statement Import (Phase 1)
+
+Operators upload an OFX or CSV statement, the service parses + dedupes
+the rows, and a review screen lets the operator match each line to an
+existing journal line or ignore it. #240.
+
+## Phase 1 scope
+
+- **Models**: `StatementImport` per upload + `StatementLine` per row.
+- **Formats**: OFX (SGML/XML, regex-based parser — no `ofxparse` dep) and CSV with default column names (`Date`, `Amount`, `Description`, `FITID`).
+- **Dedup**: by `(account_id, fitid)` when fitid is present; otherwise by exact `(account_id, posted_date, amount, description)` match.
+- **Match suggestions**: same account, ±5 days from `posted_date`, exact-amount match, excluding already-reconciled journal lines. Top 5.
+- **Match action**: links the statement line to a journal line and promotes the journal line's `cleared_status` to `cleared` (#239's vocabulary).
+- **Ignore action**: marks the statement line as ignored (won't show in "needs review").
+- **Bank-account guard**: imports refuse on non-bank accounts.
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `POST` | `/api/v1/banking/imports` | multipart upload (`account_id`, `source_format`, `file`). |
+| `GET` | `/api/v1/banking/imports?account_id=...` | List recent imports. |
+| `GET` | `/api/v1/banking/imports/{import_id}/lines?status_filter=...` | List lines for an import. |
+| `GET` | `/api/v1/banking/imports/lines/{line_id}/suggestions` | Top match candidates. |
+| `POST` | `/api/v1/banking/imports/lines/{line_id}/match` | Match to a journal line. |
+| `POST` | `/api/v1/banking/imports/lines/{line_id}/ignore` | Skip from review. |
+
+## Phase 2 follow-ups
+
+- **Auto-match rules** (#241) — picked up next; depends on this issue's data model. The hooks are in place: rules run during import to auto-handle statement lines that match a configured pattern.
+- **CSV column-mapping UI** with saved-per-account mappings (Phase 1 only supports the default headers).
+- **QFX / QIF** parsers.
+- **Multi-account OFX bundles** — Phase 1 ignores `<BANKACCTFROM>` checks.
+- **Create-transaction-from-line** flow — operator can already match against an existing JE; Phase 2 will let them post a new receipt/payment inline.
+- **Frontend** review screen for the import.


### PR DESCRIPTION
Closes #240 Phase 1. OFX (regex parser, no new dep) + CSV import, fitid dedup, manual match → promotes JL to cleared via #239 vocabulary. 386 tests pass (378 + 8 new). Phase 2 (auto-match rules #241, CSV mapping UI, frontend, create-from-line) in `docs/statement_import.md`.