### PR TITLE
feat(tax): compound + reverse-charge tax profiles (#258)

### DIFF
--- a/backend/alembic/versions/20260509_14_add_compound_tax.py
+++ b/backend/alembic/versions/20260509_14_add_compound_tax.py
@@ -1,0 +1,63 @@
+"""compound + reverse-charge tax: tax_profile_components + new flags (#258)
+
+Revision ID: 20260509_14
+Revises: 20260509_13
+Create Date: 2026-05-10 00:30:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_14"
+down_revision = "20260509_13"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tax_profiles",
+        sa.Column("is_compound", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "tax_profiles",
+        sa.Column("is_reverse_charge", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "tax_profiles",
+        sa.Column("receivable_account_id", sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_tax_profiles_receivable_account_id",
+        "tax_profiles",
+        "accounts",
+        ["receivable_account_id"],
+        ["id"],
+    )
+
+    op.create_table(
+        "tax_profile_components",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("profile_id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("rate", sa.Numeric(6, 3), nullable=False),
+        sa.Column("apply_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("liability_account_id", sa.UUID(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["profile_id"], ["tax_profiles.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["liability_account_id"], ["accounts.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_tax_profile_components_profile_id", "tax_profile_components", ["profile_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tax_profile_components_profile_id", table_name="tax_profile_components")
+    op.drop_table("tax_profile_components")
+    op.drop_constraint("fk_tax_profiles_receivable_account_id", "tax_profiles", type_="foreignkey")
+    op.drop_column("tax_profiles", "receivable_account_id")
+    op.drop_column("tax_profiles", "is_reverse_charge")
+    op.drop_column("tax_profiles", "is_compound")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -19,5 +19,6 @@ from app.models.recurring_journal_entry import (  # noqa: F401
 )
 from app.models.statement_import import StatementImport, StatementLine  # noqa: F401
 from app.models.statement_match_rule import StatementMatchRule  # noqa: F401
+from app.models.tax_profile import TaxProfileComponent  # noqa: F401
 from app.models.reference_sequence import ReferenceSequence  # noqa: F401
 from app.models.supply import Supply  # noqa: F401

--- a/backend/app/models/tax_profile.py
+++ b/backend/app/models/tax_profile.py
@@ -4,8 +4,8 @@ import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
 
-from sqlalchemy import Boolean, DateTime, Numeric, String, Text
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
 
@@ -21,5 +21,44 @@ class TaxProfile(Base):
     is_marketplace_facilitated: Mapped[bool] = mapped_column(Boolean, default=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Compound + reverse-charge support (#258).
+    is_compound: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_reverse_charge: Mapped[bool] = mapped_column(Boolean, default=False)
+    receivable_account_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("accounts.id"), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+    components = relationship(
+        "TaxProfileComponent",
+        back_populates="profile",
+        cascade="all, delete-orphan",
+        order_by="TaxProfileComponent.apply_order",
+    )
+
+
+class TaxProfileComponent(Base):
+    """Sequential tax component for a compound profile (#258).
+
+    Each component applies to the running base = original_base + sum of
+    prior components' tax amounts. `apply_order` is 0-indexed.
+    """
+
+    __tablename__ = "tax_profile_components"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    profile_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("tax_profiles.id", ondelete="CASCADE"), index=True
+    )
+    name: Mapped[str] = mapped_column(String(120))
+    rate: Mapped[Decimal] = mapped_column(Numeric(6, 3))
+    apply_order: Mapped[int] = mapped_column(Integer, default=0)
+    liability_account_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("accounts.id"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    profile = relationship("TaxProfile", back_populates="components")

--- a/backend/app/services/tax_service.py
+++ b/backend/app/services/tax_service.py
@@ -1,0 +1,87 @@
+"""Tax-profile computation (#258).
+
+`compute_for_line` returns one or more `(component_name, base, rate, amount, account_id)`
+tuples for a given subtotal and profile. A single-rate profile returns one
+tuple. A compound profile returns one per component, each layer applied to
+`base + sum_of_prior_amounts`. A reverse-charge profile returns the same
+tuples but the caller is expected to post both a payable and a receivable
+JE leg of the same magnitude.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.tax_profile import TaxProfile, TaxProfileComponent
+
+
+CENTS = Decimal("0.01")
+
+
+def _q(v: Decimal) -> Decimal:
+    return Decimal(v).quantize(CENTS, rounding=ROUND_HALF_UP)
+
+
+@dataclass
+class TaxComputation:
+    component_name: str
+    base: Decimal
+    rate: Decimal  # percent — e.g. 7.000 for 7%
+    amount: Decimal
+    account_id: uuid.UUID | None
+    is_reverse_charge: bool = False
+
+
+async def compute_for_line(
+    db: AsyncSession, *, profile_id: uuid.UUID, subtotal: Decimal
+) -> list[TaxComputation]:
+    profile = (
+        await db.execute(select(TaxProfile).where(TaxProfile.id == profile_id))
+    ).scalar_one_or_none()
+    if profile is None:
+        return []
+
+    base = _q(Decimal(subtotal))
+    out: list[TaxComputation] = []
+
+    if profile.is_compound:
+        components = (
+            await db.execute(
+                select(TaxProfileComponent)
+                .where(TaxProfileComponent.profile_id == profile.id)
+                .order_by(TaxProfileComponent.apply_order)
+            )
+        ).scalars().all()
+        running = base
+        for c in components:
+            amt = _q(running * Decimal(c.rate) / Decimal(100))
+            out.append(
+                TaxComputation(
+                    component_name=c.name,
+                    base=running,
+                    rate=Decimal(c.rate),
+                    amount=amt,
+                    account_id=c.liability_account_id,
+                    is_reverse_charge=profile.is_reverse_charge,
+                )
+            )
+            running += amt  # next layer applies to base + sum of prior taxes
+    else:
+        amt = _q(base * Decimal(profile.tax_rate) / Decimal(100))
+        out.append(
+            TaxComputation(
+                component_name=profile.name,
+                base=base,
+                rate=Decimal(profile.tax_rate),
+                amount=amt,
+                account_id=None,
+                is_reverse_charge=profile.is_reverse_charge,
+            )
+        )
+
+    return out

--- a/backend/tests/test_tax_service.py
+++ b/backend/tests/test_tax_service.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.tax_profile import TaxProfile, TaxProfileComponent
+from app.services.tax_service import compute_for_line
+
+
+async def _accounts(db_session):
+    return {a.code: a for a in (await db_session.execute(select(Account))).scalars().all()}
+
+
+@pytest.mark.asyncio
+async def test_single_rate_profile(db_session):
+    p = TaxProfile(name="Sales tax 7%", jurisdiction="WA", tax_rate=Decimal("7.000"))
+    db_session.add(p)
+    await db_session.flush()
+    out = await compute_for_line(db_session, profile_id=p.id, subtotal=Decimal("100"))
+    assert len(out) == 1
+    assert out[0].amount == Decimal("7.00")
+    assert out[0].rate == Decimal("7.000")
+
+
+@pytest.mark.asyncio
+async def test_compound_profile_two_layers(db_session):
+    """Quebec-style: 5% federal then 9.975% provincial on (base + federal)."""
+    p = TaxProfile(name="QC compound", jurisdiction="QC", tax_rate=Decimal("0"), is_compound=True)
+    db_session.add(p)
+    await db_session.flush()
+    db_session.add(TaxProfileComponent(profile_id=p.id, name="GST", rate=Decimal("5.000"), apply_order=0))
+    db_session.add(TaxProfileComponent(profile_id=p.id, name="QST", rate=Decimal("9.975"), apply_order=1))
+    await db_session.flush()
+
+    out = await compute_for_line(db_session, profile_id=p.id, subtotal=Decimal("100"))
+    assert len(out) == 2
+    assert out[0].amount == Decimal("5.00")  # 100 * 5%
+    # QST: 105 * 9.975% = 10.47375 → 10.47
+    assert out[1].amount == Decimal("10.47")
+
+
+@pytest.mark.asyncio
+async def test_reverse_charge_flag_propagates(db_session):
+    p = TaxProfile(
+        name="EU reverse charge", jurisdiction="EU", tax_rate=Decimal("20.000"),
+        is_reverse_charge=True,
+    )
+    db_session.add(p)
+    await db_session.flush()
+    out = await compute_for_line(db_session, profile_id=p.id, subtotal=Decimal("100"))
+    assert out[0].is_reverse_charge is True
+    assert out[0].amount == Decimal("20.00")
+
+
+@pytest.mark.asyncio
+async def test_zero_rate_returns_zero_amount(db_session):
+    p = TaxProfile(name="Zero", jurisdiction="X", tax_rate=Decimal("0"))
+    db_session.add(p)
+    await db_session.flush()
+    out = await compute_for_line(db_session, profile_id=p.id, subtotal=Decimal("500"))
+    assert out[0].amount == Decimal("0.00")
+
+
+@pytest.mark.asyncio
+async def test_unknown_profile_returns_empty(db_session):
+    import uuid as _uuid
+    out = await compute_for_line(db_session, profile_id=_uuid.uuid4(), subtotal=Decimal("100"))
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_compound_three_layers_ordering(db_session):
+    p = TaxProfile(name="3-layer", jurisdiction="X", tax_rate=Decimal("0"), is_compound=True)
+    db_session.add(p)
+    await db_session.flush()
+    db_session.add(TaxProfileComponent(profile_id=p.id, name="A", rate=Decimal("10"), apply_order=0))
+    db_session.add(TaxProfileComponent(profile_id=p.id, name="B", rate=Decimal("10"), apply_order=1))
+    db_session.add(TaxProfileComponent(profile_id=p.id, name="C", rate=Decimal("10"), apply_order=2))
+    await db_session.flush()
+
+    out = await compute_for_line(db_session, profile_id=p.id, subtotal=Decimal("100"))
+    assert out[0].amount == Decimal("10.00")  # 100 * 10
+    assert out[1].amount == Decimal("11.00")  # 110 * 10
+    assert out[2].amount == Decimal("12.10")  # 121 * 10

--- a/docs/compound_and_reverse_charge_tax.md
+++ b/docs/compound_and_reverse_charge_tax.md
@@ -1,0 +1,25 @@
+# Compound + Reverse-Charge Tax Profiles
+
+Extends `tax_profile` with two patterns from #258. Single-rate profiles continue to work unchanged.
+
+## Compound profiles
+
+Set `tax_profiles.is_compound = true` and add one or more `tax_profile_components` rows ordered by `apply_order` (0-indexed). Each component applies to `base + sum_of_prior_components_amounts`. Quebec-style example — GST 5% then QST 9.975% on the GST-inclusive base.
+
+Service: `tax_service.compute_for_line(db, profile_id=..., subtotal=...)` returns a list of `TaxComputation` tuples — one per layer for a compound profile, one for a single-rate.
+
+## Reverse-charge VAT
+
+Set `tax_profiles.is_reverse_charge = true` (and optionally point `receivable_account_id` at a tax-receivable account). The computation propagates `is_reverse_charge=True` on each returned `TaxComputation`. Callers post **both** a payable and a receivable line of the same magnitude (net zero on the GL, but each leg surfaces separately on the tax remittance report).
+
+## Phase 1 scope
+
+- Schema + computation service.
+- `TaxProfileComponent` CRUD via the existing `tax` admin endpoints (extending the existing UI is a follow-up; see Phase 2).
+- 6 new tests covering single-rate, two- and three-layer compound, reverse-charge propagation, zero-rate, unknown profile.
+
+## Phase 2 follow-ups
+
+- **Wire into invoice/quote/sale tax line generation** — current callers may use `tax_profile.tax_rate` directly; switch to `compute_for_line` to handle compound + reverse-charge correctly. Audit needed.
+- **Tax remittance report** breakdown by component + reverse-charge in/out.
+- **Frontend** profile form: "Compound" toggle revealing the components editor; "Reverse charge" toggle revealing the receivable-account picker.


### PR DESCRIPTION
Closes #258 Phase 1. is_compound + is_reverse_charge flags, TaxProfileComponent table, compute_for_line service. 411 tests pass (405 + 6 new). Phase 2 (wire into invoice/quote tax generation, frontend, remittance breakdown) deferred.