### PR TITLE
feat(reports): trial balance + receipts/payments summary (#249)

### DIFF
--- a/backend/app/api/v1/endpoints/reports.py
+++ b/backend/app/api/v1/endpoints/reports.py
@@ -36,8 +36,10 @@ from app.services.report_service import (
     generate_inventory_report,
     generate_inventory_valuation_report,
     generate_pl_report,
+    generate_receipts_payments_summary_report,
     generate_sales_report,
     generate_tax_liability_summary_report,
+    generate_trial_balance_report,
 )
 
 router = APIRouter(prefix="/reports", tags=["Reports"])
@@ -214,3 +216,46 @@ async def pl_accrual_report(db: DB, date_from: datetime.date | None = Query(None
 @router.get("/pl-cash", response_model=ProfitAndLossResponse, summary="Cash-basis P&L")
 async def pl_cash_report(db: DB, date_from: datetime.date | None = Query(None), date_to: datetime.date | None = Query(None)):
     return await generate_cash_pl_report(db, date_from, date_to)
+
+
+@router.get("/trial-balance", summary="Trial balance — debit + credit columns at a point in time")
+async def trial_balance_report(db: DB, as_of_date: datetime.date = Query(...)):
+    return await generate_trial_balance_report(db, as_of_date)
+
+
+@router.get(
+    "/receipts-payments-summary",
+    summary="Receipts & Payments Summary — categorized cash movements grouped by GL account",
+)
+async def receipts_payments_summary_report(
+    db: DB,
+    date_from: datetime.date | None = Query(None),
+    date_to: datetime.date | None = Query(None),
+):
+    return await generate_receipts_payments_summary_report(db, date_from, date_to)
+
+
+@router.get("/trial-balance.csv", summary="Trial balance as CSV")
+async def trial_balance_csv(db: DB, as_of_date: datetime.date = Query(...)):
+    from fastapi.responses import Response
+    report = await generate_trial_balance_report(db, as_of_date)
+    csv = export_to_csv(
+        report["rows"],
+        columns=["account_code", "account_name", "account_type", "debit", "credit"],
+    )
+    return Response(content=csv, media_type="text/csv")
+
+
+@router.get("/receipts-payments-summary.csv", summary="Receipts & Payments Summary as CSV")
+async def receipts_payments_csv(
+    db: DB,
+    date_from: datetime.date | None = Query(None),
+    date_to: datetime.date | None = Query(None),
+):
+    from fastapi.responses import Response
+    report = await generate_receipts_payments_summary_report(db, date_from, date_to)
+    csv = export_to_csv(
+        report["rows"],
+        columns=["account_code", "account_name", "account_type", "is_bank_account", "inflows", "outflows", "net", "transaction_count"],
+    )
+    return Response(content=csv, media_type="text/csv")

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -699,6 +699,118 @@ async def generate_cash_flow_summary_report(db: AsyncSession, date_from: date | 
     }
 
 
+async def generate_trial_balance_report(db: AsyncSession, as_of_date: date):
+    """Account-by-account debit + credit balances at a point in time (#249).
+
+    Per accounting convention: each account's balance shows on its
+    natural side. A debit-normal account with a positive balance shows
+    in the Debit column; same balance going negative would show in
+    Credit (and vice versa for credit-normal accounts).
+    """
+    balances = await _posted_journal_balances(db, date_to=as_of_date)
+    rows = []
+    total_debit = Decimal("0")
+    total_credit = Decimal("0")
+    for (code, name, account_type, normal_balance), amount in sorted(balances.items()):
+        debit = Decimal("0")
+        credit = Decimal("0")
+        if normal_balance == "debit":
+            if amount >= 0:
+                debit = amount
+            else:
+                credit = -amount
+        else:
+            if amount >= 0:
+                credit = amount
+            else:
+                debit = -amount
+        if debit == 0 and credit == 0:
+            continue
+        rows.append({
+            "account_code": code,
+            "account_name": name,
+            "account_type": account_type,
+            "debit": debit,
+            "credit": credit,
+        })
+        total_debit += debit
+        total_credit += credit
+    return {
+        "as_of_date": as_of_date.isoformat(),
+        "rows": rows,
+        "total_debit": total_debit,
+        "total_credit": total_credit,
+        "is_balanced": total_debit == total_credit,
+    }
+
+
+async def generate_receipts_payments_summary_report(
+    db: AsyncSession, date_from: date | None, date_to: date | None
+):
+    """Categorized cash-movement view grouped by GL account over the
+    selected date range (#249). One row per account with `inflows`,
+    `outflows`, `net`, `transaction_count`.
+    """
+    stmt = (
+        select(
+            Account.id,
+            Account.code,
+            Account.name,
+            Account.account_type,
+            Account.is_bank_account,
+            JournalLine.entry_type,
+            JournalLine.amount,
+        )
+        .join(JournalLine, JournalLine.account_id == Account.id)
+        .join(JournalEntry, JournalEntry.id == JournalLine.journal_entry_id)
+        .where(JournalEntry.status == "posted")
+    )
+    if date_from:
+        stmt = stmt.where(JournalEntry.entry_date >= date_from)
+    if date_to:
+        stmt = stmt.where(JournalEntry.entry_date <= date_to)
+    rows = (await db.execute(stmt)).all()
+
+    by_account: dict = {}
+    for account_id, code, name, account_type, is_bank, entry_type, amount in rows:
+        rec = by_account.setdefault(
+            account_id,
+            {
+                "account_id": str(account_id),
+                "account_code": code,
+                "account_name": name,
+                "account_type": account_type,
+                "is_bank_account": bool(is_bank),
+                "inflows": Decimal("0"),
+                "outflows": Decimal("0"),
+                "transaction_count": 0,
+            },
+        )
+        rec["transaction_count"] += 1
+        if entry_type == "debit":
+            rec["inflows"] += amount
+        else:
+            rec["outflows"] += amount
+
+    out = []
+    total_inflows = Decimal("0")
+    total_outflows = Decimal("0")
+    for rec in by_account.values():
+        rec["net"] = rec["inflows"] - rec["outflows"]
+        total_inflows += rec["inflows"]
+        total_outflows += rec["outflows"]
+        out.append(rec)
+    out.sort(key=lambda r: -abs(r["net"]))
+    return {
+        "date_from": date_from.isoformat() if date_from else None,
+        "date_to": date_to.isoformat() if date_to else None,
+        "rows": out,
+        "total_inflows": total_inflows,
+        "total_outflows": total_outflows,
+        "net_change": total_inflows - total_outflows,
+    }
+
+
 def export_to_csv(rows: list[dict], columns: list[str] | None = None) -> str:
     """Convert a list of dicts to CSV string."""
     if not rows:

--- a/backend/tests/test_trial_balance_and_receipts_payments.py
+++ b/backend/tests/test_trial_balance_and_receipts_payments.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.journal_entry import JournalEntry
+from app.models.journal_line import JournalLine
+from app.services.report_service import (
+    generate_receipts_payments_summary_report,
+    generate_trial_balance_report,
+)
+
+
+async def _post_je(db_session, *, date, lines):
+    """Helper. lines = [(account_code, entry_type, amount), ...]"""
+    accts = {a.code: a for a in (await db_session.execute(select(Account))).scalars().all()}
+    je = JournalEntry(
+        entry_number=f"JE-T-{date.isoformat()}-{len(lines)}",
+        entry_date=date,
+        status="posted",
+    )
+    db_session.add(je)
+    await db_session.flush()
+    for i, (code, etype, amount) in enumerate(lines, start=1):
+        db_session.add(
+            JournalLine(
+                journal_entry_id=je.id,
+                account_id=accts[code].id,
+                line_number=i,
+                entry_type=etype,
+                amount=Decimal(amount),
+            )
+        )
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_trial_balance_empty(db_session):
+    rep = await generate_trial_balance_report(db_session, datetime.date(2026, 12, 31))
+    assert rep["rows"] == []
+    assert rep["total_debit"] == Decimal("0")
+    assert rep["total_credit"] == Decimal("0")
+    assert rep["is_balanced"] is True
+
+
+@pytest.mark.asyncio
+async def test_trial_balance_balanced_after_postings(db_session):
+    # Post: Dr Cash 100 / Cr Sales 100
+    await _post_je(db_session, date=datetime.date(2026, 5, 1), lines=[
+        ("1000", "debit", "100"),
+        ("4000", "credit", "100"),
+    ])
+    rep = await generate_trial_balance_report(db_session, datetime.date(2026, 12, 31))
+    assert rep["is_balanced"] is True
+    assert rep["total_debit"] == Decimal("100")
+    assert rep["total_credit"] == Decimal("100")
+    codes = {r["account_code"] for r in rep["rows"]}
+    assert "1000" in codes
+    assert "4000" in codes
+
+
+@pytest.mark.asyncio
+async def test_trial_balance_respects_as_of_date(db_session):
+    await _post_je(db_session, date=datetime.date(2026, 1, 1), lines=[
+        ("1000", "debit", "50"),
+        ("4000", "credit", "50"),
+    ])
+    await _post_je(db_session, date=datetime.date(2027, 1, 1), lines=[
+        ("1000", "debit", "200"),
+        ("4000", "credit", "200"),
+    ])
+    rep = await generate_trial_balance_report(db_session, datetime.date(2026, 12, 31))
+    cash_row = next(r for r in rep["rows"] if r["account_code"] == "1000")
+    assert cash_row["debit"] == Decimal("50")
+
+
+@pytest.mark.asyncio
+async def test_trial_balance_signs_negative_balances_correctly(db_session):
+    # Post a contra-balance scenario: Cr Cash 30 / Dr Sales 30 → cash goes
+    # negative on its natural side, so it should land in Credit column.
+    # (Pretend Cash is overdrawn for the sake of the test.)
+    await _post_je(db_session, date=datetime.date(2026, 5, 1), lines=[
+        ("1000", "credit", "30"),
+        ("4000", "debit", "30"),
+    ])
+    rep = await generate_trial_balance_report(db_session, datetime.date(2026, 12, 31))
+    cash_row = next(r for r in rep["rows"] if r["account_code"] == "1000")
+    assert cash_row["debit"] == Decimal("0")
+    assert cash_row["credit"] == Decimal("30")
+
+
+@pytest.mark.asyncio
+async def test_receipts_payments_summary_empty(db_session):
+    rep = await generate_receipts_payments_summary_report(db_session, None, None)
+    assert rep["rows"] == []
+    assert rep["total_inflows"] == Decimal("0")
+    assert rep["total_outflows"] == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_receipts_payments_summary_groups_by_account(db_session):
+    await _post_je(db_session, date=datetime.date(2026, 5, 1), lines=[
+        ("1000", "debit", "500"),
+        ("4000", "credit", "500"),
+    ])
+    await _post_je(db_session, date=datetime.date(2026, 5, 5), lines=[
+        ("1000", "credit", "100"),
+        ("6500", "debit", "100"),
+    ])
+    rep = await generate_receipts_payments_summary_report(
+        db_session, datetime.date(2026, 5, 1), datetime.date(2026, 5, 31)
+    )
+    cash = next(r for r in rep["rows"] if r["account_code"] == "1000")
+    assert cash["inflows"] == Decimal("500")
+    assert cash["outflows"] == Decimal("100")
+    assert cash["net"] == Decimal("400")
+    assert cash["transaction_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_receipts_payments_summary_period_bounds(db_session):
+    await _post_je(db_session, date=datetime.date(2026, 1, 1), lines=[
+        ("1000", "debit", "1000"),
+        ("4000", "credit", "1000"),
+    ])
+    await _post_je(db_session, date=datetime.date(2026, 6, 1), lines=[
+        ("1000", "debit", "200"),
+        ("4000", "credit", "200"),
+    ])
+    rep = await generate_receipts_payments_summary_report(
+        db_session, datetime.date(2026, 5, 1), datetime.date(2026, 12, 31)
+    )
+    cash = next(r for r in rep["rows"] if r["account_code"] == "1000")
+    assert cash["inflows"] == Decimal("200")
+    assert cash["transaction_count"] == 1

--- a/docs/financial_reporting_parity.md
+++ b/docs/financial_reporting_parity.md
@@ -1,0 +1,52 @@
+# Financial Reporting Parity (Phase 1)
+
+#249. Audit-then-fill approach. Most of the financial-statement surface was already shipped via closed issue #37; this PR adds the two missing pieces and documents the full set so operators (and future Claude sessions) can find everything from one place.
+
+## What was already there (verified)
+
+| Endpoint | Service | Notes |
+|---|---|---|
+| `GET /api/v1/reports/pl` | `generate_pl_report` | Standard P&L. |
+| `GET /api/v1/reports/pl-accrual` | `generate_accrual_pl_report` | Accrual-basis P&L. |
+| `GET /api/v1/reports/pl-cash` | `generate_cash_pl_report` | Cash-basis P&L. |
+| `GET /api/v1/reports/balance-sheet` | `generate_balance_sheet_report` | As-of-date balance sheet, balanced check. |
+| `GET /api/v1/reports/cash-flow` | `generate_cash_flow_summary_report` | Indirect-style cash flow summary. |
+| `GET /api/v1/reports/ar-aging` | `generate_ar_aging_report` | AR aging buckets (also exposed via invoices.py). |
+| `GET /api/v1/reports/ap-aging` | `generate_ap_aging_report` | AP aging buckets. |
+| `GET /api/v1/reports/sales` | `generate_sales_report` | Sales report. |
+| `GET /api/v1/reports/inventory` | `generate_inventory_report` | Inventory report. |
+| `GET /api/v1/reports/inventory-valuation` | `generate_inventory_valuation_report` | Inventory valuation summary. |
+| `GET /api/v1/reports/cogs-breakdown` | `generate_cogs_breakdown_report` | COGS breakdown by period. |
+| `GET /api/v1/reports/tax-liability` | `generate_tax_liability_summary_report` | Tax liability summary. |
+
+## What this PR adds
+
+| Endpoint | Service | Notes |
+|---|---|---|
+| `GET /api/v1/reports/trial-balance` | `generate_trial_balance_report` | Account-by-account debit/credit balances at a point in time. Includes `is_balanced` invariant. |
+| `GET /api/v1/reports/trial-balance.csv` | (CSV export) | UTF-8 CSV. |
+| `GET /api/v1/reports/receipts-payments-summary` | `generate_receipts_payments_summary_report` | Categorized cash-movement view grouped by GL account over the period. Each row carries `inflows`, `outflows`, `net`, `transaction_count`, sorted by absolute net. Marks `is_bank_account` for downstream drill-down. |
+| `GET /api/v1/reports/receipts-payments-summary.csv` | (CSV export) | UTF-8 CSV. |
+
+## Trial balance behavior
+
+The trial balance assigns each account's balance to its natural side. A debit-normal account with a positive running balance lands in the Debit column; if the running balance is negative (overdraft / contra position), it lands in Credit instead. Same logic in reverse for credit-normal accounts. A balanced book makes `total_debit == total_credit`; the response includes `is_balanced` so callers can assert it.
+
+## Receipts & Payments Summary
+
+For each account that had any journal-line activity in the date range:
+- `inflows` = sum of debit amounts
+- `outflows` = sum of credit amounts
+- `net` = inflows − outflows
+- `transaction_count` = number of journal lines
+
+Sort: by `abs(net)` desc — biggest movers first. The `is_bank_account` flag is exposed so a future drill-down view can default to bank accounts only.
+
+## Phase 2 follow-ups
+
+- **Period comparison** on P&L / Balance Sheet / Cash Flow (side-by-side current vs. prior-period). Endpoints accept the inputs already; we just need a comparison rendering on the response side.
+- **AR-aging service consolidation**: AR aging today lives in two places (`/api/v1/reports/ar-aging` and the legacy invoice-side `/api/v1/invoices/.../aging-report`). Both work; consolidating onto one shared `aging_service.py` is a refactor rather than a feature.
+- **Cash Flow ↔ Balance Sheet ending-cash invariant test** — confirm `ending_cash(period_end) - ending_cash(period_start) == cash_flow_net_change`.
+- **Drill-down**: clicking an account row in Receipts & Payments Summary returns the underlying journal lines.
+- **Frontend** pages for the new endpoints + period-comparison UI.
+- **PDF export** via #244's WeasyPrint renderer.


### PR DESCRIPTION
Closes #249 Phase 1. Audit-then-fill: most financial reports were already shipped via #37; this adds Trial Balance + Receipts & Payments Summary plus a doc cataloging the full set. Period comparison + AR-aging consolidation deferred. 482 tests pass (475 + 7 new).