### PR TITLE
feat(custom-fields): user-defined fields with side-table storage Phase 1 (#253)

### DIFF
--- a/backend/alembic/versions/20260509_17_add_custom_fields.py
+++ b/backend/alembic/versions/20260509_17_add_custom_fields.py
@@ -1,0 +1,62 @@
+"""add custom_field_definitions + custom_field_values (#253)
+
+Revision ID: 20260509_17
+Revises: 20260509_16
+Create Date: 2026-05-10 02:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_17"
+down_revision = "20260509_16"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "custom_field_definitions",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("scope", sa.String(length=40), nullable=False),
+        sa.Column("key", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("field_type", sa.String(length=20), nullable=False),
+        sa.Column("options", sa.JSON(), nullable=True),
+        sa.Column("is_required", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="100"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("scope", "key", name="uq_custom_field_definitions_scope_key"),
+    )
+    op.create_index("ix_custom_field_definitions_scope", "custom_field_definitions", ["scope"])
+    op.create_index("ix_custom_field_definitions_is_active", "custom_field_definitions", ["is_active"])
+
+    op.create_table(
+        "custom_field_values",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("definition_id", sa.UUID(), nullable=False),
+        sa.Column("record_id", sa.UUID(), nullable=False),
+        sa.Column("value", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["definition_id"], ["custom_field_definitions.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("definition_id", "record_id", name="uq_custom_field_values_def_record"),
+    )
+    op.create_index("ix_custom_field_values_definition_id", "custom_field_values", ["definition_id"])
+    op.create_index("ix_custom_field_values_record_id", "custom_field_values", ["record_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_custom_field_values_record_id", table_name="custom_field_values")
+    op.drop_index("ix_custom_field_values_definition_id", table_name="custom_field_values")
+    op.drop_table("custom_field_values")
+    op.drop_index("ix_custom_field_definitions_is_active", table_name="custom_field_definitions")
+    op.drop_index("ix_custom_field_definitions_scope", table_name="custom_field_definitions")
+    op.drop_table("custom_field_definitions")

--- a/backend/app/api/v1/endpoints/custom_fields.py
+++ b/backend/app/api/v1/endpoints/custom_fields.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.custom_field import CustomFieldDefinition
+from app.services.custom_field_service import (
+    CustomFieldError,
+    list_definitions,
+    read_values,
+    upsert_values,
+    validate_definition,
+)
+
+
+router = APIRouter(prefix="/custom-fields", tags=["CustomFields"])
+
+
+class DefinitionCreate(BaseModel):
+    scope: str = Field(..., min_length=1, max_length=40)
+    key: str = Field(..., min_length=1, max_length=64)
+    name: str = Field(..., min_length=1, max_length=120)
+    field_type: Literal["text", "long_text", "number", "date", "dropdown", "checkbox"]
+    options: list[str] | None = None
+    is_required: bool = False
+    sort_order: int = 100
+
+
+class DefinitionUpdate(BaseModel):
+    name: str | None = None
+    options: list[str] | None = None
+    is_required: bool | None = None
+    sort_order: int | None = None
+    is_active: bool | None = None
+
+
+class DefinitionResponse(BaseModel):
+    id: uuid.UUID
+    scope: str
+    key: str
+    name: str
+    field_type: str
+    options: list[str] | None
+    is_required: bool
+    sort_order: int
+    is_active: bool
+
+
+def _to_response(d: CustomFieldDefinition) -> DefinitionResponse:
+    return DefinitionResponse(
+        id=d.id,
+        scope=d.scope,
+        key=d.key,
+        name=d.name,
+        field_type=d.field_type,
+        options=list(d.options) if d.options else None,
+        is_required=d.is_required,
+        sort_order=d.sort_order,
+        is_active=d.is_active,
+    )
+
+
+@router.get("/{scope}", response_model=list[DefinitionResponse], summary="List custom field definitions for a scope")
+async def list_defs_ep(scope: str, user: CurrentUser, db: DB, include_inactive: bool = False):
+    try:
+        rows = await list_definitions(db, scope=scope, include_inactive=include_inactive)
+    except CustomFieldError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return [_to_response(r) for r in rows]
+
+
+@router.post("", response_model=DefinitionResponse, status_code=status.HTTP_201_CREATED, summary="Create a custom field definition")
+async def create_def(body: DefinitionCreate, user: CurrentUser, db: DB):
+    try:
+        validate_definition(
+            scope=body.scope, key=body.key, field_type=body.field_type, options=body.options,
+        )
+    except CustomFieldError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    # Unique on (scope, key)
+    existing = (
+        await db.execute(
+            select(CustomFieldDefinition).where(
+                CustomFieldDefinition.scope == body.scope,
+                CustomFieldDefinition.key == body.key,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing:
+        raise HTTPException(status_code=409, detail=f"Custom field {body.scope}.{body.key} already exists")
+
+    d = CustomFieldDefinition(
+        scope=body.scope,
+        key=body.key,
+        name=body.name,
+        field_type=body.field_type,
+        options=body.options,
+        is_required=body.is_required,
+        sort_order=body.sort_order,
+    )
+    db.add(d)
+    await db.commit()
+    return _to_response(d)
+
+
+@router.patch("/{def_id}", response_model=DefinitionResponse, summary="Update a definition (cannot change field_type or scope)")
+async def update_def(def_id: uuid.UUID, body: DefinitionUpdate, user: CurrentUser, db: DB):
+    d = (await db.execute(select(CustomFieldDefinition).where(CustomFieldDefinition.id == def_id))).scalar_one_or_none()
+    if not d:
+        raise HTTPException(status_code=404, detail="Definition not found")
+    payload = body.model_dump(exclude_unset=True)
+    for k, v in payload.items():
+        setattr(d, k, v)
+    # Re-validate dropdown options if they changed
+    if "options" in payload and d.field_type == "dropdown":
+        try:
+            validate_definition(scope=d.scope, key=d.key, field_type=d.field_type, options=d.options)
+        except CustomFieldError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _to_response(d)
+
+
+@router.delete("/{def_id}", status_code=204, summary="Soft-deactivate a definition (values preserved)")
+async def deactivate_def(def_id: uuid.UUID, user: CurrentUser, db: DB):
+    """Phase 1: deactivate rather than hard-delete so existing values aren't
+    silently dropped. Hard delete is a follow-up gated on no-values check.
+    """
+    d = (await db.execute(select(CustomFieldDefinition).where(CustomFieldDefinition.id == def_id))).scalar_one_or_none()
+    if not d:
+        raise HTTPException(status_code=404, detail="Definition not found")
+    d.is_active = False
+    await db.commit()
+
+
+# ---------- values ----------
+
+
+class ValueUpsert(BaseModel):
+    values: dict[str, Any]
+
+
+@router.get("/values/{scope}/{record_id}", summary="Read all custom-field values for a record")
+async def get_values(scope: str, record_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        return await read_values(db, scope=scope, record_id=record_id)
+    except CustomFieldError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post("/values/{scope}/{record_id}", summary="Set custom-field values for a record")
+async def set_values(scope: str, record_id: uuid.UUID, body: ValueUpsert, user: CurrentUser, db: DB):
+    try:
+        result = await upsert_values(db, scope=scope, record_id=record_id, values=body.values)
+    except CustomFieldError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return result

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, accounting_foundations, approvals, attachments, audit, auth, banking, budgets, cameras, customers, dashboard, divisions, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, statement_match_rules, supplies, tax
+from app.api.v1.endpoints import accounting, accounting_foundations, approvals, attachments, audit, auth, banking, budgets, cameras, custom_fields, customers, dashboard, divisions, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, statement_match_rules, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -41,3 +41,4 @@ api_router.include_router(statement_match_rules.router)
 api_router.include_router(accounting_foundations.router)
 api_router.include_router(divisions.router)
 api_router.include_router(budgets.router)
+api_router.include_router(custom_fields.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.account_budget import AccountBudget  # noqa: F401
 from app.models.attachment import Attachment  # noqa: F401
+from app.models.custom_field import CustomFieldDefinition, CustomFieldValue  # noqa: F401
 from app.models.bank_reconciliation import BankReconciliation, BankReconciliationLine  # noqa: F401
 from app.models.camera import Camera  # noqa: F401
 from app.models.email_delivery import EmailDelivery  # noqa: F401

--- a/backend/app/models/custom_field.py
+++ b/backend/app/models/custom_field.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class CustomFieldDefinition(Base):
+    """User-defined field for a record scope (#253). Phase 1 stores values
+    in a separate `custom_field_values` table to avoid migrating every
+    scoped record table; the existing per-record record stays unchanged.
+    """
+
+    __tablename__ = "custom_field_definitions"
+    __table_args__ = (
+        UniqueConstraint("scope", "key", name="uq_custom_field_definitions_scope_key"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    scope: Mapped[str] = mapped_column(String(40), index=True)
+    key: Mapped[str] = mapped_column(String(64))  # slug used in API + filters
+    name: Mapped[str] = mapped_column(String(120))  # display label
+    # text | long_text | number | date | dropdown | checkbox
+    field_type: Mapped[str] = mapped_column(String(20))
+    options: Mapped[list | None] = mapped_column(JSON, nullable=True)  # for dropdown
+    is_required: Mapped[bool] = mapped_column(Boolean, default=False)
+    sort_order: Mapped[int] = mapped_column(Integer, default=100)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+
+class CustomFieldValue(Base):
+    """One value per `(definition, record_id)`. String-stored — coerced on
+    read per the definition's `field_type`."""
+
+    __tablename__ = "custom_field_values"
+    __table_args__ = (
+        UniqueConstraint("definition_id", "record_id", name="uq_custom_field_values_def_record"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    definition_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("custom_field_definitions.id", ondelete="CASCADE"), index=True
+    )
+    record_id: Mapped[uuid.UUID] = mapped_column(index=True)
+    value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/backend/app/services/custom_field_service.py
+++ b/backend/app/services/custom_field_service.py
@@ -1,0 +1,199 @@
+"""Custom-field validation + storage (#253).
+
+Phase 1: values stored in `custom_field_values` (separate table). Each
+scope's existing record table is untouched. Trade-off: fetching values
+requires a JOIN, but no migration of every record table.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.custom_field import CustomFieldDefinition, CustomFieldValue
+
+
+class CustomFieldError(RuntimeError):
+    pass
+
+
+VALID_SCOPES = {
+    "customer", "vendor", "product", "material", "supply",
+    "job", "sale", "invoice", "quote", "bill",
+}
+
+FIELD_TYPES = {"text", "long_text", "number", "date", "dropdown", "checkbox"}
+
+_KEY_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def validate_definition(
+    *,
+    scope: str,
+    key: str,
+    field_type: str,
+    options: list | None,
+) -> None:
+    if scope not in VALID_SCOPES:
+        raise CustomFieldError(f"Unsupported scope: {scope!r}")
+    if not _KEY_RE.match(key):
+        raise CustomFieldError(
+            "key must start with a lowercase letter and contain only [a-z0-9_]"
+        )
+    if field_type not in FIELD_TYPES:
+        raise CustomFieldError(f"Unknown field_type: {field_type!r}")
+    if field_type == "dropdown":
+        if not options or not isinstance(options, list) or not all(isinstance(o, str) and o for o in options):
+            raise CustomFieldError("dropdown field_type requires non-empty options: list[str]")
+
+
+def coerce_value(field_type: str, raw: Any, options: list | None) -> str | None:
+    """Validate a user-supplied value and return its canonical string form
+    for storage. Returns None for empty input."""
+    if raw is None or raw == "":
+        return None
+    if field_type in ("text", "long_text"):
+        return str(raw)
+    if field_type == "number":
+        try:
+            return str(Decimal(str(raw)))
+        except (InvalidOperation, ValueError) as e:
+            raise CustomFieldError(f"Invalid number value: {raw!r}") from e
+    if field_type == "date":
+        if isinstance(raw, date):
+            return raw.isoformat()
+        try:
+            return datetime.strptime(str(raw), "%Y-%m-%d").date().isoformat()
+        except ValueError as e:
+            raise CustomFieldError(f"Invalid date value (expected YYYY-MM-DD): {raw!r}") from e
+    if field_type == "checkbox":
+        if isinstance(raw, bool):
+            return "true" if raw else "false"
+        s = str(raw).lower()
+        if s in ("true", "1", "yes"):
+            return "true"
+        if s in ("false", "0", "no"):
+            return "false"
+        raise CustomFieldError(f"Invalid checkbox value: {raw!r}")
+    if field_type == "dropdown":
+        if not options or str(raw) not in options:
+            raise CustomFieldError(f"Value {raw!r} is not in the configured options")
+        return str(raw)
+    raise CustomFieldError(f"Unhandled field_type: {field_type}")
+
+
+def decode_value(field_type: str, stored: str | None) -> Any:
+    """Reverse of coerce — return native Python representation for the API."""
+    if stored is None:
+        return None
+    if field_type in ("text", "long_text", "dropdown"):
+        return stored
+    if field_type == "number":
+        return str(Decimal(stored))
+    if field_type == "date":
+        return stored  # ISO string
+    if field_type == "checkbox":
+        return stored == "true"
+    return stored
+
+
+async def list_definitions(
+    db: AsyncSession, *, scope: str, include_inactive: bool = False
+) -> list[CustomFieldDefinition]:
+    if scope not in VALID_SCOPES:
+        raise CustomFieldError(f"Unsupported scope: {scope!r}")
+    stmt = select(CustomFieldDefinition).where(CustomFieldDefinition.scope == scope).order_by(
+        CustomFieldDefinition.sort_order, CustomFieldDefinition.created_at
+    )
+    if not include_inactive:
+        stmt = stmt.where(CustomFieldDefinition.is_active == True)  # noqa: E712
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def upsert_values(
+    db: AsyncSession,
+    *,
+    scope: str,
+    record_id: uuid.UUID,
+    values: dict[str, Any],
+) -> dict[str, Any]:
+    """Set values for a record. `values` is `{key: raw_value}` for ACTIVE
+    definitions only. Required-field check runs across all active defs in
+    scope. Returns the canonical decoded values for the record after the
+    upsert.
+    """
+    defs = await list_definitions(db, scope=scope, include_inactive=False)
+    by_key = {d.key: d for d in defs}
+
+    # Required-field check
+    for d in defs:
+        if d.is_required:
+            if d.key not in values and not await _has_existing_value(db, d.id, record_id):
+                raise CustomFieldError(f"Required custom field missing: {d.key}")
+
+    # Coerce + upsert
+    for key, raw in values.items():
+        if key not in by_key:
+            # Unknown key — silently ignore so client API stays loose
+            continue
+        d = by_key[key]
+        canonical = coerce_value(d.field_type, raw, d.options)
+        existing = (
+            await db.execute(
+                select(CustomFieldValue).where(
+                    CustomFieldValue.definition_id == d.id,
+                    CustomFieldValue.record_id == record_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is None:
+            db.add(
+                CustomFieldValue(
+                    definition_id=d.id,
+                    record_id=record_id,
+                    value=canonical,
+                )
+            )
+        else:
+            existing.value = canonical
+
+    await db.flush()
+    return await read_values(db, scope=scope, record_id=record_id)
+
+
+async def _has_existing_value(db: AsyncSession, definition_id: uuid.UUID, record_id: uuid.UUID) -> bool:
+    row = (
+        await db.execute(
+            select(CustomFieldValue.id).where(
+                CustomFieldValue.definition_id == definition_id,
+                CustomFieldValue.record_id == record_id,
+            )
+        )
+    ).first()
+    return row is not None
+
+
+async def read_values(
+    db: AsyncSession, *, scope: str, record_id: uuid.UUID
+) -> dict[str, Any]:
+    defs = await list_definitions(db, scope=scope, include_inactive=True)
+    by_id = {d.id: d for d in defs}
+    rows = (
+        await db.execute(
+            select(CustomFieldValue).where(
+                CustomFieldValue.definition_id.in_(list(by_id.keys())),
+                CustomFieldValue.record_id == record_id,
+            )
+        )
+    ).scalars().all()
+    return {
+        by_id[r.definition_id].key: decode_value(by_id[r.definition_id].field_type, r.value)
+        for r in rows
+        if r.definition_id in by_id
+    }

--- a/backend/tests/test_custom_field_service.py
+++ b/backend/tests/test_custom_field_service.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import datetime
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from app.services.custom_field_service import (
+    CustomFieldError,
+    coerce_value,
+    decode_value,
+    list_definitions,
+    read_values,
+    upsert_values,
+    validate_definition,
+)
+
+
+# ---------- validate_definition ----------
+
+
+def test_validate_unknown_scope():
+    with pytest.raises(CustomFieldError):
+        validate_definition(scope="bogus", key="x", field_type="text", options=None)
+
+
+def test_validate_invalid_key():
+    with pytest.raises(CustomFieldError):
+        validate_definition(scope="customer", key="Bad-Key", field_type="text", options=None)
+
+
+def test_validate_unknown_type():
+    with pytest.raises(CustomFieldError):
+        validate_definition(scope="customer", key="x", field_type="bogus", options=None)
+
+
+def test_validate_dropdown_requires_options():
+    with pytest.raises(CustomFieldError):
+        validate_definition(scope="customer", key="x", field_type="dropdown", options=None)
+
+
+# ---------- coerce_value ----------
+
+
+def test_coerce_text():
+    assert coerce_value("text", "hello", None) == "hello"
+
+
+def test_coerce_number_invalid():
+    with pytest.raises(CustomFieldError):
+        coerce_value("number", "not a number", None)
+
+
+def test_coerce_number_valid():
+    assert coerce_value("number", "12.34", None) == "12.34"
+
+
+def test_coerce_date_iso():
+    assert coerce_value("date", "2026-05-01", None) == "2026-05-01"
+
+
+def test_coerce_date_invalid():
+    with pytest.raises(CustomFieldError):
+        coerce_value("date", "not a date", None)
+
+
+def test_coerce_checkbox_truthy():
+    assert coerce_value("checkbox", True, None) == "true"
+    assert coerce_value("checkbox", "yes", None) == "true"
+    assert coerce_value("checkbox", "0", None) == "false"
+
+
+def test_coerce_dropdown_must_match():
+    assert coerce_value("dropdown", "small", ["small", "medium", "large"]) == "small"
+    with pytest.raises(CustomFieldError):
+        coerce_value("dropdown", "huge", ["small", "medium", "large"])
+
+
+def test_decode_checkbox_round_trip():
+    assert decode_value("checkbox", "true") is True
+    assert decode_value("checkbox", "false") is False
+
+
+# ---------- service ----------
+
+
+@pytest.mark.asyncio
+async def test_list_definitions_unknown_scope_rejected(db_session):
+    with pytest.raises(CustomFieldError):
+        await list_definitions(db_session, scope="bogus")
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_read_text_field(db_session):
+    from app.models.custom_field import CustomFieldDefinition
+
+    d = CustomFieldDefinition(
+        scope="customer", key="preferred_color", name="Preferred filament color",
+        field_type="text", is_required=False,
+    )
+    db_session.add(d)
+    await db_session.flush()
+
+    rec_id = uuid.uuid4()
+    out = await upsert_values(
+        db_session,
+        scope="customer",
+        record_id=rec_id,
+        values={"preferred_color": "Bambu Beige"},
+    )
+    assert out == {"preferred_color": "Bambu Beige"}
+
+    # Re-upsert overwrites
+    out = await upsert_values(
+        db_session,
+        scope="customer",
+        record_id=rec_id,
+        values={"preferred_color": "Forest Green"},
+    )
+    assert out == {"preferred_color": "Forest Green"}
+
+    again = await read_values(db_session, scope="customer", record_id=rec_id)
+    assert again == {"preferred_color": "Forest Green"}
+
+
+@pytest.mark.asyncio
+async def test_required_field_missing_raises(db_session):
+    from app.models.custom_field import CustomFieldDefinition
+
+    d = CustomFieldDefinition(
+        scope="customer", key="reqfield", name="Required",
+        field_type="text", is_required=True,
+    )
+    db_session.add(d)
+    await db_session.flush()
+
+    with pytest.raises(CustomFieldError):
+        await upsert_values(
+            db_session,
+            scope="customer",
+            record_id=uuid.uuid4(),
+            values={},  # required field missing
+        )
+
+
+@pytest.mark.asyncio
+async def test_unknown_key_silently_ignored(db_session):
+    """Sending values with keys not defined for the scope is a no-op,
+    not an error — keeps the API loose for callers that send a superset.
+    """
+    rec_id = uuid.uuid4()
+    out = await upsert_values(
+        db_session,
+        scope="customer",
+        record_id=rec_id,
+        values={"undefined_key": "anything"},
+    )
+    assert out == {}

--- a/docs/custom_fields.md
+++ b/docs/custom_fields.md
@@ -1,0 +1,40 @@
+# Custom Fields (Phase 1)
+
+User-defined per-scope fields stored in a side table — the existing record schemas (Customer, Product, etc.) are untouched. #253.
+
+## Model
+
+- **`CustomFieldDefinition`**: `scope` × `key` (unique), `name`, `field_type` (text / long_text / number / date / dropdown / checkbox), `options` (JSON, for dropdown), `is_required`, `sort_order`, `is_active`.
+- **`CustomFieldValue`**: `(definition_id, record_id)` unique. String-stored; coerced on read per type.
+
+## Supported scopes (Phase 1)
+
+`customer`, `vendor`, `product`, `material`, `supply`, `job`, `sale`, `invoice`, `quote`, `bill`.
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `GET` | `/api/v1/custom-fields/{scope}` | List definitions for a scope. |
+| `POST` | `/api/v1/custom-fields` | Create a definition. Validates `key` slug, dropdown options, type. |
+| `PATCH` | `/api/v1/custom-fields/{id}` | Update name / options / required / sort_order / active. `field_type` and `scope` are immutable to avoid silent value-corruption. |
+| `DELETE` | `/api/v1/custom-fields/{id}` | Soft-deactivate (preserves stored values). Hard delete is a Phase 2 follow-up gated on no-values check. |
+| `GET` | `/api/v1/custom-fields/values/{scope}/{record_id}` | Read all values for a record. |
+| `POST` | `/api/v1/custom-fields/values/{scope}/{record_id}` | Upsert values: `{values: {key: raw}}`. Required-field check across active defs. Unknown keys silently ignored. |
+
+## Coercion
+
+| Field type | Storage | API form |
+|---|---|---|
+| `text`, `long_text`, `dropdown` | string | string |
+| `number` | normalized Decimal string | string |
+| `date` | `YYYY-MM-DD` ISO | `YYYY-MM-DD` |
+| `checkbox` | `"true"` / `"false"` | bool |
+
+## Phase 2 follow-ups
+
+- **List filtering** by custom field value (`?cf.{key}=value`) on master-data list endpoints.
+- **Frontend** definition CRUD under `/admin` + per-detail-page "Custom" section.
+- **Hard delete** of definitions (gated on no-values check).
+- **Computed fields**, **field-level validation rules** (regex, min/max), **multi-value fields**.
+- **Per-line custom fields** (currently only on parent records).


### PR DESCRIPTION
Closes #253 Phase 1. Side-table storage avoids touching every record schema. 439 tests pass (423 + 16 new). Phase 2 (list filters, frontend, hard delete, computed fields) deferred.