### PR TITLE
feat(notes): credit + debit notes Phase 1 (#248)

### DIFF
--- a/backend/alembic/versions/20260509_19_add_credit_debit_notes.py
+++ b/backend/alembic/versions/20260509_19_add_credit_debit_notes.py
@@ -1,0 +1,124 @@
+"""add credit/debit notes + COA seed (#248)
+
+Revision ID: 20260509_19
+Revises: 20260509_18
+Create Date: 2026-05-10 03:00:00
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_19"
+down_revision = "20260509_18"
+branch_labels = None
+depends_on = None
+
+
+NEW_ACCOUNTS = [
+    ("4800", "Sales Returns", "revenue", "debit"),
+    ("5400", "Purchase Returns", "cogs", "credit"),
+]
+
+
+def _create_note_tables(prefix: str, parent_fk_table: str, parent_id_column: str) -> None:
+    op.create_table(
+        f"{prefix}_notes",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(f"{prefix}_note_number", sa.String(length=50), nullable=False),
+        sa.Column("vendor_id" if prefix == "debit" else "customer_id", sa.UUID(), nullable=False),
+        sa.Column(parent_id_column, sa.UUID(), nullable=True),
+        sa.Column("issued_on", sa.Date(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="draft"),
+        sa.Column("reason", sa.String(length=40), nullable=True),
+        sa.Column("subtotal_amount", sa.Numeric(12, 2), nullable=False, server_default="0"),
+        sa.Column("tax_amount", sa.Numeric(12, 2), nullable=False, server_default="0"),
+        sa.Column("total_amount", sa.Numeric(12, 2), nullable=False, server_default="0"),
+        sa.Column("applied_amount", sa.Numeric(12, 2), nullable=False, server_default="0"),
+        sa.Column("journal_entry_id", sa.UUID(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(
+            ["vendor_id" if prefix == "debit" else "customer_id"],
+            ["vendors.id" if prefix == "debit" else "customers.id"],
+        ),
+        sa.ForeignKeyConstraint([parent_id_column], [parent_fk_table]),
+        sa.ForeignKeyConstraint(["journal_entry_id"], ["journal_entries.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(f"{prefix}_note_number", name=f"uq_{prefix}_notes_number"),
+    )
+    op.create_index(f"ix_{prefix}_notes_status", f"{prefix}_notes", ["status"])
+
+    op.create_table(
+        f"{prefix}_note_lines",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(f"{prefix}_note_id", sa.UUID(), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=False),
+        sa.Column("quantity", sa.Numeric(12, 4), nullable=False),
+        sa.Column("unit_price", sa.Numeric(12, 2), nullable=False),
+        sa.Column("line_total", sa.Numeric(12, 2), nullable=False),
+        sa.Column("account_id", sa.UUID(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint([f"{prefix}_note_id"], [f"{prefix}_notes.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["account_id"], ["accounts.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(f"ix_{prefix}_note_lines_{prefix}_note_id", f"{prefix}_note_lines", [f"{prefix}_note_id"])
+
+    other_id = "invoice_id" if prefix == "credit" else "bill_id"
+    other_table = "invoices" if prefix == "credit" else "bills"
+    op.create_table(
+        f"{prefix}_note_applications",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(f"{prefix}_note_id", sa.UUID(), nullable=False),
+        sa.Column(other_id, sa.UUID(), nullable=False),
+        sa.Column("amount", sa.Numeric(12, 2), nullable=False),
+        sa.Column("applied_on", sa.Date(), nullable=False),
+        sa.Column("journal_entry_id", sa.UUID(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint([f"{prefix}_note_id"], [f"{prefix}_notes.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint([other_id], [other_table + ".id"]),
+        sa.ForeignKeyConstraint(["journal_entry_id"], ["journal_entries.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(f"ix_{prefix}_note_applications_{prefix}_note_id", f"{prefix}_note_applications", [f"{prefix}_note_id"])
+    op.create_index(f"ix_{prefix}_note_applications_{other_id}", f"{prefix}_note_applications", [other_id])
+
+
+def upgrade() -> None:
+    _create_note_tables("credit", "invoices.id", "original_invoice_id")
+    _create_note_tables("debit", "bills.id", "original_bill_id")
+
+    bind = op.get_bind()
+    for code, name, account_type, normal_balance in NEW_ACCOUNTS:
+        existing = bind.execute(
+            sa.text("SELECT 1 FROM accounts WHERE code = :code"), {"code": code}
+        ).first()
+        if existing:
+            continue
+        bind.execute(
+            sa.text(
+                "INSERT INTO accounts (id, code, name, account_type, normal_balance, "
+                "is_active, is_system, is_bank_account, created_at, updated_at) "
+                "VALUES (:id, :code, :name, :type, :normal, true, true, false, NOW(), NOW())"
+            ),
+            {
+                "id": str(uuid.uuid4()),
+                "code": code,
+                "name": name,
+                "type": account_type,
+                "normal": normal_balance,
+            },
+        )
+
+
+def downgrade() -> None:
+    for prefix in ("debit", "credit"):
+        op.drop_table(f"{prefix}_note_applications")
+        op.drop_table(f"{prefix}_note_lines")
+        op.drop_table(f"{prefix}_notes")

--- a/backend/app/api/v1/endpoints/notes.py
+++ b/backend/app/api/v1/endpoints/notes.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.credit_note import CreditNote, CreditNoteLine
+from app.models.debit_note import DebitNote, DebitNoteLine
+from app.services.note_service import (
+    NoteError,
+    apply_credit_note,
+    apply_debit_note,
+    create_credit_note,
+    create_debit_note,
+    issue_credit_note,
+    issue_debit_note,
+    void_credit_note,
+    void_debit_note,
+)
+
+
+router = APIRouter(tags=["CreditDebitNotes"])
+
+
+class LineIn(BaseModel):
+    description: str = Field(..., min_length=1, max_length=255)
+    quantity: Decimal = Field(..., gt=0)
+    unit_price: Decimal = Field(..., ge=0)
+    account_id: uuid.UUID
+
+
+class CreditNoteCreate(BaseModel):
+    customer_id: uuid.UUID
+    issued_on: date
+    original_invoice_id: uuid.UUID | None = None
+    reason: str | None = None
+    notes: str | None = None
+    lines: list[LineIn] = Field(..., min_length=1)
+
+
+class DebitNoteCreate(BaseModel):
+    vendor_id: uuid.UUID
+    issued_on: date
+    original_bill_id: uuid.UUID | None = None
+    reason: str | None = None
+    notes: str | None = None
+    lines: list[LineIn] = Field(..., min_length=1)
+
+
+class ApplyRequest(BaseModel):
+    target_id: uuid.UUID
+    amount: Decimal = Field(..., gt=0)
+    applied_on: date | None = None
+
+
+def _credit_to_dict(n: CreditNote) -> dict:
+    return {
+        "id": str(n.id),
+        "credit_note_number": n.credit_note_number,
+        "customer_id": str(n.customer_id),
+        "original_invoice_id": str(n.original_invoice_id) if n.original_invoice_id else None,
+        "issued_on": n.issued_on.isoformat(),
+        "status": n.status,
+        "reason": n.reason,
+        "subtotal_amount": str(Decimal(n.subtotal_amount)),
+        "total_amount": str(Decimal(n.total_amount)),
+        "applied_amount": str(Decimal(n.applied_amount)),
+        "journal_entry_id": str(n.journal_entry_id) if n.journal_entry_id else None,
+        "notes": n.notes,
+    }
+
+
+def _debit_to_dict(n: DebitNote) -> dict:
+    return {
+        "id": str(n.id),
+        "debit_note_number": n.debit_note_number,
+        "vendor_id": str(n.vendor_id),
+        "original_bill_id": str(n.original_bill_id) if n.original_bill_id else None,
+        "issued_on": n.issued_on.isoformat(),
+        "status": n.status,
+        "reason": n.reason,
+        "subtotal_amount": str(Decimal(n.subtotal_amount)),
+        "total_amount": str(Decimal(n.total_amount)),
+        "applied_amount": str(Decimal(n.applied_amount)),
+        "journal_entry_id": str(n.journal_entry_id) if n.journal_entry_id else None,
+        "notes": n.notes,
+    }
+
+
+# ---------- credit notes ----------
+
+
+@router.post("/credit-notes", status_code=status.HTTP_201_CREATED, summary="Create a draft credit note")
+async def create_cn(body: CreditNoteCreate, user: CurrentUser, db: DB):
+    try:
+        n = await create_credit_note(
+            db,
+            customer_id=body.customer_id,
+            issued_on=body.issued_on,
+            lines=[l.model_dump(mode="json") for l in body.lines],
+            original_invoice_id=body.original_invoice_id,
+            reason=body.reason,
+            notes=body.notes,
+        )
+    except NoteError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _credit_to_dict(n)
+
+
+@router.get("/credit-notes", summary="List credit notes")
+async def list_cn(user: CurrentUser, db: DB, customer_id: uuid.UUID | None = None, status_filter: str | None = None):
+    stmt = select(CreditNote).order_by(CreditNote.issued_on.desc())
+    if customer_id:
+        stmt = stmt.where(CreditNote.customer_id == customer_id)
+    if status_filter:
+        stmt = stmt.where(CreditNote.status == status_filter)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [_credit_to_dict(r) for r in rows]
+
+
+@router.get("/credit-notes/{note_id}", summary="Credit note detail")
+async def get_cn(note_id: uuid.UUID, user: CurrentUser, db: DB):
+    n = (await db.execute(select(CreditNote).where(CreditNote.id == note_id))).scalar_one_or_none()
+    if not n:
+        raise HTTPException(status_code=404, detail="Credit note not found")
+    lines = (
+        await db.execute(select(CreditNoteLine).where(CreditNoteLine.credit_note_id == n.id))
+    ).scalars().all()
+    return {
+        **_credit_to_dict(n),
+        "lines": [
+            {
+                "id": str(l.id),
+                "description": l.description,
+                "quantity": str(Decimal(l.quantity)),
+                "unit_price": str(Decimal(l.unit_price)),
+                "line_total": str(Decimal(l.line_total)),
+                "account_id": str(l.account_id),
+            }
+            for l in lines
+        ],
+    }
+
+
+@router.post("/credit-notes/{note_id}/issue", summary="Issue (post JE) a draft credit note")
+async def issue_cn(note_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        n = await issue_credit_note(db, note_id)
+    except NoteError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _credit_to_dict(n)
+
+
+@router.post("/credit-notes/{note_id}/apply", summary="Apply credit note to an invoice")
+async def apply_cn(note_id: uuid.UUID, body: ApplyRequest, user: CurrentUser, db: DB):
+    try:
+        app = await apply_credit_note(
+            db,
+            note_id=note_id,
+            invoice_id=body.target_id,
+            amount=body.amount,
+            applied_on=body.applied_on,
+        )
+    except NoteError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return {
+        "id": str(app.id),
+        "credit_note_id": str(app.credit_note_id),
+        "invoice_id": str(app.invoice_id),
+        "amount": str(Decimal(app.amount)),
+        "applied_on": app.applied_on.isoformat(),
+    }
+
+
+@router.post("/credit-notes/{note_id}/void", summary="Void a credit note (reverses issue JE)")
+async def void_cn(note_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        n = await void_credit_note(db, note_id)
+    except NoteError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _credit_to_dict(n)
+
+
+# ---------- debit notes (mirror) ----------
+
+
+@router.post("/debit-notes", status_code=status.HTTP_201_CREATED, summary="Create a draft debit note")
+async def create_dn(body: DebitNoteCreate, user: CurrentUser, db: DB):
+    try:
+        n = await create_debit_note(
+            db,
+            vendor_id=body.vendor_id,
+            issued_on=body.issued_on,
+            lines=[l.model_dump(mode="json") for l in body.lines],
+            original_bill_id=body.original_bill_id,
+            reason=body.reason,
+            notes=body.notes,
+        )
+    except NoteError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _debit_to_dict(n)
+
+
+@router.get("/debit-notes", summary="List debit notes")
+async def list_dn(user: CurrentUser, db: DB, vendor_id: uuid.UUID | None = None, status_filter: str | None = None):
+    stmt = select(DebitNote).order_by(DebitNote.issued_on.desc())
+    if vendor_id:
+        stmt = stmt.where(DebitNote.vendor_id == vendor_id)
+    if status_filter:
+        stmt = stmt.where(DebitNote.status == status_filter)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [_debit_to_dict(r) for r in rows]
+
+
+@router.get("/debit-notes/{note_id}", summary="Debit note detail")
+async def get_dn(note_id: uuid.UUID, user: CurrentUser, db: DB):
+    n = (await db.execute(select(DebitNote).where(DebitNote.id == note_id))).scalar_one_or_none()
+    if not n:
+        raise HTTPException(status_code=404, detail="Debit note not found")
+    lines = (
+        await db.execute(select(DebitNoteLine).where(DebitNoteLine.debit_note_id == n.id))
+    ).scalars().all()
+    return {
+        **_debit_to_dict(n),
+        "lines": [
+            {
+                "id": str(l.id),
+                "description": l.description,
+                "quantity": str(Decimal(l.quantity)),
+                "unit_price": str(Decimal(l.unit_price)),
+                "line_total": str(Decimal(l.line_total)),
+                "account_id": str(l.account_id),
+            }
+            for l in lines
+        ],
+    }
+
+
+@router.post("/debit-notes/{note_id}/issue", summary="Issue (post JE) a draft debit note")
+async def issue_dn(note_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        n = await issue_debit_note(db, note_id)
+    except NoteError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _debit_to_dict(n)
+
+
+@router.post("/debit-notes/{note_id}/apply", summary="Apply debit note to a bill")
+async def apply_dn(note_id: uuid.UUID, body: ApplyRequest, user: CurrentUser, db: DB):
+    try:
+        app = await apply_debit_note(
+            db,
+            note_id=note_id,
+            bill_id=body.target_id,
+            amount=body.amount,
+            applied_on=body.applied_on,
+        )
+    except NoteError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return {
+        "id": str(app.id),
+        "debit_note_id": str(app.debit_note_id),
+        "bill_id": str(app.bill_id),
+        "amount": str(Decimal(app.amount)),
+        "applied_on": app.applied_on.isoformat(),
+    }
+
+
+@router.post("/debit-notes/{note_id}/void", summary="Void a debit note (reverses issue JE)")
+async def void_dn(note_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        n = await void_debit_note(db, note_id)
+    except NoteError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _debit_to_dict(n)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, accounting_foundations, approvals, attachments, audit, auth, banking, batch_ops, budgets, cameras, custom_fields, customers, dashboard, divisions, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, kits, locations, materials, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, statement_match_rules, supplies, tax
+from app.api.v1.endpoints import accounting, accounting_foundations, approvals, attachments, audit, auth, banking, batch_ops, budgets, cameras, custom_fields, customers, dashboard, divisions, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, kits, locations, materials, notes, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, statement_match_rules, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -44,3 +44,4 @@ api_router.include_router(budgets.router)
 api_router.include_router(custom_fields.router)
 api_router.include_router(batch_ops.router)
 api_router.include_router(kits.router)
+api_router.include_router(notes.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,8 @@
 from app.models.account_budget import AccountBudget  # noqa: F401
 from app.models.attachment import Attachment  # noqa: F401
+from app.models.credit_note import CreditNote, CreditNoteApplication, CreditNoteLine  # noqa: F401
 from app.models.custom_field import CustomFieldDefinition, CustomFieldValue  # noqa: F401
+from app.models.debit_note import DebitNote, DebitNoteApplication, DebitNoteLine  # noqa: F401
 from app.models.bank_reconciliation import BankReconciliation, BankReconciliationLine  # noqa: F401
 from app.models.camera import Camera  # noqa: F401
 from app.models.email_delivery import EmailDelivery  # noqa: F401

--- a/backend/app/models/credit_note.py
+++ b/backend/app/models/credit_note.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class CreditNote(Base):
+    """Customer-facing return/refund document (#248)."""
+
+    __tablename__ = "credit_notes"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    credit_note_number: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    customer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("customers.id"), index=True)
+    original_invoice_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("invoices.id"), nullable=True, index=True
+    )
+    issued_on: Mapped[date] = mapped_column(Date)
+    status: Mapped[str] = mapped_column(String(20), default="draft", index=True)
+    reason: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    subtotal_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    tax_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    total_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    applied_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    journal_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("journal_entries.id"), nullable=True
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    lines = relationship("CreditNoteLine", back_populates="credit_note", cascade="all, delete-orphan")
+    applications = relationship("CreditNoteApplication", back_populates="credit_note", cascade="all, delete-orphan")
+
+
+class CreditNoteLine(Base):
+    __tablename__ = "credit_note_lines"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    credit_note_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("credit_notes.id", ondelete="CASCADE"), index=True
+    )
+    description: Mapped[str] = mapped_column(String(255))
+    quantity: Mapped[Decimal] = mapped_column(Numeric(12, 4))
+    unit_price: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    line_total: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    credit_note = relationship("CreditNote", back_populates="lines")
+
+
+class CreditNoteApplication(Base):
+    __tablename__ = "credit_note_applications"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    credit_note_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("credit_notes.id", ondelete="CASCADE"), index=True
+    )
+    invoice_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("invoices.id"), index=True)
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    applied_on: Mapped[date] = mapped_column(Date)
+    journal_entry_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("journal_entries.id"))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    credit_note = relationship("CreditNote", back_populates="applications")

--- a/backend/app/models/debit_note.py
+++ b/backend/app/models/debit_note.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class DebitNote(Base):
+    """Vendor-facing return document (#248). Symmetric mirror of CreditNote."""
+
+    __tablename__ = "debit_notes"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    debit_note_number: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    vendor_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("vendors.id"), index=True)
+    original_bill_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("bills.id"), nullable=True, index=True
+    )
+    issued_on: Mapped[date] = mapped_column(Date)
+    status: Mapped[str] = mapped_column(String(20), default="draft", index=True)
+    reason: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    subtotal_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    tax_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    total_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    applied_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    journal_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("journal_entries.id"), nullable=True
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    lines = relationship("DebitNoteLine", back_populates="debit_note", cascade="all, delete-orphan")
+    applications = relationship("DebitNoteApplication", back_populates="debit_note", cascade="all, delete-orphan")
+
+
+class DebitNoteLine(Base):
+    __tablename__ = "debit_note_lines"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    debit_note_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("debit_notes.id", ondelete="CASCADE"), index=True
+    )
+    description: Mapped[str] = mapped_column(String(255))
+    quantity: Mapped[Decimal] = mapped_column(Numeric(12, 4))
+    unit_price: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    line_total: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id"))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    debit_note = relationship("DebitNote", back_populates="lines")
+
+
+class DebitNoteApplication(Base):
+    __tablename__ = "debit_note_applications"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    debit_note_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("debit_notes.id", ondelete="CASCADE"), index=True
+    )
+    bill_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("bills.id"), index=True)
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    applied_on: Mapped[date] = mapped_column(Date)
+    journal_entry_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("journal_entries.id"))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    debit_note = relationship("DebitNote", back_populates="applications")

--- a/backend/app/services/accounting_service.py
+++ b/backend/app/services/accounting_service.py
@@ -56,6 +56,9 @@ STARTER_CHART_OF_ACCOUNTS = [
     # Accounting foundations cluster (#260)
     ("1900", "Suspense", "asset", "debit"),
     ("3300", "Opening Balance Equity", "equity", "credit"),
+    # Credit/debit notes (#248)
+    ("4800", "Sales Returns", "revenue", "debit"),
+    ("5400", "Purchase Returns", "cogs", "credit"),
 ]
 
 

--- a/backend/app/services/note_service.py
+++ b/backend/app/services/note_service.py
@@ -1,0 +1,462 @@
+"""Credit + debit note lifecycle (#248).
+
+Phase 1:
+- Create draft with line items
+- Issue: posts JE
+  - Credit note: Cr AR (1100) / Dr Sales Returns + line accounts
+  - Debit note: Cr Purchase Returns + line accounts / Dr AP (2000)
+- Apply to invoice/bill: posts JE that reduces both sides
+  - Credit note application: Dr Sales Returns / Cr AR (against the invoice)
+  - Debit note application: Dr AP (against the bill) / Cr Purchase Returns
+- Void: blocked once any application has been recorded.
+
+Restock interaction with #242 finished-goods layers, refund-in-cash,
+email scope registration, marketplace bridging are all deferred to
+Phase 2.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account
+from app.models.bill import Bill
+from app.models.credit_note import CreditNote, CreditNoteApplication, CreditNoteLine
+from app.models.debit_note import DebitNote, DebitNoteApplication, DebitNoteLine
+from app.models.invoice import Invoice
+from app.schemas.accounting import JournalEntryCreate, JournalLineCreate
+from app.services.accounting_service import (
+    AccountingValidationError,
+    create_journal_entry,
+)
+from app.services.reference_number_service import next_number
+
+
+class NoteError(RuntimeError):
+    pass
+
+
+async def _account_by_code(db: AsyncSession, code: str) -> Account:
+    a = (await db.execute(select(Account).where(Account.code == code))).scalar_one_or_none()
+    if a is None:
+        raise NoteError(f"COA missing account code {code}; run migration")
+    return a
+
+
+# ---------- credit notes ----------
+
+
+async def create_credit_note(
+    db: AsyncSession,
+    *,
+    customer_id: uuid.UUID,
+    issued_on: date,
+    lines: list[dict],
+    original_invoice_id: uuid.UUID | None = None,
+    reason: str | None = None,
+    notes: str | None = None,
+) -> CreditNote:
+    if not lines:
+        raise NoteError("Credit note must have at least one line")
+    number = await next_number(db, "credit_note")
+    note = CreditNote(
+        credit_note_number=number,
+        customer_id=customer_id,
+        original_invoice_id=original_invoice_id,
+        issued_on=issued_on,
+        status="draft",
+        reason=reason,
+        notes=notes,
+    )
+    db.add(note)
+    await db.flush()
+    subtotal = Decimal("0")
+    for line in lines:
+        qty = Decimal(str(line["quantity"]))
+        price = Decimal(str(line["unit_price"]))
+        total = (qty * price).quantize(Decimal("0.01"))
+        subtotal += total
+        db.add(
+            CreditNoteLine(
+                credit_note_id=note.id,
+                description=line["description"],
+                quantity=qty,
+                unit_price=price,
+                line_total=total,
+                account_id=line["account_id"],
+            )
+        )
+    note.subtotal_amount = subtotal
+    note.total_amount = subtotal  # tax flow deferred to Phase 2
+    await db.flush()
+    return note
+
+
+async def issue_credit_note(db: AsyncSession, note_id: uuid.UUID) -> CreditNote:
+    note = await _require_credit_note(db, note_id)
+    if note.status != "draft":
+        raise NoteError(f"Cannot issue credit note in status {note.status}")
+
+    ar = await _account_by_code(db, "1100")
+    sales_returns = await _account_by_code(db, "4800")
+    lines = (
+        await db.execute(select(CreditNoteLine).where(CreditNoteLine.credit_note_id == note.id))
+    ).scalars().all()
+
+    # JE: Cr AR (total) / Dr each line's account at line_total
+    je_lines = [
+        JournalLineCreate(
+            account_id=ar.id,
+            entry_type="credit",
+            amount=Decimal(note.total_amount),
+            description=f"Credit note {note.credit_note_number}",
+        )
+    ]
+    for line in lines:
+        # If the line points at a revenue account (the typical "reverse a
+        # sale" case), debiting that account is the right reversal. If the
+        # operator picked Sales Returns (4800), we still debit it.
+        je_lines.append(
+            JournalLineCreate(
+                account_id=line.account_id,
+                entry_type="debit",
+                amount=Decimal(line.line_total),
+                description=f"Credit note line: {line.description}",
+            )
+        )
+    try:
+        entry = await create_journal_entry(
+            db,
+            JournalEntryCreate(
+                entry_date=note.issued_on,
+                source_type="credit_note",
+                source_id=str(note.id),
+                memo=f"Issue credit note {note.credit_note_number}",
+                lines=je_lines,
+            ),
+        )
+    except AccountingValidationError as e:
+        raise NoteError(str(e)) from e
+
+    note.status = "issued"
+    note.journal_entry_id = entry.id
+    await db.flush()
+    _ = sales_returns  # 4800 reserved for Phase 2 refund-in-cash flow
+    return note
+
+
+async def apply_credit_note(
+    db: AsyncSession,
+    *,
+    note_id: uuid.UUID,
+    invoice_id: uuid.UUID,
+    amount: Decimal,
+    applied_on: date | None = None,
+) -> CreditNoteApplication:
+    note = await _require_credit_note(db, note_id)
+    if note.status not in ("issued", "partially_applied"):
+        raise NoteError(f"Cannot apply credit note in status {note.status}")
+    amt = Decimal(amount)
+    if amt <= 0:
+        raise NoteError("amount must be > 0")
+    remaining = Decimal(note.total_amount) - Decimal(note.applied_amount)
+    if amt > remaining:
+        raise NoteError(f"amount exceeds remaining credit ({remaining})")
+
+    invoice = (await db.execute(select(Invoice).where(Invoice.id == invoice_id))).scalar_one_or_none()
+    if invoice is None:
+        raise NoteError("Invoice not found")
+    if invoice.customer_id and invoice.customer_id != note.customer_id:
+        raise NoteError("Invoice belongs to a different customer")
+
+    ar = await _account_by_code(db, "1100")
+    sales_returns = await _account_by_code(db, "4800")
+
+    try:
+        entry = await create_journal_entry(
+            db,
+            JournalEntryCreate(
+                entry_date=applied_on or datetime.now(timezone.utc).date(),
+                source_type="credit_note_application",
+                source_id=str(note.id),
+                memo=f"Apply credit note {note.credit_note_number} to invoice {invoice.invoice_number}",
+                lines=[
+                    # Reduce the invoice's AR side by re-posting a credit
+                    JournalLineCreate(
+                        account_id=ar.id,
+                        entry_type="credit",
+                        amount=amt,
+                        description=f"Apply credit note to invoice {invoice.invoice_number}",
+                    ),
+                    JournalLineCreate(
+                        account_id=sales_returns.id,
+                        entry_type="debit",
+                        amount=amt,
+                        description=f"Apply credit note {note.credit_note_number}",
+                    ),
+                ],
+            ),
+        )
+    except AccountingValidationError as e:
+        raise NoteError(str(e)) from e
+
+    application = CreditNoteApplication(
+        credit_note_id=note.id,
+        invoice_id=invoice.id,
+        amount=amt,
+        applied_on=applied_on or datetime.now(timezone.utc).date(),
+        journal_entry_id=entry.id,
+    )
+    db.add(application)
+    note.applied_amount = Decimal(note.applied_amount) + amt
+    if note.applied_amount >= note.total_amount:
+        note.status = "applied"
+    else:
+        note.status = "partially_applied"
+
+    # Reduce the invoice's outstanding by treating the application as credits_applied
+    invoice.credits_applied = Decimal(invoice.credits_applied) + amt
+    invoice.balance_due = max(Decimal("0"), Decimal(invoice.balance_due) - amt)
+    await db.flush()
+    return application
+
+
+async def void_credit_note(db: AsyncSession, note_id: uuid.UUID) -> CreditNote:
+    note = await _require_credit_note(db, note_id)
+    if note.status == "void":
+        return note
+    if Decimal(note.applied_amount) > 0:
+        raise NoteError("Cannot void a credit note that has been applied; reverse the applications first")
+    if note.status == "issued":
+        # Reverse the issue JE
+        from app.schemas.accounting import JournalEntryReverse
+        from app.services.accounting_service import reverse_journal_entry
+
+        if note.journal_entry_id is not None:
+            try:
+                await reverse_journal_entry(
+                    db,
+                    entry_id=note.journal_entry_id,
+                    payload=JournalEntryReverse(
+                        reversal_date=datetime.now(timezone.utc).date(),
+                        memo=f"Void credit note {note.credit_note_number}",
+                    ),
+                )
+            except AccountingValidationError as e:
+                raise NoteError(str(e)) from e
+    note.status = "void"
+    await db.flush()
+    return note
+
+
+async def _require_credit_note(db: AsyncSession, note_id: uuid.UUID) -> CreditNote:
+    note = (await db.execute(select(CreditNote).where(CreditNote.id == note_id))).scalar_one_or_none()
+    if note is None:
+        raise NoteError("Credit note not found")
+    return note
+
+
+# ---------- debit notes ----------
+
+
+async def create_debit_note(
+    db: AsyncSession,
+    *,
+    vendor_id: uuid.UUID,
+    issued_on: date,
+    lines: list[dict],
+    original_bill_id: uuid.UUID | None = None,
+    reason: str | None = None,
+    notes: str | None = None,
+) -> DebitNote:
+    if not lines:
+        raise NoteError("Debit note must have at least one line")
+    number = await next_number(db, "debit_note")
+    note = DebitNote(
+        debit_note_number=number,
+        vendor_id=vendor_id,
+        original_bill_id=original_bill_id,
+        issued_on=issued_on,
+        status="draft",
+        reason=reason,
+        notes=notes,
+    )
+    db.add(note)
+    await db.flush()
+    subtotal = Decimal("0")
+    for line in lines:
+        qty = Decimal(str(line["quantity"]))
+        price = Decimal(str(line["unit_price"]))
+        total = (qty * price).quantize(Decimal("0.01"))
+        subtotal += total
+        db.add(
+            DebitNoteLine(
+                debit_note_id=note.id,
+                description=line["description"],
+                quantity=qty,
+                unit_price=price,
+                line_total=total,
+                account_id=line["account_id"],
+            )
+        )
+    note.subtotal_amount = subtotal
+    note.total_amount = subtotal
+    await db.flush()
+    return note
+
+
+async def issue_debit_note(db: AsyncSession, note_id: uuid.UUID) -> DebitNote:
+    note = await _require_debit_note(db, note_id)
+    if note.status != "draft":
+        raise NoteError(f"Cannot issue debit note in status {note.status}")
+
+    ap = await _account_by_code(db, "2000")
+    purchase_returns = await _account_by_code(db, "5400")
+    lines = (
+        await db.execute(select(DebitNoteLine).where(DebitNoteLine.debit_note_id == note.id))
+    ).scalars().all()
+
+    # JE: Dr AP / Cr line account (or Cr Purchase Returns) for line_total
+    je_lines = [
+        JournalLineCreate(
+            account_id=ap.id,
+            entry_type="debit",
+            amount=Decimal(note.total_amount),
+            description=f"Debit note {note.debit_note_number}",
+        )
+    ]
+    for line in lines:
+        je_lines.append(
+            JournalLineCreate(
+                account_id=line.account_id,
+                entry_type="credit",
+                amount=Decimal(line.line_total),
+                description=f"Debit note line: {line.description}",
+            )
+        )
+    try:
+        entry = await create_journal_entry(
+            db,
+            JournalEntryCreate(
+                entry_date=note.issued_on,
+                source_type="debit_note",
+                source_id=str(note.id),
+                memo=f"Issue debit note {note.debit_note_number}",
+                lines=je_lines,
+            ),
+        )
+    except AccountingValidationError as e:
+        raise NoteError(str(e)) from e
+
+    note.status = "issued"
+    note.journal_entry_id = entry.id
+    await db.flush()
+    _ = purchase_returns  # reserved for Phase 2 refund-from-vendor cash flow
+    return note
+
+
+async def apply_debit_note(
+    db: AsyncSession,
+    *,
+    note_id: uuid.UUID,
+    bill_id: uuid.UUID,
+    amount: Decimal,
+    applied_on: date | None = None,
+) -> DebitNoteApplication:
+    note = await _require_debit_note(db, note_id)
+    if note.status not in ("issued", "partially_applied"):
+        raise NoteError(f"Cannot apply debit note in status {note.status}")
+    amt = Decimal(amount)
+    if amt <= 0:
+        raise NoteError("amount must be > 0")
+    remaining = Decimal(note.total_amount) - Decimal(note.applied_amount)
+    if amt > remaining:
+        raise NoteError(f"amount exceeds remaining debit ({remaining})")
+
+    bill = (await db.execute(select(Bill).where(Bill.id == bill_id))).scalar_one_or_none()
+    if bill is None:
+        raise NoteError("Bill not found")
+
+    ap = await _account_by_code(db, "2000")
+    purchase_returns = await _account_by_code(db, "5400")
+
+    try:
+        entry = await create_journal_entry(
+            db,
+            JournalEntryCreate(
+                entry_date=applied_on or datetime.now(timezone.utc).date(),
+                source_type="debit_note_application",
+                source_id=str(note.id),
+                memo=f"Apply debit note {note.debit_note_number} to bill",
+                lines=[
+                    JournalLineCreate(
+                        account_id=ap.id,
+                        entry_type="debit",
+                        amount=amt,
+                        description=f"Apply debit note to bill",
+                    ),
+                    JournalLineCreate(
+                        account_id=purchase_returns.id,
+                        entry_type="credit",
+                        amount=amt,
+                        description=f"Apply debit note {note.debit_note_number}",
+                    ),
+                ],
+            ),
+        )
+    except AccountingValidationError as e:
+        raise NoteError(str(e)) from e
+
+    application = DebitNoteApplication(
+        debit_note_id=note.id,
+        bill_id=bill.id,
+        amount=amt,
+        applied_on=applied_on or datetime.now(timezone.utc).date(),
+        journal_entry_id=entry.id,
+    )
+    db.add(application)
+    note.applied_amount = Decimal(note.applied_amount) + amt
+    if note.applied_amount >= note.total_amount:
+        note.status = "applied"
+    else:
+        note.status = "partially_applied"
+    await db.flush()
+    return application
+
+
+async def void_debit_note(db: AsyncSession, note_id: uuid.UUID) -> DebitNote:
+    note = await _require_debit_note(db, note_id)
+    if note.status == "void":
+        return note
+    if Decimal(note.applied_amount) > 0:
+        raise NoteError("Cannot void an applied debit note; reverse the applications first")
+    if note.status == "issued" and note.journal_entry_id is not None:
+        from app.schemas.accounting import JournalEntryReverse
+        from app.services.accounting_service import reverse_journal_entry
+
+        try:
+            await reverse_journal_entry(
+                db,
+                entry_id=note.journal_entry_id,
+                payload=JournalEntryReverse(
+                    reversal_date=datetime.now(timezone.utc).date(),
+                    memo=f"Void debit note {note.debit_note_number}",
+                ),
+            )
+        except AccountingValidationError as e:
+            raise NoteError(str(e)) from e
+    note.status = "void"
+    await db.flush()
+    return note
+
+
+async def _require_debit_note(db: AsyncSession, note_id: uuid.UUID) -> DebitNote:
+    note = (await db.execute(select(DebitNote).where(DebitNote.id == note_id))).scalar_one_or_none()
+    if note is None:
+        raise NoteError("Debit note not found")
+    return note

--- a/backend/app/services/reference_number_service.py
+++ b/backend/app/services/reference_number_service.py
@@ -21,6 +21,8 @@ FORMATS: Final[dict[str, str]] = {
     "inventory_transfer": "IT-{year}-{value:04d}",
     "inter_account_transfer": "T-{year}-{value:04d}",
     "expense_claim": "EC-{year}-{value:04d}",
+    "credit_note": "CN-{year}-{value:04d}",
+    "debit_note": "DN-{year}-{value:04d}",
 }
 
 

--- a/backend/tests/test_note_service.py
+++ b/backend/tests/test_note_service.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.customer import Customer
+from app.models.invoice import Invoice
+from app.models.bill import Bill
+from app.models.vendor import Vendor
+from app.services.note_service import (
+    NoteError,
+    apply_credit_note,
+    apply_debit_note,
+    create_credit_note,
+    create_debit_note,
+    issue_credit_note,
+    issue_debit_note,
+    void_credit_note,
+    void_debit_note,
+)
+
+
+async def _accounts(db_session) -> dict[str, Account]:
+    return {a.code: a for a in (await db_session.execute(select(Account))).scalars().all()}
+
+
+async def _customer(db_session) -> Customer:
+    c = Customer(name="Test", email="x@y.z")
+    db_session.add(c)
+    await db_session.flush()
+    return c
+
+
+async def _vendor(db_session) -> Vendor:
+    v = Vendor(name="Test Vendor")
+    db_session.add(v)
+    await db_session.flush()
+    return v
+
+
+async def _invoice(db_session, customer_id, total: Decimal) -> Invoice:
+    inv = Invoice(
+        invoice_number="INV-TEST-001",
+        customer_id=customer_id,
+        issue_date=datetime.date(2026, 5, 1),
+        subtotal=total, total_due=total, balance_due=total,
+        status="sent",
+    )
+    db_session.add(inv)
+    await db_session.flush()
+    return inv
+
+
+# ---------- credit notes ----------
+
+
+@pytest.mark.asyncio
+async def test_create_credit_note_assigns_number(db_session):
+    accts = await _accounts(db_session)
+    c = await _customer(db_session)
+    n = await create_credit_note(
+        db_session,
+        customer_id=c.id,
+        issued_on=datetime.date(2026, 5, 1),
+        lines=[{"description": "Refund", "quantity": "1", "unit_price": "50", "account_id": accts["4800"].id}],
+    )
+    assert n.credit_note_number.startswith("CN-")
+    assert n.total_amount == Decimal("50.00")
+    assert n.status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_credit_note_no_lines_rejected(db_session):
+    c = await _customer(db_session)
+    with pytest.raises(NoteError):
+        await create_credit_note(
+            db_session,
+            customer_id=c.id,
+            issued_on=datetime.date(2026, 5, 1),
+            lines=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_issue_credit_note_posts_je(db_session):
+    accts = await _accounts(db_session)
+    c = await _customer(db_session)
+    n = await create_credit_note(
+        db_session,
+        customer_id=c.id,
+        issued_on=datetime.date(2026, 5, 1),
+        lines=[{"description": "Refund", "quantity": "1", "unit_price": "50", "account_id": accts["4800"].id}],
+    )
+    n = await issue_credit_note(db_session, n.id)
+    assert n.status == "issued"
+    assert n.journal_entry_id is not None
+
+
+@pytest.mark.asyncio
+async def test_apply_credit_note_partially(db_session):
+    accts = await _accounts(db_session)
+    c = await _customer(db_session)
+    inv = await _invoice(db_session, c.id, Decimal("200"))
+    n = await create_credit_note(
+        db_session,
+        customer_id=c.id,
+        issued_on=datetime.date(2026, 5, 1),
+        lines=[{"description": "Refund", "quantity": "1", "unit_price": "100", "account_id": accts["4800"].id}],
+    )
+    await issue_credit_note(db_session, n.id)
+    app = await apply_credit_note(
+        db_session, note_id=n.id, invoice_id=inv.id, amount=Decimal("60"),
+    )
+    assert Decimal(app.amount) == Decimal("60")
+    refreshed = (await db_session.execute(select(type(n)).where(type(n).id == n.id))).scalar_one()
+    assert Decimal(refreshed.applied_amount) == Decimal("60")
+    assert refreshed.status == "partially_applied"
+    # Invoice balance reduced
+    inv2 = (await db_session.execute(select(Invoice).where(Invoice.id == inv.id))).scalar_one()
+    assert Decimal(inv2.balance_due) == Decimal("140")
+
+
+@pytest.mark.asyncio
+async def test_apply_overdraw_rejected(db_session):
+    accts = await _accounts(db_session)
+    c = await _customer(db_session)
+    inv = await _invoice(db_session, c.id, Decimal("500"))
+    n = await create_credit_note(
+        db_session,
+        customer_id=c.id,
+        issued_on=datetime.date(2026, 5, 1),
+        lines=[{"description": "x", "quantity": "1", "unit_price": "50", "account_id": accts["4800"].id}],
+    )
+    await issue_credit_note(db_session, n.id)
+    with pytest.raises(NoteError):
+        await apply_credit_note(db_session, note_id=n.id, invoice_id=inv.id, amount=Decimal("100"))
+
+
+@pytest.mark.asyncio
+async def test_void_credit_note_blocked_after_application(db_session):
+    accts = await _accounts(db_session)
+    c = await _customer(db_session)
+    inv = await _invoice(db_session, c.id, Decimal("100"))
+    n = await create_credit_note(
+        db_session,
+        customer_id=c.id,
+        issued_on=datetime.date(2026, 5, 1),
+        lines=[{"description": "x", "quantity": "1", "unit_price": "20", "account_id": accts["4800"].id}],
+    )
+    await issue_credit_note(db_session, n.id)
+    await apply_credit_note(db_session, note_id=n.id, invoice_id=inv.id, amount=Decimal("20"))
+    with pytest.raises(NoteError):
+        await void_credit_note(db_session, n.id)
+
+
+@pytest.mark.asyncio
+async def test_void_credit_note_unapplied(db_session):
+    accts = await _accounts(db_session)
+    c = await _customer(db_session)
+    n = await create_credit_note(
+        db_session,
+        customer_id=c.id,
+        issued_on=datetime.date(2026, 5, 1),
+        lines=[{"description": "x", "quantity": "1", "unit_price": "10", "account_id": accts["4800"].id}],
+    )
+    await issue_credit_note(db_session, n.id)
+    n = await void_credit_note(db_session, n.id)
+    assert n.status == "void"
+
+
+# ---------- debit notes ----------
+
+
+@pytest.mark.asyncio
+async def test_debit_note_lifecycle(db_session):
+    accts = await _accounts(db_session)
+    v = await _vendor(db_session)
+    n = await create_debit_note(
+        db_session,
+        vendor_id=v.id,
+        issued_on=datetime.date(2026, 5, 1),
+        lines=[{"description": "Return filament", "quantity": "1", "unit_price": "30", "account_id": accts["5400"].id}],
+    )
+    assert n.debit_note_number.startswith("DN-")
+    n = await issue_debit_note(db_session, n.id)
+    assert n.status == "issued"
+    assert n.journal_entry_id is not None
+
+
+@pytest.mark.asyncio
+async def test_apply_debit_note(db_session):
+    accts = await _accounts(db_session)
+    v = await _vendor(db_session)
+    accts2 = await _accounts(db_session)
+    bill = Bill(
+        bill_number="BL-1",
+        vendor_id=v.id,
+        account_id=accts2["6500"].id,
+        description="Test bill",
+        issue_date=datetime.date(2026, 5, 1),
+        amount=Decimal("100"),
+        status="open",
+    )
+    db_session.add(bill)
+    await db_session.flush()
+
+    n = await create_debit_note(
+        db_session,
+        vendor_id=v.id,
+        issued_on=datetime.date(2026, 5, 1),
+        lines=[{"description": "Return", "quantity": "1", "unit_price": "30", "account_id": accts["5400"].id}],
+    )
+    await issue_debit_note(db_session, n.id)
+    app = await apply_debit_note(db_session, note_id=n.id, bill_id=bill.id, amount=Decimal("30"))
+    assert Decimal(app.amount) == Decimal("30")
+
+
+@pytest.mark.asyncio
+async def test_void_debit_note_unapplied(db_session):
+    accts = await _accounts(db_session)
+    v = await _vendor(db_session)
+    n = await create_debit_note(
+        db_session,
+        vendor_id=v.id,
+        issued_on=datetime.date(2026, 5, 1),
+        lines=[{"description": "x", "quantity": "1", "unit_price": "10", "account_id": accts["5400"].id}],
+    )
+    await issue_debit_note(db_session, n.id)
+    n = await void_debit_note(db_session, n.id)
+    assert n.status == "void"

--- a/docs/credit_and_debit_notes.md
+++ b/docs/credit_and_debit_notes.md
@@ -1,0 +1,56 @@
+# Credit + Debit Notes (Phase 1)
+
+#248 Phase 1. Numbered customer-facing credit notes and vendor-facing debit notes with line items, JE on issue, apply-to-invoice/bill, void.
+
+## Lifecycle
+
+`draft → issued → partially_applied → applied` (or `void` from any non-applied state).
+
+## Credit notes
+
+- **Create**: draft with line items pointing at any account (typically Sales Returns 4800 or the original sale's revenue account).
+- **Issue**: posts JE — Cr AR (1100) for total, Dr each line's account at line_total. Sets `status=issued`, links `journal_entry_id`.
+- **Apply to invoice**: posts JE — Cr AR / Dr Sales Returns for the applied amount. Increments `applied_amount`, increments `Invoice.credits_applied`, decrements `Invoice.balance_due`. Status flips to `partially_applied` or `applied`.
+- **Void**: refused if `applied_amount > 0`. Otherwise reverses the issue JE.
+
+## Debit notes (symmetric)
+
+- **Issue**: posts JE — Dr AP (2000) / Cr each line's account.
+- **Apply to bill**: Dr AP / Cr Purchase Returns (5400).
+- **Void**: same rules.
+
+## Allocator scopes
+
+- `credit_note` → `CN-{year}-{value:04d}`
+- `debit_note` → `DN-{year}-{value:04d}`
+
+## COA seed
+
+Migration `20260509_19` adds:
+
+| Code | Name | Type |
+|---|---|---|
+| 4800 | Sales Returns | revenue (debit-normal) |
+| 5400 | Purchase Returns | cogs (credit-normal) |
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `POST` | `/api/v1/credit-notes` | Create draft |
+| `GET` | `/api/v1/credit-notes` | List, filter by `customer_id`, `status_filter` |
+| `GET` | `/api/v1/credit-notes/{id}` | Detail with lines |
+| `POST` | `/api/v1/credit-notes/{id}/issue` | Post JE |
+| `POST` | `/api/v1/credit-notes/{id}/apply` | Body: `{target_id (invoice id), amount, applied_on?}` |
+| `POST` | `/api/v1/credit-notes/{id}/void` | Reverse if unapplied |
+
+Debit notes mirror: `/api/v1/debit-notes`, with `vendor_id` and `target_id` = bill id.
+
+## Phase 2 follow-ups
+
+- **Restock interaction with #242** — when a credit note line points at an inventory product, restore qty to its `FinishedGoodsLayer`. Requires the per-sale-line layer-draw breakdown that's also a #242 follow-up.
+- **Refund-in-cash** — instead of holding the credit, post a cash refund (Cr Cash / Dr customer credit liability or AR depending on path).
+- **Email scope registration with #244** — register `credit_note` and `debit_note` so notes can be emailed via the existing email transport.
+- **Marketplace settlement bridging** — auto-create credit notes when marketplace refunds appear in settlements.
+- **Tax line generation** on issue (currently subtotal == total).
+- **Frontend** create/issue/apply UI plus invoice→credit-note pre-populate.


### PR DESCRIPTION
Closes #248 Phase 1. Numbered notes with line items, JE on issue, apply-to-invoice/bill, void. Restock + refund-in-cash + email + marketplace deferred. 462 tests pass (452 + 10 new). 2 new COA accounts.