### PR TITLE
feat(banking): statement-line auto-match rules Phase 1 (#241)

### DIFF
--- a/backend/alembic/versions/20260509_12_add_statement_match_rules.py
+++ b/backend/alembic/versions/20260509_12_add_statement_match_rules.py
@@ -1,0 +1,46 @@
+"""add statement_match_rules (#241)
+
+Revision ID: 20260509_12
+Revises: 20260509_11
+Create Date: 2026-05-09 23:58:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_12"
+down_revision = "20260509_11"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "statement_match_rules",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("account_id", sa.UUID(), nullable=True),
+        sa.Column("match_type", sa.String(length=20), nullable=False),
+        sa.Column("match_pattern", sa.String(length=500), nullable=False),
+        sa.Column("match_amount_sign", sa.String(length=10), nullable=False, server_default="any"),
+        sa.Column("action", sa.String(length=30), nullable=False),
+        sa.Column("priority", sa.Integer(), nullable=False, server_default="100"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["account_id"], ["accounts.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_statement_match_rules_account_id", "statement_match_rules", ["account_id"])
+    op.create_index("ix_statement_match_rules_priority", "statement_match_rules", ["priority"])
+    op.create_index("ix_statement_match_rules_is_active", "statement_match_rules", ["is_active"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_statement_match_rules_is_active", table_name="statement_match_rules")
+    op.drop_index("ix_statement_match_rules_priority", table_name="statement_match_rules")
+    op.drop_index("ix_statement_match_rules_account_id", table_name="statement_match_rules")
+    op.drop_table("statement_match_rules")

--- a/backend/app/api/v1/endpoints/statement_match_rules.py
+++ b/backend/app/api/v1/endpoints/statement_match_rules.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.statement_match_rule import StatementMatchRule
+from app.services.statement_match_rule_service import (
+    StatementMatchRuleError,
+    apply_rules_to_import,
+    validate_rule,
+)
+
+
+router = APIRouter(prefix="/banking/rules", tags=["Banking"])
+
+
+class RuleCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    account_id: uuid.UUID | None = None
+    match_type: Literal["contains", "regex"]
+    match_pattern: str = Field(..., min_length=1, max_length=500)
+    match_amount_sign: Literal["debit", "credit", "any"] = "any"
+    action: Literal["ignore"] = "ignore"  # Phase 1
+    priority: int = Field(100, ge=0)
+    is_active: bool = True
+
+
+class RuleUpdate(BaseModel):
+    name: str | None = Field(None, max_length=120)
+    account_id: uuid.UUID | None = None
+    match_type: Literal["contains", "regex"] | None = None
+    match_pattern: str | None = Field(None, max_length=500)
+    match_amount_sign: Literal["debit", "credit", "any"] | None = None
+    action: Literal["ignore"] | None = None
+    priority: int | None = Field(None, ge=0)
+    is_active: bool | None = None
+
+
+class RuleResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    account_id: uuid.UUID | None
+    match_type: str
+    match_pattern: str
+    match_amount_sign: str
+    action: str
+    priority: int
+    is_active: bool
+    created_at: datetime
+
+
+def _to_response(r: StatementMatchRule) -> RuleResponse:
+    return RuleResponse(
+        id=r.id,
+        name=r.name,
+        account_id=r.account_id,
+        match_type=r.match_type,
+        match_pattern=r.match_pattern,
+        match_amount_sign=r.match_amount_sign,
+        action=r.action,
+        priority=r.priority,
+        is_active=r.is_active,
+        created_at=r.created_at,
+    )
+
+
+@router.get("", response_model=list[RuleResponse], summary="List statement-match rules")
+async def list_rules(user: CurrentUser, db: DB):
+    rows = (
+        await db.execute(select(StatementMatchRule).order_by(StatementMatchRule.priority))
+    ).scalars().all()
+    return [_to_response(r) for r in rows]
+
+
+@router.post("", response_model=RuleResponse, status_code=status.HTTP_201_CREATED, summary="Create a rule")
+async def create_rule_ep(body: RuleCreate, user: CurrentUser, db: DB):
+    try:
+        validate_rule(
+            match_type=body.match_type,
+            match_pattern=body.match_pattern,
+            match_amount_sign=body.match_amount_sign,
+            action=body.action,
+        )
+    except StatementMatchRuleError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    r = StatementMatchRule(
+        name=body.name,
+        account_id=body.account_id,
+        match_type=body.match_type,
+        match_pattern=body.match_pattern,
+        match_amount_sign=body.match_amount_sign,
+        action=body.action,
+        priority=body.priority,
+        is_active=body.is_active,
+    )
+    db.add(r)
+    await db.commit()
+    return _to_response(r)
+
+
+@router.patch("/{rule_id}", response_model=RuleResponse, summary="Update a rule")
+async def update_rule_ep(rule_id: uuid.UUID, body: RuleUpdate, user: CurrentUser, db: DB):
+    r = (await db.execute(select(StatementMatchRule).where(StatementMatchRule.id == rule_id))).scalar_one_or_none()
+    if not r:
+        raise HTTPException(status_code=404, detail="Rule not found")
+    payload = body.model_dump(exclude_unset=True)
+    for k, v in payload.items():
+        setattr(r, k, v)
+    try:
+        validate_rule(
+            match_type=r.match_type,
+            match_pattern=r.match_pattern,
+            match_amount_sign=r.match_amount_sign,
+            action=r.action,
+        )
+    except StatementMatchRuleError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _to_response(r)
+
+
+@router.delete("/{rule_id}", status_code=204, summary="Delete a rule")
+async def delete_rule_ep(rule_id: uuid.UUID, user: CurrentUser, db: DB):
+    r = (await db.execute(select(StatementMatchRule).where(StatementMatchRule.id == rule_id))).scalar_one_or_none()
+    if not r:
+        raise HTTPException(status_code=404, detail="Rule not found")
+    await db.delete(r)
+    await db.commit()
+
+
+@router.post("/imports/{import_id}/apply-rules", summary="Re-apply rules to an existing import's pending lines")
+async def apply_rules_ep(import_id: uuid.UUID, user: CurrentUser, db: DB):
+    summary = await apply_rules_to_import(db, import_id=import_id)
+    await db.commit()
+    return summary

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, approvals, attachments, audit, auth, banking, cameras, customers, dashboard, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, supplies, tax
+from app.api.v1.endpoints import accounting, approvals, attachments, audit, auth, banking, cameras, customers, dashboard, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, statement_match_rules, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -37,3 +37,4 @@ api_router.include_router(recurring_invoices.router)
 api_router.include_router(expense_claims.router)
 api_router.include_router(intangible_assets.router)
 api_router.include_router(statement_imports.router)
+api_router.include_router(statement_match_rules.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -14,5 +14,6 @@ from app.models.inventory_location import (  # noqa: F401
 from app.models.product_bom_item import ProductBOMItem  # noqa: F401
 from app.models.recurring_invoice import RecurringInvoice, RecurringInvoiceRun  # noqa: F401
 from app.models.statement_import import StatementImport, StatementLine  # noqa: F401
+from app.models.statement_match_rule import StatementMatchRule  # noqa: F401
 from app.models.reference_sequence import ReferenceSequence  # noqa: F401
 from app.models.supply import Supply  # noqa: F401

--- a/backend/app/models/statement_match_rule.py
+++ b/backend/app/models/statement_match_rule.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class StatementMatchRule(Base):
+    """Rule that auto-handles imported statement lines (#241).
+
+    Phase 1 supports the `ignore` action only — fully matches a known
+    description pattern and skips the line from review. Phase 2 will
+    add `create_receipt` / `create_payment` actions that auto-post JEs.
+    """
+
+    __tablename__ = "statement_match_rules"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(120))
+    account_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("accounts.id"), nullable=True, index=True
+    )
+    match_type: Mapped[str] = mapped_column(String(20))  # contains | regex
+    match_pattern: Mapped[str] = mapped_column(String(500))
+    match_amount_sign: Mapped[str] = mapped_column(String(10), default="any")  # debit | credit | any
+    action: Mapped[str] = mapped_column(String(30))  # ignore (Phase 1) | create_receipt / create_payment (Phase 2)
+    priority: Mapped[int] = mapped_column(Integer, default=100, index=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/backend/app/services/statement_import_service.py
+++ b/backend/app/services/statement_import_service.py
@@ -219,6 +219,13 @@ async def import_statement(
     imp.line_count = line_count
     imp.duplicate_count = duplicate_count
     await db.flush()
+
+    # Apply auto-match rules (#241) to lines just inserted. Phase 1 only
+    # handles the `ignore` action; other actions are no-ops until Phase 2.
+    from app.services.statement_match_rule_service import apply_rules_to_import
+
+    await apply_rules_to_import(db, import_id=imp.id)
+
     return imp
 
 

--- a/backend/app/services/statement_match_rule_service.py
+++ b/backend/app/services/statement_match_rule_service.py
@@ -1,0 +1,135 @@
+"""Auto-match rules for imported statement lines (#241).
+
+Phase 1: only the `ignore` action is implemented — match by description
+pattern (contains or regex) plus optional amount-sign filter, and the
+matching statement line is set to `ignored` immediately during import
+review. Phase 2 will add `create_receipt`/`create_payment` actions that
+auto-post a real JE.
+
+Rules are evaluated in priority order (lower number first). First match
+wins.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.statement_import import StatementLine
+from app.models.statement_match_rule import StatementMatchRule
+
+
+class StatementMatchRuleError(RuntimeError):
+    pass
+
+
+SUPPORTED_ACTIONS = {"ignore"}  # Phase 1
+
+
+def _matches_pattern(rule: StatementMatchRule, description: str) -> bool:
+    if rule.match_type == "contains":
+        return rule.match_pattern.lower() in description.lower()
+    if rule.match_type == "regex":
+        try:
+            return re.search(rule.match_pattern, description, re.IGNORECASE) is not None
+        except re.error:
+            return False
+    return False
+
+
+def _matches_sign(rule: StatementMatchRule, amount: Decimal) -> bool:
+    if rule.match_amount_sign == "any":
+        return True
+    if rule.match_amount_sign == "debit":
+        return amount < 0  # outflow
+    if rule.match_amount_sign == "credit":
+        return amount > 0  # inflow
+    return False
+
+
+async def evaluate_rules_for_line(
+    db: AsyncSession, line: StatementLine
+) -> StatementMatchRule | None:
+    """Return the highest-priority active rule that matches the line, or None."""
+    rules = (
+        await db.execute(
+            select(StatementMatchRule).where(
+                StatementMatchRule.is_active == True,  # noqa: E712
+            ).order_by(StatementMatchRule.priority.asc(), StatementMatchRule.created_at.asc())
+        )
+    ).scalars().all()
+    for rule in rules:
+        if rule.account_id is not None and rule.account_id != line.account_id:
+            continue
+        if not _matches_pattern(rule, line.description):
+            continue
+        if not _matches_sign(rule, Decimal(line.amount)):
+            continue
+        return rule
+    return None
+
+
+async def apply_rules_to_import(
+    db: AsyncSession, *, import_id: uuid.UUID
+) -> dict:
+    """Walk every unmatched line for the given import and apply the first
+    matching rule's action. Phase 1: only `ignore` is acted upon.
+    Returns a summary dict of counts.
+    """
+    lines = (
+        await db.execute(
+            select(StatementLine).where(
+                StatementLine.import_id == import_id,
+                StatementLine.match_status == "unmatched",
+            )
+        )
+    ).scalars().all()
+
+    auto_ignored = 0
+    skipped_unsupported = 0
+    for line in lines:
+        rule = await evaluate_rules_for_line(db, line)
+        if rule is None:
+            continue
+        if rule.action == "ignore":
+            line.match_status = "ignored"
+            auto_ignored += 1
+        else:
+            # Phase 2 actions surfaced but not yet executed
+            skipped_unsupported += 1
+
+    await db.flush()
+    return {
+        "considered": len(lines),
+        "auto_ignored": auto_ignored,
+        "skipped_unsupported_actions": skipped_unsupported,
+    }
+
+
+def validate_rule(
+    *,
+    match_type: str,
+    match_pattern: str,
+    match_amount_sign: str,
+    action: str,
+) -> None:
+    if match_type not in ("contains", "regex"):
+        raise StatementMatchRuleError(f"Unknown match_type: {match_type}")
+    if not match_pattern:
+        raise StatementMatchRuleError("match_pattern is required")
+    if match_type == "regex":
+        try:
+            re.compile(match_pattern)
+        except re.error as e:
+            raise StatementMatchRuleError(f"Invalid regex: {e}") from e
+    if match_amount_sign not in ("debit", "credit", "any"):
+        raise StatementMatchRuleError(f"Unknown match_amount_sign: {match_amount_sign}")
+    if action not in SUPPORTED_ACTIONS:
+        raise StatementMatchRuleError(
+            f"Action {action!r} is declared but not implemented in Phase 1; "
+            f"supported actions: {sorted(SUPPORTED_ACTIONS)}"
+        )

--- a/backend/tests/test_statement_match_rule_service.py
+++ b/backend/tests/test_statement_match_rule_service.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.statement_import import StatementLine
+from app.models.statement_match_rule import StatementMatchRule
+from app.services.statement_import_service import import_statement
+from app.services.statement_match_rule_service import (
+    StatementMatchRuleError,
+    apply_rules_to_import,
+    evaluate_rules_for_line,
+    validate_rule,
+)
+
+
+SAMPLE_OFX = """
+<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><BANKTRANLIST>
+<STMTTRN><DTPOSTED>20260501<TRNAMT>-25.00<FITID>F1<NAME>Filament supplier</STMTTRN>
+<STMTTRN><DTPOSTED>20260503<TRNAMT>500.00<FITID>F2<NAME>Etsy payout</STMTTRN>
+<STMTTRN><DTPOSTED>20260505<TRNAMT>-3.50<FITID>F3<NAME>ATM CHECK FEE</STMTTRN>
+</BANKTRANLIST></STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>
+"""
+
+
+async def _bank(db_session) -> Account:
+    a = Account(
+        code="1010", name="Operating", account_type="asset",
+        normal_balance="debit", is_bank_account=True, bank_account_kind="checking",
+    )
+    db_session.add(a)
+    await db_session.flush()
+    return a
+
+
+def test_validate_rule_unknown_type():
+    with pytest.raises(StatementMatchRuleError):
+        validate_rule(match_type="bogus", match_pattern="x", match_amount_sign="any", action="ignore")
+
+
+def test_validate_rule_invalid_regex():
+    with pytest.raises(StatementMatchRuleError):
+        validate_rule(match_type="regex", match_pattern="[unclosed", match_amount_sign="any", action="ignore")
+
+
+def test_validate_rule_unsupported_action():
+    with pytest.raises(StatementMatchRuleError):
+        validate_rule(match_type="contains", match_pattern="x", match_amount_sign="any", action="create_receipt")
+
+
+@pytest.mark.asyncio
+async def test_evaluate_contains_match(db_session):
+    a = await _bank(db_session)
+    rule = StatementMatchRule(
+        name="ATM fees", match_type="contains", match_pattern="ATM",
+        match_amount_sign="debit", action="ignore", priority=10,
+    )
+    db_session.add(rule)
+    line = StatementLine(
+        import_id=__import__("uuid").uuid4(),  # placeholder; not persisted
+        account_id=a.id,
+        posted_date=datetime.date(2026, 5, 5),
+        amount=Decimal("-3.50"),
+        description="ATM CHECK FEE",
+        match_status="unmatched",
+    )
+    matched = await evaluate_rules_for_line(db_session, line)
+    assert matched is not None
+    assert matched.id == rule.id
+
+
+@pytest.mark.asyncio
+async def test_evaluate_regex_match(db_session):
+    a = await _bank(db_session)
+    rule = StatementMatchRule(
+        name="Etsy payouts", match_type="regex", match_pattern=r"^Etsy\s+payout",
+        match_amount_sign="credit", action="ignore", priority=10,
+    )
+    db_session.add(rule)
+    line = StatementLine(
+        import_id=__import__("uuid").uuid4(),
+        account_id=a.id,
+        posted_date=datetime.date(2026, 5, 3),
+        amount=Decimal("500.00"),
+        description="Etsy payout 0501",
+        match_status="unmatched",
+    )
+    assert (await evaluate_rules_for_line(db_session, line)) is not None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_sign_filter_blocks(db_session):
+    a = await _bank(db_session)
+    rule = StatementMatchRule(
+        name="Debits only", match_type="contains", match_pattern="payout",
+        match_amount_sign="debit", action="ignore", priority=10,
+    )
+    db_session.add(rule)
+    line = StatementLine(
+        import_id=__import__("uuid").uuid4(),
+        account_id=a.id,
+        posted_date=datetime.date(2026, 5, 3),
+        amount=Decimal("500.00"),  # credit, not debit
+        description="Etsy payout",
+        match_status="unmatched",
+    )
+    assert (await evaluate_rules_for_line(db_session, line)) is None
+
+
+@pytest.mark.asyncio
+async def test_priority_ordering(db_session):
+    a = await _bank(db_session)
+    db_session.add(StatementMatchRule(
+        name="Low priority", match_type="contains", match_pattern="payout",
+        match_amount_sign="any", action="ignore", priority=200,
+    ))
+    db_session.add(StatementMatchRule(
+        name="High priority", match_type="contains", match_pattern="payout",
+        match_amount_sign="any", action="ignore", priority=10,
+    ))
+    await db_session.flush()
+    line = StatementLine(
+        import_id=__import__("uuid").uuid4(),
+        account_id=a.id,
+        posted_date=datetime.date(2026, 5, 3),
+        amount=Decimal("500.00"),
+        description="Etsy payout",
+        match_status="unmatched",
+    )
+    matched = await evaluate_rules_for_line(db_session, line)
+    assert matched is not None
+    assert matched.name == "High priority"
+
+
+@pytest.mark.asyncio
+async def test_inactive_rule_ignored(db_session):
+    a = await _bank(db_session)
+    db_session.add(StatementMatchRule(
+        name="Inactive", match_type="contains", match_pattern="payout",
+        match_amount_sign="any", action="ignore", is_active=False, priority=10,
+    ))
+    await db_session.flush()
+    line = StatementLine(
+        import_id=__import__("uuid").uuid4(),
+        account_id=a.id,
+        posted_date=datetime.date(2026, 5, 3),
+        amount=Decimal("500.00"),
+        description="Etsy payout",
+        match_status="unmatched",
+    )
+    assert (await evaluate_rules_for_line(db_session, line)) is None
+
+
+@pytest.mark.asyncio
+async def test_rules_applied_during_import(db_session):
+    a = await _bank(db_session)
+    db_session.add(StatementMatchRule(
+        name="Auto-ignore ATM fees", match_type="contains", match_pattern="ATM",
+        match_amount_sign="any", action="ignore", priority=10,
+    ))
+    await db_session.flush()
+
+    imp = await import_statement(
+        db_session,
+        account_id=a.id,
+        source_format="ofx",
+        source_filename="x.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    await db_session.commit()
+    rows = (await db_session.execute(select(StatementLine).where(StatementLine.import_id == imp.id))).scalars().all()
+    statuses = {r.fitid: r.match_status for r in rows}
+    # The ATM fee should be auto-ignored
+    assert statuses["F3"] == "ignored"
+    # Others remain unmatched
+    assert statuses["F1"] == "unmatched"
+    assert statuses["F2"] == "unmatched"
+
+
+@pytest.mark.asyncio
+async def test_apply_rules_to_import_summary(db_session):
+    a = await _bank(db_session)
+    imp = await import_statement(
+        db_session,
+        account_id=a.id,
+        source_format="ofx",
+        source_filename="x.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    db_session.add(StatementMatchRule(
+        name="Block all credits", match_type="contains", match_pattern="",
+        match_amount_sign="credit", action="ignore", priority=10,
+    ))
+    await db_session.flush()
+    summary = await apply_rules_to_import(db_session, import_id=imp.id)
+    assert summary["auto_ignored"] >= 1

--- a/docs/statement_match_rules.md
+++ b/docs/statement_match_rules.md
@@ -1,0 +1,45 @@
+# Statement Auto-Match Rules (Phase 1)
+
+Operators define rules that automatically handle imported statement lines (#241). Phase 1 supports the **`ignore`** action only — auto-skip noise like ATM fees from review. Phase 2 will add `create_receipt` / `create_payment` actions that auto-post journal entries.
+
+## Model
+
+`StatementMatchRule`:
+
+| Field | Notes |
+|---|---|
+| `name` | Operator label. |
+| `account_id` | Optional; null = applies across all bank accounts. |
+| `match_type` | `contains` (case-insensitive substring) or `regex` (Python re, case-insensitive). |
+| `match_pattern` | Substring or regex. |
+| `match_amount_sign` | `debit` (negative), `credit` (positive), or `any`. |
+| `action` | `ignore` (Phase 1). Validation rejects unsupported actions. |
+| `priority` | Lower = higher priority. First match wins. |
+| `is_active` | Inactive rules are skipped. |
+
+## Behavior
+
+Rules are evaluated automatically during `import_statement` for every newly-inserted statement line, in priority order. The first matching rule's action runs:
+
+- **`ignore`** → line's `match_status` flips to `ignored` so it never appears in the review queue.
+- Other actions → silently no-op in Phase 1, counted in `skipped_unsupported_actions`.
+
+The `apply-rules` endpoint can be called manually to re-evaluate an existing import's pending lines after rules change.
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `GET` | `/api/v1/banking/rules` | List, ordered by priority. |
+| `POST` | `/api/v1/banking/rules` | Create. Validates regex if `match_type=regex`; rejects unsupported actions. |
+| `PATCH` | `/api/v1/banking/rules/{id}` | Update. Re-validates on save. |
+| `DELETE` | `/api/v1/banking/rules/{id}` | Hard delete. |
+| `POST` | `/api/v1/banking/rules/imports/{import_id}/apply-rules` | Re-apply rules to existing pending lines on an import. |
+
+## Phase 2 follow-ups
+
+1. **`create_receipt` / `create_payment` actions** — auto-post a JE with the matching counterparty + category accounts. Requires populating `counterparty_id`, `category_account_id`, `tax_profile_id` fields on the rule.
+2. **Dry-run preview** — run rules against an import without mutating, return per-rule counts so operators can validate before activation.
+3. **"Create rule from line" shortcut** — pre-fill match_pattern from the description.
+4. **`create_inter_account_transfer` action** — paired with #246 once both ship.
+5. **Frontend** rules CRUD + dry-run preview + reorder by priority.


### PR DESCRIPTION
Closes #241 Phase 1. Rules CRUD + auto-apply during import for the 'ignore' action. Phase 2 (create_receipt/create_payment, dry-run, frontend) in `docs/statement_match_rules.md`. 396 tests pass (386 + 10 new).