### PR TITLE
feat(orders): sales orders + purchase orders Phase 1 (#261)

### DIFF
--- a/backend/alembic/versions/20260509_20_add_orders.py
+++ b/backend/alembic/versions/20260509_20_add_orders.py
@@ -1,0 +1,95 @@
+"""add sales_orders + purchase_orders (#261 Phase 1)
+
+Revision ID: 20260509_20
+Revises: 20260509_19
+Create Date: 2026-05-10 04:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_20"
+down_revision = "20260509_19"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sales_orders",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("sales_order_number", sa.String(length=50), nullable=False),
+        sa.Column("customer_id", sa.UUID(), nullable=True),
+        sa.Column("customer_name", sa.String(length=200), nullable=True),
+        sa.Column("quote_id", sa.UUID(), nullable=True),
+        sa.Column("issue_date", sa.Date(), nullable=False),
+        sa.Column("expected_ship_date", sa.Date(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="draft"),
+        sa.Column("subtotal_amount", sa.Numeric(12, 2), nullable=False, server_default="0"),
+        sa.Column("total_amount", sa.Numeric(12, 2), nullable=False, server_default="0"),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["customer_id"], ["customers.id"]),
+        sa.ForeignKeyConstraint(["quote_id"], ["quotes.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("sales_order_number", name="uq_sales_orders_number"),
+    )
+    op.create_index("ix_sales_orders_status", "sales_orders", ["status"])
+    op.create_index("ix_sales_orders_customer_id", "sales_orders", ["customer_id"])
+
+    op.create_table(
+        "sales_order_lines",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("sales_order_id", sa.UUID(), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=False),
+        sa.Column("quantity", sa.Numeric(12, 4), nullable=False),
+        sa.Column("unit_price", sa.Numeric(12, 2), nullable=False),
+        sa.Column("line_total", sa.Numeric(12, 2), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["sales_order_id"], ["sales_orders.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_sales_order_lines_sales_order_id", "sales_order_lines", ["sales_order_id"])
+
+    op.create_table(
+        "purchase_orders",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("purchase_order_number", sa.String(length=50), nullable=False),
+        sa.Column("vendor_id", sa.UUID(), nullable=False),
+        sa.Column("issue_date", sa.Date(), nullable=False),
+        sa.Column("expected_receive_date", sa.Date(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="draft"),
+        sa.Column("subtotal_amount", sa.Numeric(12, 2), nullable=False, server_default="0"),
+        sa.Column("total_amount", sa.Numeric(12, 2), nullable=False, server_default="0"),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["vendor_id"], ["vendors.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("purchase_order_number", name="uq_purchase_orders_number"),
+    )
+    op.create_index("ix_purchase_orders_status", "purchase_orders", ["status"])
+    op.create_index("ix_purchase_orders_vendor_id", "purchase_orders", ["vendor_id"])
+
+    op.create_table(
+        "purchase_order_lines",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("purchase_order_id", sa.UUID(), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=False),
+        sa.Column("quantity", sa.Numeric(12, 4), nullable=False),
+        sa.Column("unit_price", sa.Numeric(12, 2), nullable=False),
+        sa.Column("line_total", sa.Numeric(12, 2), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["purchase_order_id"], ["purchase_orders.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_purchase_order_lines_purchase_order_id", "purchase_order_lines", ["purchase_order_id"])
+
+
+def downgrade() -> None:
+    for t in ("purchase_order_lines", "purchase_orders", "sales_order_lines", "sales_orders"):
+        op.drop_table(t)

--- a/backend/app/api/v1/endpoints/orders.py
+++ b/backend/app/api/v1/endpoints/orders.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.purchase_order import PurchaseOrder, PurchaseOrderLine
+from app.models.sales_order import SalesOrder, SalesOrderLine
+from app.services.reference_number_service import next_number
+
+
+router = APIRouter(tags=["Orders"])
+
+
+# ---------- shared schemas ----------
+
+
+class LineIn(BaseModel):
+    description: str = Field(..., min_length=1, max_length=255)
+    quantity: Decimal = Field(..., gt=0)
+    unit_price: Decimal = Field(..., ge=0)
+
+
+# ---------- sales orders ----------
+
+
+class SOCreate(BaseModel):
+    customer_id: uuid.UUID | None = None
+    customer_name: str | None = Field(None, max_length=200)
+    quote_id: uuid.UUID | None = None
+    issue_date: date
+    expected_ship_date: date | None = None
+    notes: str | None = None
+    lines: list[LineIn] = Field(..., min_length=1)
+
+
+def _so_to_dict(so: SalesOrder) -> dict:
+    return {
+        "id": str(so.id),
+        "sales_order_number": so.sales_order_number,
+        "customer_id": str(so.customer_id) if so.customer_id else None,
+        "customer_name": so.customer_name,
+        "quote_id": str(so.quote_id) if so.quote_id else None,
+        "issue_date": so.issue_date.isoformat(),
+        "expected_ship_date": so.expected_ship_date.isoformat() if so.expected_ship_date else None,
+        "status": so.status,
+        "subtotal_amount": str(Decimal(so.subtotal_amount)),
+        "total_amount": str(Decimal(so.total_amount)),
+        "notes": so.notes,
+    }
+
+
+@router.post("/sales-orders", status_code=status.HTTP_201_CREATED, summary="Create a sales order")
+async def create_so(body: SOCreate, user: CurrentUser, db: DB):
+    if not body.customer_id and not body.customer_name:
+        raise HTTPException(status_code=400, detail="customer_id or customer_name required")
+    number = await next_number(db, "sales_order")
+    so = SalesOrder(
+        sales_order_number=number,
+        customer_id=body.customer_id,
+        customer_name=body.customer_name,
+        quote_id=body.quote_id,
+        issue_date=body.issue_date,
+        expected_ship_date=body.expected_ship_date,
+        notes=body.notes,
+    )
+    db.add(so)
+    await db.flush()
+    subtotal = Decimal("0")
+    for line in body.lines:
+        total = (line.quantity * line.unit_price).quantize(Decimal("0.01"))
+        subtotal += total
+        db.add(
+            SalesOrderLine(
+                sales_order_id=so.id,
+                description=line.description,
+                quantity=line.quantity,
+                unit_price=line.unit_price,
+                line_total=total,
+            )
+        )
+    so.subtotal_amount = subtotal
+    so.total_amount = subtotal
+    await db.commit()
+    return _so_to_dict(so)
+
+
+@router.get("/sales-orders", summary="List sales orders")
+async def list_so(user: CurrentUser, db: DB, customer_id: uuid.UUID | None = None, status_filter: str | None = None):
+    stmt = select(SalesOrder).order_by(SalesOrder.issue_date.desc())
+    if customer_id:
+        stmt = stmt.where(SalesOrder.customer_id == customer_id)
+    if status_filter:
+        stmt = stmt.where(SalesOrder.status == status_filter)
+    return [_so_to_dict(r) for r in (await db.execute(stmt)).scalars().all()]
+
+
+@router.get("/sales-orders/{order_id}", summary="Sales order detail")
+async def get_so(order_id: uuid.UUID, user: CurrentUser, db: DB):
+    so = (await db.execute(select(SalesOrder).where(SalesOrder.id == order_id))).scalar_one_or_none()
+    if not so:
+        raise HTTPException(status_code=404, detail="Sales order not found")
+    lines = (await db.execute(select(SalesOrderLine).where(SalesOrderLine.sales_order_id == so.id))).scalars().all()
+    return {
+        **_so_to_dict(so),
+        "lines": [
+            {
+                "id": str(l.id),
+                "description": l.description,
+                "quantity": str(Decimal(l.quantity)),
+                "unit_price": str(Decimal(l.unit_price)),
+                "line_total": str(Decimal(l.line_total)),
+            }
+            for l in lines
+        ],
+    }
+
+
+@router.post("/sales-orders/{order_id}/confirm", summary="Confirm a draft sales order")
+async def confirm_so(order_id: uuid.UUID, user: CurrentUser, db: DB):
+    so = (await db.execute(select(SalesOrder).where(SalesOrder.id == order_id))).scalar_one_or_none()
+    if not so:
+        raise HTTPException(status_code=404, detail="Sales order not found")
+    if so.status != "draft":
+        raise HTTPException(status_code=400, detail=f"Cannot confirm in status {so.status}")
+    so.status = "confirmed"
+    await db.commit()
+    return _so_to_dict(so)
+
+
+@router.post("/sales-orders/{order_id}/cancel", summary="Cancel a sales order")
+async def cancel_so(order_id: uuid.UUID, user: CurrentUser, db: DB):
+    so = (await db.execute(select(SalesOrder).where(SalesOrder.id == order_id))).scalar_one_or_none()
+    if not so:
+        raise HTTPException(status_code=404, detail="Sales order not found")
+    if so.status == "cancelled":
+        return _so_to_dict(so)
+    so.status = "cancelled"
+    await db.commit()
+    return _so_to_dict(so)
+
+
+# ---------- purchase orders ----------
+
+
+class POCreate(BaseModel):
+    vendor_id: uuid.UUID
+    issue_date: date
+    expected_receive_date: date | None = None
+    notes: str | None = None
+    lines: list[LineIn] = Field(..., min_length=1)
+
+
+def _po_to_dict(po: PurchaseOrder) -> dict:
+    return {
+        "id": str(po.id),
+        "purchase_order_number": po.purchase_order_number,
+        "vendor_id": str(po.vendor_id),
+        "issue_date": po.issue_date.isoformat(),
+        "expected_receive_date": po.expected_receive_date.isoformat() if po.expected_receive_date else None,
+        "status": po.status,
+        "subtotal_amount": str(Decimal(po.subtotal_amount)),
+        "total_amount": str(Decimal(po.total_amount)),
+        "notes": po.notes,
+    }
+
+
+@router.post("/purchase-orders", status_code=status.HTTP_201_CREATED, summary="Create a purchase order")
+async def create_po(body: POCreate, user: CurrentUser, db: DB):
+    number = await next_number(db, "purchase_order")
+    po = PurchaseOrder(
+        purchase_order_number=number,
+        vendor_id=body.vendor_id,
+        issue_date=body.issue_date,
+        expected_receive_date=body.expected_receive_date,
+        notes=body.notes,
+    )
+    db.add(po)
+    await db.flush()
+    subtotal = Decimal("0")
+    for line in body.lines:
+        total = (line.quantity * line.unit_price).quantize(Decimal("0.01"))
+        subtotal += total
+        db.add(
+            PurchaseOrderLine(
+                purchase_order_id=po.id,
+                description=line.description,
+                quantity=line.quantity,
+                unit_price=line.unit_price,
+                line_total=total,
+            )
+        )
+    po.subtotal_amount = subtotal
+    po.total_amount = subtotal
+    await db.commit()
+    return _po_to_dict(po)
+
+
+@router.get("/purchase-orders", summary="List purchase orders")
+async def list_po(user: CurrentUser, db: DB, vendor_id: uuid.UUID | None = None, status_filter: str | None = None):
+    stmt = select(PurchaseOrder).order_by(PurchaseOrder.issue_date.desc())
+    if vendor_id:
+        stmt = stmt.where(PurchaseOrder.vendor_id == vendor_id)
+    if status_filter:
+        stmt = stmt.where(PurchaseOrder.status == status_filter)
+    return [_po_to_dict(r) for r in (await db.execute(stmt)).scalars().all()]
+
+
+@router.get("/purchase-orders/{order_id}", summary="Purchase order detail")
+async def get_po(order_id: uuid.UUID, user: CurrentUser, db: DB):
+    po = (await db.execute(select(PurchaseOrder).where(PurchaseOrder.id == order_id))).scalar_one_or_none()
+    if not po:
+        raise HTTPException(status_code=404, detail="Purchase order not found")
+    lines = (await db.execute(select(PurchaseOrderLine).where(PurchaseOrderLine.purchase_order_id == po.id))).scalars().all()
+    return {
+        **_po_to_dict(po),
+        "lines": [
+            {
+                "id": str(l.id),
+                "description": l.description,
+                "quantity": str(Decimal(l.quantity)),
+                "unit_price": str(Decimal(l.unit_price)),
+                "line_total": str(Decimal(l.line_total)),
+            }
+            for l in lines
+        ],
+    }
+
+
+@router.post("/purchase-orders/{order_id}/confirm", summary="Confirm a draft purchase order")
+async def confirm_po(order_id: uuid.UUID, user: CurrentUser, db: DB):
+    po = (await db.execute(select(PurchaseOrder).where(PurchaseOrder.id == order_id))).scalar_one_or_none()
+    if not po:
+        raise HTTPException(status_code=404, detail="Purchase order not found")
+    if po.status != "draft":
+        raise HTTPException(status_code=400, detail=f"Cannot confirm in status {po.status}")
+    po.status = "confirmed"
+    await db.commit()
+    return _po_to_dict(po)
+
+
+@router.post("/purchase-orders/{order_id}/cancel", summary="Cancel a purchase order")
+async def cancel_po(order_id: uuid.UUID, user: CurrentUser, db: DB):
+    po = (await db.execute(select(PurchaseOrder).where(PurchaseOrder.id == order_id))).scalar_one_or_none()
+    if not po:
+        raise HTTPException(status_code=404, detail="Purchase order not found")
+    if po.status == "cancelled":
+        return _po_to_dict(po)
+    po.status = "cancelled"
+    await db.commit()
+    return _po_to_dict(po)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, accounting_foundations, approvals, attachments, audit, auth, banking, batch_ops, budgets, cameras, custom_fields, customers, dashboard, divisions, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, kits, locations, materials, notes, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, statement_match_rules, supplies, tax
+from app.api.v1.endpoints import accounting, accounting_foundations, approvals, attachments, audit, auth, banking, batch_ops, budgets, cameras, custom_fields, customers, dashboard, divisions, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, kits, locations, materials, notes, orders, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, statement_match_rules, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -45,3 +45,4 @@ api_router.include_router(custom_fields.router)
 api_router.include_router(batch_ops.router)
 api_router.include_router(kits.router)
 api_router.include_router(notes.router)
+api_router.include_router(orders.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -17,7 +17,9 @@ from app.models.inventory_location import (  # noqa: F401
     InventoryTransferLine,
 )
 from app.models.product_bom_item import ProductBOMItem  # noqa: F401
+from app.models.purchase_order import PurchaseOrder, PurchaseOrderLine  # noqa: F401
 from app.models.recurring_invoice import RecurringInvoice, RecurringInvoiceRun  # noqa: F401
+from app.models.sales_order import SalesOrder, SalesOrderLine  # noqa: F401
 from app.models.recurring_journal_entry import (  # noqa: F401
     RecurringJournalEntry,
     RecurringJournalEntryRun,

--- a/backend/app/models/purchase_order.py
+++ b/backend/app/models/purchase_order.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class PurchaseOrder(Base):
+    """Optional intermediate document between (no quote) and Bill (#261).
+    Symmetric mirror of SalesOrder.
+    """
+
+    __tablename__ = "purchase_orders"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    purchase_order_number: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    vendor_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("vendors.id"), index=True)
+    issue_date: Mapped[date] = mapped_column(Date)
+    expected_receive_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    status: Mapped[str] = mapped_column(String(20), default="draft", index=True)
+    subtotal_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    total_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    lines = relationship("PurchaseOrderLine", back_populates="purchase_order", cascade="all, delete-orphan")
+
+
+class PurchaseOrderLine(Base):
+    __tablename__ = "purchase_order_lines"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    purchase_order_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("purchase_orders.id", ondelete="CASCADE"), index=True
+    )
+    description: Mapped[str] = mapped_column(String(255))
+    quantity: Mapped[Decimal] = mapped_column(Numeric(12, 4))
+    unit_price: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    line_total: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    purchase_order = relationship("PurchaseOrder", back_populates="lines")

--- a/backend/app/models/sales_order.py
+++ b/backend/app/models/sales_order.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class SalesOrder(Base):
+    """Optional intermediate document between Quote and Invoice (#261).
+    Phase 1 lifecycle: draft → confirmed → cancelled.
+    """
+
+    __tablename__ = "sales_orders"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    sales_order_number: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    customer_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("customers.id"), nullable=True, index=True
+    )
+    customer_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    quote_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("quotes.id"), nullable=True, index=True
+    )
+    issue_date: Mapped[date] = mapped_column(Date)
+    expected_ship_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    status: Mapped[str] = mapped_column(String(20), default="draft", index=True)
+    subtotal_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    total_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    lines = relationship("SalesOrderLine", back_populates="sales_order", cascade="all, delete-orphan")
+
+
+class SalesOrderLine(Base):
+    __tablename__ = "sales_order_lines"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    sales_order_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("sales_orders.id", ondelete="CASCADE"), index=True
+    )
+    description: Mapped[str] = mapped_column(String(255))
+    quantity: Mapped[Decimal] = mapped_column(Numeric(12, 4))
+    unit_price: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    line_total: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    sales_order = relationship("SalesOrder", back_populates="lines")

--- a/backend/app/services/reference_number_service.py
+++ b/backend/app/services/reference_number_service.py
@@ -23,6 +23,8 @@ FORMATS: Final[dict[str, str]] = {
     "expense_claim": "EC-{year}-{value:04d}",
     "credit_note": "CN-{year}-{value:04d}",
     "debit_note": "DN-{year}-{value:04d}",
+    "sales_order": "SO-{year}-{value:04d}",
+    "purchase_order": "PO-{year}-{value:04d}",
 }
 
 

--- a/backend/tests/test_orders_api.py
+++ b/backend/tests/test_orders_api.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models.customer import Customer
+from app.models.vendor import Vendor
+
+
+@pytest.mark.asyncio
+async def test_create_sales_order_assigns_number(client: AsyncClient, auth_headers, db_session):
+    c = Customer(name="X", email="x@y.z")
+    db_session.add(c)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/v1/sales-orders",
+        json={
+            "customer_id": str(c.id),
+            "issue_date": "2026-05-01",
+            "lines": [{"description": "Widget", "quantity": "5", "unit_price": "10"}],
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["sales_order_number"].startswith("SO-")
+    assert body["status"] == "draft"
+    assert body["total_amount"] == "50.00"
+
+
+@pytest.mark.asyncio
+async def test_sales_order_requires_customer_or_name(client: AsyncClient, auth_headers):
+    resp = await client.post(
+        "/api/v1/sales-orders",
+        json={
+            "issue_date": "2026-05-01",
+            "lines": [{"description": "X", "quantity": "1", "unit_price": "1"}],
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_confirm_sales_order(client: AsyncClient, auth_headers, db_session):
+    c = Customer(name="Y", email="y@z.q")
+    db_session.add(c)
+    await db_session.commit()
+    create = await client.post(
+        "/api/v1/sales-orders",
+        json={
+            "customer_id": str(c.id),
+            "issue_date": "2026-05-01",
+            "lines": [{"description": "X", "quantity": "1", "unit_price": "10"}],
+        },
+        headers=auth_headers,
+    )
+    so_id = create.json()["id"]
+    resp = await client.post(f"/api/v1/sales-orders/{so_id}/confirm", headers=auth_headers)
+    assert resp.json()["status"] == "confirmed"
+    # Cannot confirm again
+    resp2 = await client.post(f"/api/v1/sales-orders/{so_id}/confirm", headers=auth_headers)
+    assert resp2.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_cancel_sales_order(client: AsyncClient, auth_headers, db_session):
+    c = Customer(name="Z", email="z@a.b")
+    db_session.add(c)
+    await db_session.commit()
+    create = await client.post(
+        "/api/v1/sales-orders",
+        json={
+            "customer_id": str(c.id),
+            "issue_date": "2026-05-01",
+            "lines": [{"description": "X", "quantity": "1", "unit_price": "5"}],
+        },
+        headers=auth_headers,
+    )
+    so_id = create.json()["id"]
+    resp = await client.post(f"/api/v1/sales-orders/{so_id}/cancel", headers=auth_headers)
+    assert resp.json()["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_create_purchase_order(client: AsyncClient, auth_headers, db_session):
+    v = Vendor(name="V")
+    db_session.add(v)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/v1/purchase-orders",
+        json={
+            "vendor_id": str(v.id),
+            "issue_date": "2026-05-01",
+            "lines": [
+                {"description": "Filament", "quantity": "10", "unit_price": "20"},
+                {"description": "Boxes", "quantity": "100", "unit_price": "0.50"},
+            ],
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["purchase_order_number"].startswith("PO-")
+    assert body["total_amount"] == "250.00"
+
+
+@pytest.mark.asyncio
+async def test_confirm_purchase_order(client: AsyncClient, auth_headers, db_session):
+    v = Vendor(name="V2")
+    db_session.add(v)
+    await db_session.commit()
+    create = await client.post(
+        "/api/v1/purchase-orders",
+        json={
+            "vendor_id": str(v.id),
+            "issue_date": "2026-05-01",
+            "lines": [{"description": "x", "quantity": "1", "unit_price": "5"}],
+        },
+        headers=auth_headers,
+    )
+    po_id = create.json()["id"]
+    resp = await client.post(f"/api/v1/purchase-orders/{po_id}/confirm", headers=auth_headers)
+    assert resp.json()["status"] == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_purchase_order_detail_includes_lines(client: AsyncClient, auth_headers, db_session):
+    v = Vendor(name="V3")
+    db_session.add(v)
+    await db_session.commit()
+    create = await client.post(
+        "/api/v1/purchase-orders",
+        json={
+            "vendor_id": str(v.id),
+            "issue_date": "2026-05-01",
+            "lines": [{"description": "lineA", "quantity": "2", "unit_price": "3"}],
+        },
+        headers=auth_headers,
+    )
+    po_id = create.json()["id"]
+    resp = await client.get(f"/api/v1/purchase-orders/{po_id}", headers=auth_headers)
+    body = resp.json()
+    assert len(body["lines"]) == 1
+    assert body["lines"][0]["description"] == "lineA"

--- a/docs/sales_and_purchase_orders.md
+++ b/docs/sales_and_purchase_orders.md
@@ -1,0 +1,40 @@
+# Sales Orders + Purchase Orders (Phase 1)
+
+#261 Phase 1. Optional intermediate documents between quote/PO-prequel and invoice/bill. Symmetric pair.
+
+## Lifecycle
+
+`draft → confirmed → cancelled` (or stays `confirmed` indefinitely until invoice/bill is generated separately).
+
+Phase 1 does **not** track partial-fulfillment status (`partially_fulfilled`/`fulfilled`). The status flips manually via confirm/cancel actions.
+
+## Models
+
+- **`SalesOrder` + `SalesOrderLine`** — keyed by customer or customer_name; optional `quote_id` link for quote→SO conversion.
+- **`PurchaseOrder` + `PurchaseOrderLine`** — keyed by `vendor_id` (required).
+
+## Allocator scopes
+
+- `sales_order` → `SO-{year}-{value:04d}`
+- `purchase_order` → `PO-{year}-{value:04d}`
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `POST` | `/api/v1/sales-orders` | Create (draft). |
+| `GET` | `/api/v1/sales-orders` | List, filter by customer_id, status. |
+| `GET` | `/api/v1/sales-orders/{id}` | Detail with lines. |
+| `POST` | `/api/v1/sales-orders/{id}/confirm` | draft → confirmed. |
+| `POST` | `/api/v1/sales-orders/{id}/cancel` | Any state → cancelled. |
+
+Purchase orders mirror at `/api/v1/purchase-orders` with `vendor_id` instead of `customer_id`.
+
+## Phase 2 follow-ups
+
+- **Conversion endpoints**: `POST /sales-orders/{id}/create-invoice`, `POST /purchase-orders/{id}/create-bill` — pre-populate invoice/bill from SO/PO lines and link them.
+- **Partial fulfillment** state machine: track invoice/bill generation against SO/PO lines, auto-advance status to `partially_fulfilled` / `fulfilled`.
+- **Open backlog endpoints**: `GET /sales-orders/open` returning unfulfilled-line totals.
+- **Email scope registration with #244** so SOs and POs can be emailed.
+- **Goods receipt linkage** (`material_receipt.purchase_order_line_id`) for three-way matching.
+- **Frontend** — no UI yet.


### PR DESCRIPTION
Closes #261 Phase 1. Symmetric SO/PO with create + list + detail + confirm + cancel. Conversion + partial-fulfillment + email + frontend deferred. 469 tests pass (462 + 7 new). 2 new allocator scopes (SO/PO).