### PR TITLE
feat(inventory): kits Phase 1 — define product → component list (#262)

### DIFF
--- a/backend/alembic/versions/20260509_18_add_kit_components.py
+++ b/backend/alembic/versions/20260509_18_add_kit_components.py
@@ -1,0 +1,40 @@
+"""add kit_components (#262 Phase 1)
+
+Revision ID: 20260509_18
+Revises: 20260509_17
+Create Date: 2026-05-10 02:30:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_18"
+down_revision = "20260509_17"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "kit_components",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("kit_product_id", sa.UUID(), nullable=False),
+        sa.Column("component_product_id", sa.UUID(), nullable=False),
+        sa.Column("quantity", sa.Numeric(10, 4), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["kit_product_id"], ["products.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["component_product_id"], ["products.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("kit_product_id", "component_product_id", name="uq_kit_components_kit_component"),
+    )
+    op.create_index("ix_kit_components_kit_product_id", "kit_components", ["kit_product_id"])
+    op.create_index("ix_kit_components_component_product_id", "kit_components", ["component_product_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_kit_components_component_product_id", table_name="kit_components")
+    op.drop_index("ix_kit_components_kit_product_id", table_name="kit_components")
+    op.drop_table("kit_components")

--- a/backend/app/api/v1/endpoints/kits.py
+++ b/backend/app/api/v1/endpoints/kits.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.kit_component import KitComponent
+from app.models.product import Product
+
+
+router = APIRouter(prefix="/kits", tags=["Kits"])
+
+
+class KitComponentRow(BaseModel):
+    component_product_id: uuid.UUID
+    quantity: Decimal = Field(..., gt=0)
+
+
+class KitDefinitionRequest(BaseModel):
+    components: list[KitComponentRow] = Field(..., min_length=1)
+
+
+class KitComponentResponse(BaseModel):
+    id: uuid.UUID
+    component_product_id: uuid.UUID
+    quantity: Decimal
+
+
+class KitResponse(BaseModel):
+    kit_product_id: uuid.UUID
+    components: list[KitComponentResponse]
+
+
+async def _ensure_product(db, product_id: uuid.UUID) -> Product:
+    p = (await db.execute(select(Product).where(Product.id == product_id))).scalar_one_or_none()
+    if p is None:
+        raise HTTPException(status_code=404, detail=f"Product {product_id} not found")
+    return p
+
+
+@router.get("/{kit_product_id}", response_model=KitResponse, summary="Get the kit definition for a product")
+async def get_kit(kit_product_id: uuid.UUID, user: CurrentUser, db: DB):
+    await _ensure_product(db, kit_product_id)
+    rows = (
+        await db.execute(
+            select(KitComponent).where(KitComponent.kit_product_id == kit_product_id)
+        )
+    ).scalars().all()
+    return KitResponse(
+        kit_product_id=kit_product_id,
+        components=[
+            KitComponentResponse(
+                id=r.id,
+                component_product_id=r.component_product_id,
+                quantity=Decimal(r.quantity),
+            )
+            for r in rows
+        ],
+    )
+
+
+@router.put("/{kit_product_id}", response_model=KitResponse, summary="Define or replace the kit's component list")
+async def upsert_kit(kit_product_id: uuid.UUID, body: KitDefinitionRequest, user: CurrentUser, db: DB):
+    kit = await _ensure_product(db, kit_product_id)
+    # Validate component products exist + none is the kit itself (no self-reference)
+    for c in body.components:
+        if c.component_product_id == kit_product_id:
+            raise HTTPException(status_code=400, detail="A kit cannot include itself as a component")
+        await _ensure_product(db, c.component_product_id)
+
+    # Replace existing components for this kit (upsert semantics)
+    existing = (
+        await db.execute(
+            select(KitComponent).where(KitComponent.kit_product_id == kit_product_id)
+        )
+    ).scalars().all()
+    for r in existing:
+        await db.delete(r)
+    await db.flush()
+
+    out_rows = []
+    for c in body.components:
+        kc = KitComponent(
+            kit_product_id=kit_product_id,
+            component_product_id=c.component_product_id,
+            quantity=c.quantity,
+        )
+        db.add(kc)
+        await db.flush()
+        out_rows.append(
+            KitComponentResponse(
+                id=kc.id,
+                component_product_id=kc.component_product_id,
+                quantity=Decimal(kc.quantity),
+            )
+        )
+    await db.commit()
+    return KitResponse(kit_product_id=kit_product_id, components=out_rows)
+
+
+@router.delete("/{kit_product_id}", status_code=204, summary="Remove all components (the product stops being a kit)")
+async def clear_kit(kit_product_id: uuid.UUID, user: CurrentUser, db: DB):
+    rows = (
+        await db.execute(
+            select(KitComponent).where(KitComponent.kit_product_id == kit_product_id)
+        )
+    ).scalars().all()
+    for r in rows:
+        await db.delete(r)
+    await db.commit()
+
+
+@router.get("", summary="List all kit products (products with at least one component)")
+async def list_kits(user: CurrentUser, db: DB):
+    rows = (
+        await db.execute(
+            select(KitComponent.kit_product_id).distinct()
+        )
+    ).scalars().all()
+    return {"kit_product_ids": [str(r) for r in rows]}

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, accounting_foundations, approvals, attachments, audit, auth, banking, batch_ops, budgets, cameras, custom_fields, customers, dashboard, divisions, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, statement_match_rules, supplies, tax
+from app.api.v1.endpoints import accounting, accounting_foundations, approvals, attachments, audit, auth, banking, batch_ops, budgets, cameras, custom_fields, customers, dashboard, divisions, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, kits, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, statement_match_rules, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -43,3 +43,4 @@ api_router.include_router(divisions.router)
 api_router.include_router(budgets.router)
 api_router.include_router(custom_fields.router)
 api_router.include_router(batch_ops.router)
+api_router.include_router(kits.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,6 +8,7 @@ from app.models.expense_claim import ExpenseClaim, ExpenseClaimLine  # noqa: F40
 from app.models.fixed_asset import DepreciationEntry, FixedAsset  # noqa: F401
 from app.models.inter_account_transfer import InterAccountTransfer  # noqa: F401
 from app.models.intangible_asset import AmortizationEntry, IntangibleAsset  # noqa: F401
+from app.models.kit_component import KitComponent  # noqa: F401
 from app.models.inventory_location import (  # noqa: F401
     InventoryLocation,
     InventoryTransfer,

--- a/backend/app/models/kit_component.py
+++ b/backend/app/models/kit_component.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Numeric,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class KitComponent(Base):
+    """Links a 'kit' product to its component products with per-unit
+    quantities (#262). A product is treated as a kit whenever it has at
+    least one row here — no extra `kind` column on Product needed.
+    """
+
+    __tablename__ = "kit_components"
+    __table_args__ = (
+        UniqueConstraint("kit_product_id", "component_product_id", name="uq_kit_components_kit_component"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    kit_product_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("products.id", ondelete="CASCADE"), index=True
+    )
+    component_product_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("products.id"), index=True
+    )
+    quantity: Mapped[Decimal] = mapped_column(Numeric(10, 4))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )

--- a/backend/tests/test_kits_api.py
+++ b/backend/tests/test_kits_api.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from app.models.product import Product
+
+
+async def _make_product(db_session, sku: str, name: str) -> Product:
+    from app.models.material import Material
+    from decimal import Decimal
+    from sqlalchemy import select
+    mat = (await db_session.execute(select(Material))).scalars().first()
+    if mat is None:
+        mat = Material(
+            name="Test Material",
+            brand="TestBrand",
+            spool_weight_g=Decimal("1000"),
+            spool_price=Decimal("20"),
+            net_usable_g=Decimal("950"),
+            cost_per_g=Decimal("20") / Decimal("950"),
+        )
+        db_session.add(mat)
+        await db_session.flush()
+    p = Product(sku=sku, name=name, material_id=mat.id)
+    db_session.add(p)
+    await db_session.flush()
+    return p
+
+
+@pytest.mark.asyncio
+async def test_define_kit(client: AsyncClient, auth_headers, db_session):
+    kit = await _make_product(db_session, "KIT-1", "Big Kit")
+    a = await _make_product(db_session, "COMP-A", "Component A")
+    b = await _make_product(db_session, "COMP-B", "Component B")
+    await db_session.commit()
+
+    resp = await client.put(
+        f"/api/v1/kits/{kit.id}",
+        json={"components": [
+            {"component_product_id": str(a.id), "quantity": "2"},
+            {"component_product_id": str(b.id), "quantity": "1"},
+        ]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["components"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_kit_self_reference_rejected(client: AsyncClient, auth_headers, db_session):
+    p = await _make_product(db_session, "KIT-self", "Self-kit")
+    await db_session.commit()
+    resp = await client.put(
+        f"/api/v1/kits/{p.id}",
+        json={"components": [{"component_product_id": str(p.id), "quantity": "1"}]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_kit_unknown_component_rejected(client: AsyncClient, auth_headers, db_session):
+    import uuid
+    p = await _make_product(db_session, "KIT-X", "kit X")
+    await db_session.commit()
+    resp = await client.put(
+        f"/api/v1/kits/{p.id}",
+        json={"components": [{"component_product_id": str(uuid.uuid4()), "quantity": "1"}]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_kit_replace_components(client: AsyncClient, auth_headers, db_session):
+    kit = await _make_product(db_session, "KIT-R", "kit R")
+    a = await _make_product(db_session, "RA", "comp A")
+    b = await _make_product(db_session, "RB", "comp B")
+    c = await _make_product(db_session, "RC", "comp C")
+    await db_session.commit()
+    await client.put(
+        f"/api/v1/kits/{kit.id}",
+        json={"components": [{"component_product_id": str(a.id), "quantity": "1"}]},
+        headers=auth_headers,
+    )
+    # Replace
+    resp = await client.put(
+        f"/api/v1/kits/{kit.id}",
+        json={"components": [
+            {"component_product_id": str(b.id), "quantity": "2"},
+            {"component_product_id": str(c.id), "quantity": "3"},
+        ]},
+        headers=auth_headers,
+    )
+    body = resp.json()
+    assert len(body["components"]) == 2
+    component_ids = {c["component_product_id"] for c in body["components"]}
+    assert str(a.id) not in component_ids
+    assert str(b.id) in component_ids
+    assert str(c.id) in component_ids
+
+
+@pytest.mark.asyncio
+async def test_clear_kit(client: AsyncClient, auth_headers, db_session):
+    kit = await _make_product(db_session, "KIT-C", "kit C")
+    a = await _make_product(db_session, "CA", "ca")
+    await db_session.commit()
+    await client.put(
+        f"/api/v1/kits/{kit.id}",
+        json={"components": [{"component_product_id": str(a.id), "quantity": "1"}]},
+        headers=auth_headers,
+    )
+    resp = await client.delete(f"/api/v1/kits/{kit.id}", headers=auth_headers)
+    assert resp.status_code == 204
+    get_resp = await client.get(f"/api/v1/kits/{kit.id}", headers=auth_headers)
+    assert get_resp.json()["components"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_kits_only_includes_kits(client: AsyncClient, auth_headers, db_session):
+    kit = await _make_product(db_session, "KIT-L", "kit L")
+    not_kit = await _make_product(db_session, "PROD-L", "plain product")
+    a = await _make_product(db_session, "LA", "la")
+    await db_session.commit()
+    await client.put(
+        f"/api/v1/kits/{kit.id}",
+        json={"components": [{"component_product_id": str(a.id), "quantity": "1"}]},
+        headers=auth_headers,
+    )
+    resp = await client.get("/api/v1/kits", headers=auth_headers)
+    ids = resp.json()["kit_product_ids"]
+    assert str(kit.id) in ids
+    assert str(not_kit.id) not in ids

--- a/docs/kits.md
+++ b/docs/kits.md
@@ -1,0 +1,20 @@
+# Inventory Kits (Phase 1)
+
+#262's kit piece. A product is treated as a "kit" whenever it has at least one row in `kit_components` linking it to other products with quantities. No new column on Product needed.
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `GET` | `/api/v1/kits/{kit_product_id}` | Get the kit definition (component list) for a product. |
+| `PUT` | `/api/v1/kits/{kit_product_id}` | Define or replace the kit's component list. Body: `{components: [{component_product_id, quantity}, ...]}`. Self-reference is rejected. Each component product must exist. |
+| `DELETE` | `/api/v1/kits/{kit_product_id}` | Remove all components → the product stops being a kit. |
+| `GET` | `/api/v1/kits` | List all kit products (distinct `kit_product_id` values). |
+
+## Phase 2 follow-ups
+
+- **Sale-time explosion**: when a kit is sold, decrement each component's stock and post COGS for each component instead of for the kit itself. Wire into `sales_service.py`. Today the kit is treated like any other product at sale time — define-only Phase 1.
+- **Nested kits** (a kit containing another kit). Phase 1 rejects self-reference but doesn't transitively check for cycles.
+- **Find-and-merge duplicate items** (still ❌ from #262 original scope — separate issue).
+- **Inventory starting-balances CSV import** (still ❌ from #262 original scope — overlaps with #260's starting-balances workflow but for inventory).
+- **Frontend** kit editor on Product detail page.


### PR DESCRIPTION
Kit-piece of #262. KitComponent model, define/replace/list endpoints. Sale-time explosion deferred. Find-and-merge + starting-balances import remain ❌ from original #262 scope. 452 tests pass (446 + 6 new).