### PR TITLE
feat(production): production orders Phase 1 — FIFO consumption + finished-goods layers (#242)

### DIFF
--- a/backend/alembic/versions/20260509_22_add_production_orders.py
+++ b/backend/alembic/versions/20260509_22_add_production_orders.py
@@ -1,0 +1,86 @@
+"""add production_orders + consumptions + finished_goods_layers (#242 Phase 1)
+
+Revision ID: 20260509_22
+Revises: 20260509_21
+Create Date: 2026-05-10 05:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260509_22"
+down_revision = "20260509_21"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "production_orders",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("order_number", sa.String(length=50), nullable=False),
+        sa.Column("product_id", sa.UUID(), nullable=False),
+        sa.Column("output_quantity", sa.Numeric(12, 4), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="planned"),
+        sa.Column("planned_start_date", sa.Date(), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("total_material_cost", sa.Numeric(14, 4), nullable=True),
+        sa.Column("applied_overhead", sa.Numeric(14, 4), nullable=True),
+        sa.Column("total_finished_goods_value", sa.Numeric(14, 4), nullable=True),
+        sa.Column("journal_entry_id", sa.UUID(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["product_id"], ["products.id"]),
+        sa.ForeignKeyConstraint(["journal_entry_id"], ["journal_entries.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("order_number", name="uq_production_orders_number"),
+    )
+    op.create_index("ix_production_orders_status", "production_orders", ["status"])
+    op.create_index("ix_production_orders_product_id", "production_orders", ["product_id"])
+
+    op.create_table(
+        "production_order_consumptions",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("production_order_id", sa.UUID(), nullable=False),
+        sa.Column("kind", sa.String(length=20), nullable=False),
+        sa.Column("material_id", sa.UUID(), nullable=True),
+        sa.Column("supply_id", sa.UUID(), nullable=True),
+        sa.Column("product_id", sa.UUID(), nullable=True),
+        sa.Column("planned_qty", sa.Numeric(14, 4), nullable=False),
+        sa.Column("actual_qty", sa.Numeric(14, 4), nullable=True),
+        sa.Column("actual_unit_cost", sa.Numeric(14, 6), nullable=True),
+        sa.Column("actual_total_cost", sa.Numeric(14, 4), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["production_order_id"], ["production_orders.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["material_id"], ["materials.id"]),
+        sa.ForeignKeyConstraint(["supply_id"], ["supplies.id"]),
+        sa.ForeignKeyConstraint(["product_id"], ["products.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_production_order_consumptions_production_order_id", "production_order_consumptions", ["production_order_id"])
+
+    op.create_table(
+        "finished_goods_layers",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("product_id", sa.UUID(), nullable=False),
+        sa.Column("production_order_id", sa.UUID(), nullable=True),
+        sa.Column("qty_total", sa.Numeric(14, 4), nullable=False),
+        sa.Column("qty_remaining", sa.Numeric(14, 4), nullable=False),
+        sa.Column("unit_cost", sa.Numeric(14, 6), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["product_id"], ["products.id"]),
+        sa.ForeignKeyConstraint(["production_order_id"], ["production_orders.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_finished_goods_layers_product_id", "finished_goods_layers", ["product_id"])
+    op.create_index("ix_finished_goods_layers_production_order_id", "finished_goods_layers", ["production_order_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("finished_goods_layers")
+    op.drop_table("production_order_consumptions")
+    op.drop_table("production_orders")

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.models.production_order import (
+    FinishedGoodsLayer,
+    ProductionOrder,
+    ProductionOrderConsumption,
+)
+from app.services.production_order_service import (
+    ProductionOrderError,
+    cancel_order,
+    close_order,
+    create_order,
+)
+
+
+router = APIRouter(prefix="/production-orders", tags=["ProductionOrders"])
+
+
+class POCreate(BaseModel):
+    product_id: uuid.UUID
+    output_quantity: Decimal = Field(..., gt=0)
+    planned_start_date: date | None = None
+    notes: str | None = None
+
+
+class ConsumptionOut(BaseModel):
+    id: uuid.UUID
+    kind: str
+    material_id: uuid.UUID | None
+    supply_id: uuid.UUID | None
+    product_id: uuid.UUID | None
+    planned_qty: Decimal
+    actual_qty: Decimal | None
+    actual_unit_cost: Decimal | None
+    actual_total_cost: Decimal | None
+
+
+class POResponse(BaseModel):
+    id: uuid.UUID
+    order_number: str
+    product_id: uuid.UUID
+    output_quantity: Decimal
+    status: str
+    planned_start_date: date | None
+    completed_at: datetime | None
+    total_material_cost: Decimal | None
+    applied_overhead: Decimal | None
+    total_finished_goods_value: Decimal | None
+    journal_entry_id: uuid.UUID | None
+    notes: str | None
+
+
+class PODetail(POResponse):
+    consumptions: list[ConsumptionOut]
+
+
+def _to_response(order: ProductionOrder) -> POResponse:
+    return POResponse(
+        id=order.id,
+        order_number=order.order_number,
+        product_id=order.product_id,
+        output_quantity=Decimal(order.output_quantity),
+        status=order.status,
+        planned_start_date=order.planned_start_date,
+        completed_at=order.completed_at,
+        total_material_cost=Decimal(order.total_material_cost) if order.total_material_cost is not None else None,
+        applied_overhead=Decimal(order.applied_overhead) if order.applied_overhead is not None else None,
+        total_finished_goods_value=Decimal(order.total_finished_goods_value) if order.total_finished_goods_value is not None else None,
+        journal_entry_id=order.journal_entry_id,
+        notes=order.notes,
+    )
+
+
+@router.post("", response_model=POResponse, status_code=status.HTTP_201_CREATED, summary="Create a planned production order with BOM snapshot")
+async def create(body: POCreate, user: CurrentUser, db: DB):
+    try:
+        order = await create_order(
+            db,
+            product_id=body.product_id,
+            output_quantity=body.output_quantity,
+            planned_start_date=body.planned_start_date,
+            notes=body.notes,
+        )
+    except ProductionOrderError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _to_response(order)
+
+
+@router.get("", response_model=list[POResponse], summary="List production orders")
+async def list_orders(user: CurrentUser, db: DB, status_filter: str | None = None):
+    stmt = select(ProductionOrder).order_by(ProductionOrder.created_at.desc())
+    if status_filter:
+        stmt = stmt.where(ProductionOrder.status == status_filter)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [_to_response(r) for r in rows]
+
+
+@router.get("/{order_id}", response_model=PODetail, summary="Production order detail with consumption snapshot")
+async def get_order(order_id: uuid.UUID, user: CurrentUser, db: DB):
+    order = (await db.execute(select(ProductionOrder).where(ProductionOrder.id == order_id))).scalar_one_or_none()
+    if not order:
+        raise HTTPException(status_code=404, detail="Production order not found")
+    rows = (
+        await db.execute(
+            select(ProductionOrderConsumption).where(
+                ProductionOrderConsumption.production_order_id == order.id
+            )
+        )
+    ).scalars().all()
+    consumptions = [
+        ConsumptionOut(
+            id=c.id,
+            kind=c.kind,
+            material_id=c.material_id,
+            supply_id=c.supply_id,
+            product_id=c.product_id,
+            planned_qty=Decimal(c.planned_qty),
+            actual_qty=Decimal(c.actual_qty) if c.actual_qty is not None else None,
+            actual_unit_cost=Decimal(c.actual_unit_cost) if c.actual_unit_cost is not None else None,
+            actual_total_cost=Decimal(c.actual_total_cost) if c.actual_total_cost is not None else None,
+        )
+        for c in rows
+    ]
+    return PODetail(**_to_response(order).model_dump(), consumptions=consumptions)
+
+
+@router.post("/{order_id}/close", response_model=POResponse, summary="Close a planned production order — FIFO-consume materials, post JE, create finished-goods layer")
+async def close_ep(order_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        order = await close_order(db, order_id)
+    except ProductionOrderError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _to_response(order)
+
+
+@router.post("/{order_id}/cancel", response_model=POResponse, summary="Cancel a planned order (no GL impact)")
+async def cancel_ep(order_id: uuid.UUID, user: CurrentUser, db: DB):
+    try:
+        order = await cancel_order(db, order_id)
+    except ProductionOrderError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await db.commit()
+    return _to_response(order)
+
+
+# ---------- finished-goods layers (read-only) ----------
+
+
+@router.get("/finished-goods/{product_id}", summary="List finished-goods layers for a product (Phase 2 will use these for COGS)")
+async def list_layers(product_id: uuid.UUID, user: CurrentUser, db: DB, only_remaining: bool = True):
+    stmt = select(FinishedGoodsLayer).where(FinishedGoodsLayer.product_id == product_id).order_by(FinishedGoodsLayer.created_at)
+    if only_remaining:
+        stmt = stmt.where(FinishedGoodsLayer.qty_remaining > 0)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "id": str(r.id),
+            "production_order_id": str(r.production_order_id) if r.production_order_id else None,
+            "qty_total": str(Decimal(r.qty_total)),
+            "qty_remaining": str(Decimal(r.qty_remaining)),
+            "unit_cost": str(Decimal(r.unit_cost)),
+            "created_at": r.created_at.isoformat(),
+        }
+        for r in rows
+    ]

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import accounting, accounting_foundations, approvals, attachments, audit, auth, banking, batch_ops, budgets, cameras, custom_fields, customers, dashboard, delivery_notes, divisions, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, kits, locations, materials, notes, orders, pos, printers, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, statement_match_rules, supplies, tax
+from app.api.v1.endpoints import accounting, accounting_foundations, approvals, attachments, audit, auth, banking, batch_ops, budgets, cameras, custom_fields, customers, dashboard, delivery_notes, divisions, email, expense_claims, fixed_assets, insights, intangible_assets, inter_account_transfers, inventory, invoices, jobs, kits, locations, materials, notes, orders, pos, printers, production_orders, products, quotes, rates, recurring_invoices, reports, sales, sales_channels, settlements, settings, statement_imports, statement_match_rules, supplies, tax
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -47,3 +47,4 @@ api_router.include_router(kits.router)
 api_router.include_router(notes.router)
 api_router.include_router(orders.router)
 api_router.include_router(delivery_notes.router)
+api_router.include_router(production_orders.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -18,6 +18,11 @@ from app.models.inventory_location import (  # noqa: F401
     InventoryTransferLine,
 )
 from app.models.product_bom_item import ProductBOMItem  # noqa: F401
+from app.models.production_order import (  # noqa: F401
+    FinishedGoodsLayer,
+    ProductionOrder,
+    ProductionOrderConsumption,
+)
 from app.models.purchase_order import PurchaseOrder, PurchaseOrderLine  # noqa: F401
 from app.models.recurring_invoice import RecurringInvoice, RecurringInvoiceRun  # noqa: F401
 from app.models.sales_order import SalesOrder, SalesOrderLine  # noqa: F401

--- a/backend/app/models/production_order.py
+++ b/backend/app/models/production_order.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class ProductionOrder(Base):
+    """Closes the loop between operational job tracking and inventory
+    accounting (#242). At create time we snapshot the product's BOM into
+    `ProductionOrderConsumption` rows; at close-out we FIFO-consume the
+    snapshot quantities from `material_receipts` (matching the existing
+    inventory_accounting_service pattern), post a balanced JE
+    Cr Material Inventory / Dr Finished Goods, and create a
+    `FinishedGoodsLayer` row capturing the produced units' unit cost.
+    """
+
+    __tablename__ = "production_orders"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    order_number: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    product_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("products.id"), index=True)
+    output_quantity: Mapped[Decimal] = mapped_column(Numeric(12, 4))
+    status: Mapped[str] = mapped_column(String(20), default="planned", index=True)
+    planned_start_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    total_material_cost: Mapped[Decimal | None] = mapped_column(Numeric(14, 4), nullable=True)
+    applied_overhead: Mapped[Decimal | None] = mapped_column(Numeric(14, 4), nullable=True)
+    total_finished_goods_value: Mapped[Decimal | None] = mapped_column(Numeric(14, 4), nullable=True)
+    journal_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("journal_entries.id"), nullable=True
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    consumptions = relationship(
+        "ProductionOrderConsumption",
+        back_populates="production_order",
+        cascade="all, delete-orphan",
+    )
+
+
+class ProductionOrderConsumption(Base):
+    """Snapshot of a single BOM line for a production order.
+
+    Phase 1 stores material consumption only — supply consumption is
+    snapshotted but not used for FIFO drawdown. `actual_qty` defaults
+    to the planned quantity at close-out and is editable by operator
+    (Phase 2 follow-up wires the editor).
+    """
+
+    __tablename__ = "production_order_consumptions"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    production_order_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("production_orders.id", ondelete="CASCADE"), index=True
+    )
+    kind: Mapped[str] = mapped_column(String(20))  # material | supply | product
+    material_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("materials.id"), nullable=True)
+    supply_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("supplies.id"), nullable=True)
+    product_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("products.id"), nullable=True)
+    planned_qty: Mapped[Decimal] = mapped_column(Numeric(14, 4))
+    actual_qty: Mapped[Decimal | None] = mapped_column(Numeric(14, 4), nullable=True)
+    actual_unit_cost: Mapped[Decimal | None] = mapped_column(Numeric(14, 6), nullable=True)
+    actual_total_cost: Mapped[Decimal | None] = mapped_column(Numeric(14, 4), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    production_order = relationship("ProductionOrder", back_populates="consumptions")
+
+
+class FinishedGoodsLayer(Base):
+    """One layer per closed production order's output (#242). Sales-side
+    COGS will FIFO-draw from these layers in Phase 2. Phase 1 just creates
+    them and reports `qty_remaining`.
+    """
+
+    __tablename__ = "finished_goods_layers"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    product_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("products.id"), index=True)
+    production_order_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("production_orders.id"), nullable=True, index=True
+    )
+    qty_total: Mapped[Decimal] = mapped_column(Numeric(14, 4))
+    qty_remaining: Mapped[Decimal] = mapped_column(Numeric(14, 4))
+    unit_cost: Mapped[Decimal] = mapped_column(Numeric(14, 6))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -1,0 +1,251 @@
+"""Production order lifecycle (#242 Phase 1).
+
+Lifecycle: planned → completed (or cancelled).
+
+`create_order` snapshots the product's BOM into ProductionOrderConsumption
+rows so later BOM edits don't retroactively change historical orders.
+
+`close_order`:
+1. For each material consumption row, FIFO-draws from
+   `material_receipts.quantity_remaining_g` exactly like the existing
+   `inventory_accounting_service.consume_material_receipts_for_job`,
+   capturing actual unit cost.
+2. Posts JE — Cr Material Inventory (1200) for total material cost,
+   Dr Finished Goods Inventory (1400) for total finished-goods value.
+3. Creates one `FinishedGoodsLayer` row at unit_cost = total / output_qty.
+
+Phase 1 deliberate cuts:
+- No COGS-on-sale rewrite. Layers are recorded but `cost_calculator.py`
+  remains the source of truth for sale-line cost.
+- No supply consumption FIFO (snapshotted only).
+- No hourly overhead (overhead is always 0; setting deferred).
+- No operator-editable consumption (uses planned_qty as-is).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account
+from app.models.material_receipt import MaterialReceipt
+from app.models.product_bom_item import ProductBOMItem
+from app.models.production_order import (
+    FinishedGoodsLayer,
+    ProductionOrder,
+    ProductionOrderConsumption,
+)
+from app.schemas.accounting import JournalEntryCreate, JournalLineCreate
+from app.services.accounting_service import (
+    AccountingValidationError,
+    create_journal_entry,
+)
+from app.services.reference_number_service import next_number
+
+
+class ProductionOrderError(RuntimeError):
+    pass
+
+
+async def _account_by_code(db: AsyncSession, code: str) -> Account:
+    a = (await db.execute(select(Account).where(Account.code == code))).scalar_one_or_none()
+    if a is None:
+        raise ProductionOrderError(f"COA missing account code {code}; run migration")
+    return a
+
+
+async def create_order(
+    db: AsyncSession,
+    *,
+    product_id: uuid.UUID,
+    output_quantity: Decimal,
+    planned_start_date: date | None = None,
+    notes: str | None = None,
+) -> ProductionOrder:
+    if output_quantity <= 0:
+        raise ProductionOrderError("output_quantity must be > 0")
+
+    bom_items = (
+        await db.execute(
+            select(ProductBOMItem).where(ProductBOMItem.product_id == product_id)
+        )
+    ).scalars().all()
+
+    number = await next_number(db, "production_order")
+    order = ProductionOrder(
+        order_number=number,
+        product_id=product_id,
+        output_quantity=Decimal(output_quantity),
+        status="planned",
+        planned_start_date=planned_start_date,
+        notes=notes,
+    )
+    db.add(order)
+    await db.flush()
+
+    # Snapshot BOM at create time. Per-piece quantity × output_quantity
+    # = planned consumption.
+    for item in bom_items:
+        per_piece = Decimal(item.quantity)
+        planned = (per_piece * Decimal(output_quantity)).quantize(Decimal("0.0001"))
+        kind = item.component_type
+        db.add(
+            ProductionOrderConsumption(
+                production_order_id=order.id,
+                kind=kind,
+                material_id=item.material_id if kind == "material" else None,
+                supply_id=item.supply_id if kind == "supply" else None,
+                product_id=item.component_product_id if kind == "product" else None,
+                planned_qty=planned,
+            )
+        )
+    await db.flush()
+    return order
+
+
+async def close_order(db: AsyncSession, order_id: uuid.UUID) -> ProductionOrder:
+    order = (await db.execute(select(ProductionOrder).where(ProductionOrder.id == order_id))).scalar_one_or_none()
+    if order is None:
+        raise ProductionOrderError("Production order not found")
+    if order.status != "planned":
+        raise ProductionOrderError(f"Cannot close production order in status {order.status}")
+
+    consumptions = (
+        await db.execute(
+            select(ProductionOrderConsumption).where(
+                ProductionOrderConsumption.production_order_id == order.id
+            )
+        )
+    ).scalars().all()
+
+    # Phase 1: only material kinds drive FIFO consumption + cost.
+    total_material_cost = Decimal("0")
+    for c in consumptions:
+        actual_qty = Decimal(c.planned_qty)
+        c.actual_qty = actual_qty
+        if c.kind != "material" or c.material_id is None:
+            c.actual_unit_cost = Decimal("0")
+            c.actual_total_cost = Decimal("0")
+            continue
+        cost = await _consume_material_fifo(db, c.material_id, actual_qty)
+        c.actual_total_cost = cost
+        c.actual_unit_cost = (cost / actual_qty).quantize(Decimal("0.000001")) if actual_qty > 0 else Decimal("0")
+        total_material_cost += cost
+
+    applied_overhead = Decimal("0")  # Phase 1: no overhead rate
+    total_value = total_material_cost + applied_overhead
+    unit_cost = (
+        (total_value / Decimal(order.output_quantity)).quantize(Decimal("0.000001"))
+        if order.output_quantity > 0
+        else Decimal("0")
+    )
+
+    # Post JE: Cr Material Inventory / Dr Finished Goods Inventory
+    if total_value > 0:
+        material_inv = await _account_by_code(db, "1200")  # Raw Materials Inventory
+        finished_goods = await _account_by_code(db, "1400")  # Finished Goods Inventory
+        try:
+            entry = await create_journal_entry(
+                db,
+                JournalEntryCreate(
+                    entry_date=datetime.now(timezone.utc).date(),
+                    source_type="production_order",
+                    source_id=str(order.id),
+                    memo=f"Close production order {order.order_number}",
+                    lines=[
+                        JournalLineCreate(
+                            account_id=finished_goods.id,
+                            entry_type="debit",
+                            amount=total_value,
+                            description=f"Finished goods from {order.order_number}",
+                        ),
+                        JournalLineCreate(
+                            account_id=material_inv.id,
+                            entry_type="credit",
+                            amount=total_value,
+                            description=f"Material consumption for {order.order_number}",
+                        ),
+                    ],
+                ),
+            )
+        except AccountingValidationError as e:
+            raise ProductionOrderError(str(e)) from e
+        order.journal_entry_id = entry.id
+
+    # Create finished-goods layer
+    db.add(
+        FinishedGoodsLayer(
+            product_id=order.product_id,
+            production_order_id=order.id,
+            qty_total=Decimal(order.output_quantity),
+            qty_remaining=Decimal(order.output_quantity),
+            unit_cost=unit_cost,
+        )
+    )
+
+    order.status = "completed"
+    order.completed_at = datetime.now(timezone.utc)
+    order.total_material_cost = total_material_cost
+    order.applied_overhead = applied_overhead
+    order.total_finished_goods_value = total_value
+    await db.flush()
+    return order
+
+
+async def cancel_order(db: AsyncSession, order_id: uuid.UUID) -> ProductionOrder:
+    order = (await db.execute(select(ProductionOrder).where(ProductionOrder.id == order_id))).scalar_one_or_none()
+    if order is None:
+        raise ProductionOrderError("Production order not found")
+    if order.status == "cancelled":
+        return order
+    if order.status == "completed":
+        raise ProductionOrderError("Cannot cancel a completed production order")
+    order.status = "cancelled"
+    await db.flush()
+    return order
+
+
+async def _consume_material_fifo(
+    db: AsyncSession, material_id: uuid.UUID, qty: Decimal
+) -> Decimal:
+    """FIFO consume `qty` from material_receipts and return total cost.
+
+    Mirrors `inventory_accounting_service.consume_material_receipts_for_job`.
+    Uses the receipt's `landed_cost_per_g` when populated, falling back to
+    `unit_cost_per_g`.
+    """
+    if qty <= 0:
+        return Decimal("0")
+
+    receipts = (
+        await db.execute(
+            select(MaterialReceipt)
+            .where(
+                MaterialReceipt.material_id == material_id,
+                MaterialReceipt.quantity_remaining_g > 0,
+            )
+            .order_by(MaterialReceipt.purchase_date.asc(), MaterialReceipt.created_at.asc())
+        )
+    ).scalars().all()
+
+    remaining = Decimal(qty)
+    cost = Decimal("0")
+    for r in receipts:
+        if remaining <= 0:
+            break
+        available = Decimal(r.quantity_remaining_g)
+        consume = min(available, remaining)
+        # Prefer landed cost if set, else unit cost
+        per_g = Decimal(r.landed_cost_per_g) if r.landed_cost_per_g else Decimal(r.unit_cost_per_g)
+        cost += (consume * per_g).quantize(Decimal("0.0001"))
+        r.quantity_remaining_g = available - consume
+        remaining -= consume
+    # If we ran out of receipts, leave `cost` reflecting only what was
+    # available. Operator can post a starting-balances adjustment if
+    # they're not seeded; we don't error here so close-out remains useful
+    # in light/test data.
+    return cost

--- a/backend/app/services/reference_number_service.py
+++ b/backend/app/services/reference_number_service.py
@@ -26,6 +26,7 @@ FORMATS: Final[dict[str, str]] = {
     "sales_order": "SO-{year}-{value:04d}",
     "purchase_order": "PO-{year}-{value:04d}",
     "delivery_note": "DLV-{year}-{value:04d}",
+    "production_order": "PRD-{year}-{value:04d}",
 }
 
 

--- a/backend/tests/test_production_order_service.py
+++ b/backend/tests/test_production_order_service.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.material import Material
+from app.models.material_receipt import MaterialReceipt
+from app.models.product import Product
+from app.models.product_bom_item import ProductBOMItem
+from app.models.production_order import (
+    FinishedGoodsLayer,
+    ProductionOrder,
+    ProductionOrderConsumption,
+)
+from app.services.production_order_service import (
+    ProductionOrderError,
+    cancel_order,
+    close_order,
+    create_order,
+)
+
+
+async def _setup(db_session, *, qty_g="1000", cost_per_g="0.10"):
+    mat = Material(
+        name="PLA Black",
+        brand="TestBrand",
+        spool_weight_g=Decimal("1000"),
+        spool_price=Decimal("100"),
+        net_usable_g=Decimal("950"),
+        cost_per_g=Decimal(cost_per_g),
+    )
+    db_session.add(mat)
+    await db_session.flush()
+    receipt = MaterialReceipt(
+        material_id=mat.id,
+        vendor_name="Acme",
+        purchase_date=datetime.date(2026, 4, 1),
+        quantity_purchased_g=Decimal(qty_g),
+        quantity_remaining_g=Decimal(qty_g),
+        unit_cost_per_g=Decimal(cost_per_g),
+        landed_cost_total=Decimal("0"),
+        landed_cost_per_g=Decimal("0"),
+        total_cost=Decimal(qty_g) * Decimal(cost_per_g),
+    )
+    db_session.add(receipt)
+    product = Product(sku="WIDGET-1", name="Widget", material_id=mat.id)
+    db_session.add(product)
+    await db_session.flush()
+    bom = ProductBOMItem(
+        product_id=product.id,
+        component_type="material",
+        material_id=mat.id,
+        quantity=Decimal("50"),  # 50 g per unit
+        unit="g",
+    )
+    db_session.add(bom)
+    await db_session.flush()
+    return mat, product, receipt
+
+
+@pytest.mark.asyncio
+async def test_create_order_snapshots_bom(db_session):
+    _, product, _ = await _setup(db_session)
+    order = await create_order(db_session, product_id=product.id, output_quantity=Decimal("10"))
+    assert order.order_number.startswith("PRD-")
+    assert order.status == "planned"
+    consumptions = (
+        await db_session.execute(
+            select(ProductionOrderConsumption).where(
+                ProductionOrderConsumption.production_order_id == order.id
+            )
+        )
+    ).scalars().all()
+    assert len(consumptions) == 1
+    assert consumptions[0].planned_qty == Decimal("500.0000")  # 50 g × 10 units
+
+
+@pytest.mark.asyncio
+async def test_create_order_zero_qty_rejected(db_session):
+    _, product, _ = await _setup(db_session)
+    with pytest.raises(ProductionOrderError):
+        await create_order(db_session, product_id=product.id, output_quantity=Decimal("0"))
+
+
+@pytest.mark.asyncio
+async def test_close_order_consumes_fifo_and_posts_je(db_session):
+    mat, product, receipt = await _setup(db_session, qty_g="1000", cost_per_g="0.10")
+    order = await create_order(db_session, product_id=product.id, output_quantity=Decimal("10"))
+    closed = await close_order(db_session, order.id)
+    assert closed.status == "completed"
+    # 50 g × 10 units = 500 g consumed; cost = 500 × 0.10 = 50.00
+    assert Decimal(closed.total_material_cost).quantize(Decimal("0.01")) == Decimal("50.00")
+    assert closed.total_finished_goods_value == closed.total_material_cost
+    assert closed.journal_entry_id is not None
+    # Receipt drained 500 g
+    refreshed = (await db_session.execute(select(MaterialReceipt).where(MaterialReceipt.id == receipt.id))).scalar_one()
+    assert refreshed.quantity_remaining_g == Decimal("500")
+    # Layer created
+    layers = (await db_session.execute(select(FinishedGoodsLayer).where(FinishedGoodsLayer.production_order_id == order.id))).scalars().all()
+    assert len(layers) == 1
+    assert layers[0].qty_total == Decimal("10")
+    assert layers[0].qty_remaining == Decimal("10")
+    # Unit cost 50.00 / 10 = 5.00
+    assert layers[0].unit_cost == Decimal("5.000000")
+
+
+@pytest.mark.asyncio
+async def test_close_order_uses_landed_cost_when_set(db_session):
+    mat, product, receipt = await _setup(db_session, qty_g="1000", cost_per_g="0.10")
+    receipt.landed_cost_per_g = Decimal("0.15")  # operator added freight-in
+    await db_session.flush()
+    order = await create_order(db_session, product_id=product.id, output_quantity=Decimal("10"))
+    closed = await close_order(db_session, order.id)
+    # 500 g × 0.15 = 75.00
+    assert Decimal(closed.total_material_cost).quantize(Decimal("0.01")) == Decimal("75.00")
+
+
+@pytest.mark.asyncio
+async def test_close_order_walks_multiple_receipts_in_order(db_session):
+    mat, product, receipt = await _setup(db_session, qty_g="100", cost_per_g="0.10")
+    # Add a second receipt purchased later, more expensive
+    later_receipt = MaterialReceipt(
+        material_id=mat.id,
+        vendor_name="Acme",
+        purchase_date=datetime.date(2026, 5, 1),
+        quantity_purchased_g=Decimal("1000"),
+        quantity_remaining_g=Decimal("1000"),
+        unit_cost_per_g=Decimal("0.20"),
+        landed_cost_total=Decimal("0"),
+        landed_cost_per_g=Decimal("0"),
+        total_cost=Decimal("200"),
+    )
+    db_session.add(later_receipt)
+    await db_session.flush()
+
+    # Need 500g; first receipt has 100g at 0.10, then second supplies 400g at 0.20
+    order = await create_order(db_session, product_id=product.id, output_quantity=Decimal("10"))
+    closed = await close_order(db_session, order.id)
+    # cost = 100 × 0.10 + 400 × 0.20 = 10 + 80 = 90.00
+    assert Decimal(closed.total_material_cost).quantize(Decimal("0.01")) == Decimal("90.00")
+    earlier = (await db_session.execute(select(MaterialReceipt).where(MaterialReceipt.id == receipt.id))).scalar_one()
+    assert earlier.quantity_remaining_g == Decimal("0")
+    later = (await db_session.execute(select(MaterialReceipt).where(MaterialReceipt.id == later_receipt.id))).scalar_one()
+    assert later.quantity_remaining_g == Decimal("600")  # 1000 - 400
+
+
+@pytest.mark.asyncio
+async def test_cannot_close_already_closed(db_session):
+    _, product, _ = await _setup(db_session)
+    order = await create_order(db_session, product_id=product.id, output_quantity=Decimal("5"))
+    await close_order(db_session, order.id)
+    with pytest.raises(ProductionOrderError):
+        await close_order(db_session, order.id)
+
+
+@pytest.mark.asyncio
+async def test_cancel_planned_order(db_session):
+    _, product, _ = await _setup(db_session)
+    order = await create_order(db_session, product_id=product.id, output_quantity=Decimal("5"))
+    cancelled = await cancel_order(db_session, order.id)
+    assert cancelled.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cannot_cancel_completed_order(db_session):
+    _, product, _ = await _setup(db_session)
+    order = await create_order(db_session, product_id=product.id, output_quantity=Decimal("5"))
+    await close_order(db_session, order.id)
+    with pytest.raises(ProductionOrderError):
+        await cancel_order(db_session, order.id)
+
+
+@pytest.mark.asyncio
+async def test_close_order_with_no_bom_creates_zero_value_layer(db_session):
+    """A product without a BOM produces a zero-cost layer — useful as a
+    starting-balance shortcut. Doesn't post a JE since total_value == 0."""
+    mat = Material(
+        name="x", brand="x",
+        spool_weight_g=Decimal("1000"), spool_price=Decimal("10"),
+        net_usable_g=Decimal("950"), cost_per_g=Decimal("0.01"),
+    )
+    db_session.add(mat)
+    await db_session.flush()
+    product = Product(sku="NO-BOM", name="No BOM", material_id=mat.id)
+    db_session.add(product)
+    await db_session.flush()
+    order = await create_order(db_session, product_id=product.id, output_quantity=Decimal("5"))
+    closed = await close_order(db_session, order.id)
+    assert closed.status == "completed"
+    assert closed.total_material_cost == Decimal("0")
+    assert closed.journal_entry_id is None  # no JE when value is 0
+    layers = (await db_session.execute(select(FinishedGoodsLayer).where(FinishedGoodsLayer.production_order_id == order.id))).scalars().all()
+    assert len(layers) == 1
+    assert layers[0].unit_cost == Decimal("0")

--- a/docs/production_orders.md
+++ b/docs/production_orders.md
@@ -1,0 +1,51 @@
+# Production Orders (Phase 1)
+
+#242 Phase 1. Closes the loop between operational job tracking and inventory accounting: a closed production order FIFO-consumes materials from `material_receipts`, posts a balanced JE Cr Material Inventory / Dr Finished Goods Inventory, and creates a `FinishedGoodsLayer` row for the produced units.
+
+## Lifecycle
+
+`planned → completed` (or `cancelled` from planned).
+
+## Models
+
+- **`ProductionOrder`** — order_number (PRD-{year}-{value:04d} via #243), product, output quantity, status, completion timestamp, totals, JE link.
+- **`ProductionOrderConsumption`** — one row per BOM line, snapshotted at order create time so later BOM edits don't change historical orders. Phase 1 stores `actual_qty` = `planned_qty` (no operator editor yet) and only material kinds drive cost.
+- **`FinishedGoodsLayer`** — one row per closed order's output. Carries `qty_total`, `qty_remaining`, `unit_cost`. **Read-only in Phase 1** — Phase 2 will FIFO-draw from these on the sales-side COGS path.
+
+## Close-out flow
+
+1. For each `material` consumption row: FIFO-draw from `material_receipts.quantity_remaining_g` matching `inventory_accounting_service.consume_material_receipts_for_job`. Uses `landed_cost_per_g` when set, else `unit_cost_per_g`.
+2. Total material cost = sum of FIFO-drawn costs.
+3. Applied overhead = 0 (Phase 1 has no overhead-rate setting).
+4. Total finished-goods value = material cost + overhead.
+5. If value > 0: post JE — Dr Finished Goods Inventory (1400), Cr Raw Materials Inventory (1200).
+6. Create one `FinishedGoodsLayer` at unit_cost = value / output_qty.
+7. Status → `completed`, stamp `completed_at`, link the JE.
+
+When `total_finished_goods_value == 0` (e.g., product with no BOM, or material receipts already drained to 0), the layer is still created with unit_cost=0 but no JE is posted — a useful starting-balance shortcut.
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `POST` | `/api/v1/production-orders` | Create planned order with BOM snapshot. |
+| `GET` | `/api/v1/production-orders` | List, filter `?status_filter=...`. |
+| `GET` | `/api/v1/production-orders/{id}` | Detail with consumption rows. |
+| `POST` | `/api/v1/production-orders/{id}/close` | FIFO-consume + post JE + create layer. |
+| `POST` | `/api/v1/production-orders/{id}/cancel` | Cancel a planned order (no GL impact). |
+| `GET` | `/api/v1/production-orders/finished-goods/{product_id}` | List FinishedGoodsLayer rows for a product. `?only_remaining=false` to include drained layers. |
+
+## Phase 2 follow-ups
+
+The big one: **Sales-side COGS rewrite.** When a sale's product has any `FinishedGoodsLayer` with `qty_remaining > 0`, COGS for that line draws FIFO from the layers; otherwise falls back to `cost_calculator.py`. This is the highest-risk behavior shift in the original #242 scope and was deliberately deferred to Phase 1 to keep the production-order document landable cleanly. Wiring it requires:
+- Per-sale-line audit of which layers were drawn (stored as JSONB on `sale_item.py`) so refunds can restore qty_remaining.
+- Mixed-mode handling when line qty exceeds remaining layer qty (split between layers + cost_calculator residual).
+- Audit-log entry per COGS post recording which path was used.
+
+Other Phase 2 items:
+- Operator-editable `actual_qty` on consumption rows at close-out (currently uses `planned_qty` as-is).
+- Hourly overhead applied at close-out (`overhead_rate_per_hour` setting × actual print hours from a future Job link).
+- Optional `job_production_order_id` link on `Job` for hour rollup.
+- Supply consumption FIFO (snapshotted but not consumed in Phase 1).
+- Variance accounting (favorable/unfavorable BOM-vs-actual variances) — out of scope per #242 design.
+- Frontend `/production` route.


### PR DESCRIPTION
Closes #242 Phase 1. Document + FIFO consume from material_receipts + balanced JE on close + FinishedGoodsLayer creation. **Sales-side COGS rewrite deferred to Phase 2** to keep this PR's behavior-shift risk low. 491 tests pass (482 + 9 new).