### PR TITLE
feat(api): shared list-query helper for endpoint consistency (#264)

### DIFF
--- a/backend/app/api/list_query.py
+++ b/backend/app/api/list_query.py
@@ -1,0 +1,155 @@
+"""Shared list-query helper for endpoint consistency (#264).
+
+Endpoints accept a uniform set of query parameters:
+
+  - `q`             — free-text search (interpretation is per-endpoint)
+  - `sort`          — comma-separated columns, `-` prefix for desc
+                      (e.g. `sort=name,-created_at`)
+  - `page`          — 1-indexed page number
+  - `page_size`     — capped at MAX_PAGE_SIZE
+  - `?{field}=v`    — equality filter on `field`
+  - `?{field}__in=a,b` — membership filter
+
+This module exposes `ListQuery` (Pydantic dependency-injection model)
+and `apply_list_query(stmt, model, qs, *, allowed_sort, allowed_filters,
+search_columns)` to compose the request into a SQLAlchemy `select`.
+
+Adopted incrementally — existing endpoints keep their bespoke shape
+until they're refactored. New endpoints should use this helper.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import Query
+from sqlalchemy import Select, and_, or_
+
+
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 200
+
+
+@dataclass
+class ListQuery:
+    """FastAPI dependency-style holder for the shared query parameters.
+
+    Construct with FastAPI's `Depends` machinery — see `list_query_dep`.
+    """
+
+    q: str | None = None
+    sort: str | None = None
+    page: int = 1
+    page_size: int = DEFAULT_PAGE_SIZE
+
+
+def list_query_dep(
+    q: str | None = Query(None, description="Free-text search"),
+    sort: str | None = Query(None, description="Comma-separated columns, prefix `-` for desc"),
+    page: int = Query(1, ge=1, description="1-indexed page number"),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE, description=f"Page size (max {MAX_PAGE_SIZE})"),
+) -> ListQuery:
+    return ListQuery(q=q, sort=sort, page=page, page_size=page_size)
+
+
+@dataclass
+class ListQueryResult:
+    stmt: Select
+    page: int
+    page_size: int
+    offset: int
+
+
+def apply_list_query(
+    stmt: Select,
+    model: type,
+    lq: ListQuery,
+    *,
+    allowed_sort: list[str] | None = None,
+    search_columns: list[str] | None = None,
+    allowed_filters: dict[str, str] | None = None,
+    extra_filters: dict[str, object] | None = None,
+) -> ListQueryResult:
+    """Compose a `select` statement with sort + search + pagination.
+
+    Args:
+        stmt: starting `select(model)` (caller may have already added joins / where)
+        model: the SQLAlchemy model class
+        lq: parsed `ListQuery`
+        allowed_sort: list of column names callers may sort by; missing entries
+            are silently skipped (so a malicious sort param can't access
+            arbitrary columns)
+        search_columns: column names that `q=` filters across with ILIKE
+        allowed_filters: `{query_param_name: model_attr}` for equality + __in
+            filters. Use the same name on both sides if they match
+        extra_filters: dict of extra `query_param_name → value-from-request`
+            collected by the caller (FastAPI doesn't let us read arbitrary
+            query params inside the helper). Passed verbatim through the
+            `allowed_filters` logic.
+
+    Returns: a `ListQueryResult` with the composed stmt + pagination metadata.
+    The caller still runs `await db.execute(result.stmt)` to fetch rows and
+    runs a parallel `count(*)` query if total-count is needed.
+    """
+    allowed_sort = allowed_sort or []
+    search_columns = search_columns or []
+    allowed_filters = allowed_filters or {}
+    extra_filters = extra_filters or {}
+
+    # Search
+    if lq.q and search_columns:
+        like = f"%{lq.q}%"
+        clauses = []
+        for col_name in search_columns:
+            col = getattr(model, col_name, None)
+            if col is not None:
+                clauses.append(col.ilike(like))
+        if clauses:
+            stmt = stmt.where(or_(*clauses))
+
+    # Filters from `extra_filters` dict
+    for param_name, value in extra_filters.items():
+        if value is None:
+            continue
+        if param_name.endswith("__in"):
+            base = param_name[: -len("__in")]
+            attr = allowed_filters.get(base)
+            if attr is None:
+                continue
+            col = getattr(model, attr, None)
+            if col is None:
+                continue
+            values = [v.strip() for v in str(value).split(",") if v.strip()]
+            if values:
+                stmt = stmt.where(col.in_(values))
+        else:
+            attr = allowed_filters.get(param_name)
+            if attr is None:
+                continue
+            col = getattr(model, attr, None)
+            if col is None:
+                continue
+            stmt = stmt.where(col == value)
+
+    # Sort
+    if lq.sort:
+        order_clauses = []
+        for token in lq.sort.split(","):
+            token = token.strip()
+            if not token:
+                continue
+            desc = token.startswith("-")
+            col_name = token[1:] if desc else token
+            if col_name not in allowed_sort:
+                continue
+            col = getattr(model, col_name, None)
+            if col is None:
+                continue
+            order_clauses.append(col.desc() if desc else col.asc())
+        if order_clauses:
+            stmt = stmt.order_by(*order_clauses)
+
+    # Pagination
+    offset = (lq.page - 1) * lq.page_size
+    stmt = stmt.offset(offset).limit(lq.page_size)
+    return ListQueryResult(stmt=stmt, page=lq.page, page_size=lq.page_size, offset=offset)

--- a/backend/tests/test_list_query_helper.py
+++ b/backend/tests/test_list_query_helper.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from app.api.list_query import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    ListQuery,
+    apply_list_query,
+)
+from app.models.vendor import Vendor
+
+
+def _vendor(name="X", is_active=True) -> Vendor:
+    return Vendor(name=name, is_active=is_active)
+
+
+def _stmt():
+    return select(Vendor)
+
+
+def test_default_page_size_constant():
+    assert DEFAULT_PAGE_SIZE > 0
+    assert MAX_PAGE_SIZE >= DEFAULT_PAGE_SIZE
+
+
+def test_apply_list_query_no_params():
+    lq = ListQuery()
+    result = apply_list_query(
+        _stmt(),
+        Vendor,
+        lq,
+        allowed_sort=["name", "created_at"],
+        search_columns=["name"],
+        allowed_filters={"is_active": "is_active"},
+    )
+    assert result.page == 1
+    assert result.page_size == DEFAULT_PAGE_SIZE
+    assert result.offset == 0
+    # Compiled SQL should contain LIMIT and OFFSET
+    sql = str(result.stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "LIMIT" in sql.upper()
+
+
+def test_apply_list_query_search_appends_where():
+    lq = ListQuery(q="acme")
+    result = apply_list_query(
+        _stmt(),
+        Vendor,
+        lq,
+        search_columns=["name"],
+    )
+    sql = str(result.stmt.compile(compile_kwargs={"literal_binds": True})).lower()
+    assert "ilike" in sql or "like" in sql
+    assert "%acme%" in sql
+
+
+def test_apply_list_query_sort_descending():
+    lq = ListQuery(sort="-name")
+    result = apply_list_query(
+        _stmt(),
+        Vendor,
+        lq,
+        allowed_sort=["name"],
+    )
+    sql = str(result.stmt.compile(compile_kwargs={"literal_binds": True})).lower()
+    assert "order by" in sql
+    assert "desc" in sql
+
+
+def test_apply_list_query_sort_disallowed_silently_dropped():
+    lq = ListQuery(sort="password")
+    result = apply_list_query(
+        _stmt(),
+        Vendor,
+        lq,
+        allowed_sort=["name"],
+    )
+    sql = str(result.stmt.compile(compile_kwargs={"literal_binds": True})).lower()
+    # Disallowed column should not appear in ORDER BY
+    assert "password" not in sql or "order by" not in sql or "password" not in sql.split("order by", 1)[1]
+
+
+def test_apply_list_query_in_filter():
+    lq = ListQuery()
+    result = apply_list_query(
+        _stmt(),
+        Vendor,
+        lq,
+        allowed_filters={"name": "name"},
+        extra_filters={"name__in": "Acme,Globex,Initech"},
+    )
+    sql = str(result.stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "IN (" in sql.upper()
+
+
+def test_apply_list_query_pagination_offset_math():
+    lq = ListQuery(page=3, page_size=25)
+    result = apply_list_query(
+        _stmt(),
+        Vendor,
+        lq,
+        allowed_sort=["name"],
+    )
+    assert result.offset == 50
+    assert result.page == 3
+    assert result.page_size == 25
+
+
+def test_apply_list_query_unknown_filter_silently_dropped():
+    """Filters not in allowed_filters never reach the SQL — defensive
+    against accidental column exposure."""
+    lq = ListQuery()
+    result = apply_list_query(
+        _stmt(),
+        Vendor,
+        lq,
+        allowed_filters={"name": "name"},
+        extra_filters={"hashed_password": "anything"},
+    )
+    sql = str(result.stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "hashed_password" not in sql.lower()
+
+
+def test_apply_list_query_equality_filter():
+    lq = ListQuery()
+    result = apply_list_query(
+        _stmt(),
+        Vendor,
+        lq,
+        allowed_filters={"is_active": "is_active"},
+        extra_filters={"is_active": True},
+    )
+    sql = str(result.stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "is_active" in sql
+
+
+@pytest.mark.asyncio
+async def test_executes_against_real_db(db_session):
+    db_session.add(_vendor(name="Alpha", is_active=True))
+    db_session.add(_vendor(name="Beta", is_active=False))
+    db_session.add(_vendor(name="Acme Industries", is_active=True))
+    await db_session.flush()
+
+    lq = ListQuery(q="acme", sort="-name", page=1, page_size=10)
+    result = apply_list_query(
+        _stmt(),
+        Vendor,
+        lq,
+        allowed_sort=["name"],
+        search_columns=["name"],
+    )
+    rows = (await db_session.execute(result.stmt)).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].name == "Acme Industries"
+
+
+@pytest.mark.asyncio
+async def test_pagination_against_real_db(db_session):
+    for i in range(5):
+        db_session.add(_vendor(name=f"V{i}"))
+    await db_session.flush()
+    lq = ListQuery(page=2, page_size=2, sort="name")
+    result = apply_list_query(_stmt(), Vendor, lq, allowed_sort=["name"])
+    rows = (await db_session.execute(result.stmt)).scalars().all()
+    # Page 2 of size 2 with sort by name → V2, V3
+    assert len(rows) == 2
+    names = [r.name for r in rows]
+    assert names == ["V2", "V3"]

--- a/docs/consistency_pass.md
+++ b/docs/consistency_pass.md
@@ -1,0 +1,86 @@
+# Cross-Cutting Consistency Pass (#264)
+
+#264 Phase 1 ships the **shared list-query helper** as the foundation for the four-piece original scope. The other three pieces (form templates, archive flag audit, PDF parity) are documented here as Phase 2 follow-ups so future sessions know what's left.
+
+## What this PR ships
+
+A reusable `app.api.list_query` module with:
+
+- **`ListQuery`** — a Pydantic dependency model for the standard query parameters.
+- **`list_query_dep`** — FastAPI `Depends`-style constructor.
+- **`apply_list_query(stmt, model, lq, *, allowed_sort, search_columns, allowed_filters, extra_filters)`** — composes a `select` with sort + search + pagination + filters. Returns a `ListQueryResult` carrying the composed statement and pagination metadata.
+
+### Standard query parameter conventions
+
+| Param | Meaning | Example |
+|---|---|---|
+| `q` | Free-text search across `search_columns` (ILIKE) | `?q=acme` |
+| `sort` | Comma-separated columns; `-` prefix for desc | `?sort=-created_at,name` |
+| `page` | 1-indexed page number | `?page=3` |
+| `page_size` | Rows per page; capped at `MAX_PAGE_SIZE=200`; default `DEFAULT_PAGE_SIZE=50` | `?page_size=25` |
+| `?{field}=v` | Equality filter (only for fields in `allowed_filters`) | `?is_active=true` |
+| `?{field}__in=a,b,c` | Membership filter | `?status__in=draft,issued` |
+
+### Defensive behavior
+
+- Sort columns not in `allowed_sort` are silently dropped (so a malicious `sort=hashed_password` can't access arbitrary columns or leak the column existence).
+- Filter params not in `allowed_filters` are silently dropped.
+- Filter param `__in=` empty/blank values are skipped.
+
+### Adoption
+
+**No existing endpoints are modified by this PR.** They keep their bespoke shape until they're refactored to use the helper. New endpoints should adopt it from the start. Phase 2 of #264 retrofits the existing list endpoints incrementally.
+
+Example:
+
+```python
+from fastapi import Depends, Query
+from app.api.list_query import ListQuery, apply_list_query, list_query_dep
+
+@router.get("/widgets")
+async def list_widgets(
+    user: CurrentUser,
+    db: DB,
+    lq: ListQuery = Depends(list_query_dep),
+    is_active: bool | None = Query(None),
+):
+    stmt = select(Widget)
+    result = apply_list_query(
+        stmt, Widget, lq,
+        allowed_sort=["name", "created_at"],
+        search_columns=["name", "sku"],
+        allowed_filters={"is_active": "is_active"},
+        extra_filters={"is_active": is_active},
+    )
+    rows = (await db.execute(result.stmt)).scalars().all()
+    return {"page": result.page, "page_size": result.page_size, "rows": [...]}
+```
+
+## Phase 2 follow-ups (the rest of #264)
+
+Each is its own multi-PR effort and best done as a focused issue.
+
+### Form defaults / templates
+
+Per-form save-as-template + apply-on-create system extending `settings_defaults.py`. Scopes: invoice, quote, sales_order, purchase_order, bill, expense_claim, journal_entry. New endpoint family `/api/v1/form-templates`. Default template auto-applies on the create form unless the operator picks another or "blank."
+
+### Inactive / archived flag audit
+
+Standardize on a uniform `archived_at` (datetime, nullable, indexed) timestamp pattern across every master-data table:
+
+- `customer` (no flag today — needs `archived_at`)
+- `vendor` (uses `is_active` — migrate to `archived_at` with compatibility property)
+- `product` (uses `is_active`)
+- `material` (no flag today)
+- `supply` (uses `active`)
+- `sales_channel`, `tax_profile`, `expense_category`, `account`, `division`, `project` — audit each.
+
+List endpoints exclude archived rows by default with `?include_archived=true` opt-in. Archive/restore actions audit-logged.
+
+### Search/sort UX consistency (frontend side)
+
+A shared `useListQuery` React hook so URL state, debounce, and pagination UI behave identically across every list page. The backend convention is now in place — frontend adoption is a separate sweep.
+
+### PDF generation parity
+
+Audit every printable document (invoice, quote, sales_order, purchase_order, bill, credit_note, debit_note, delivery_note, expense_claim, statement). Establish one shared template scaffold (`templates/pdf/_base.html` with content blocks) and migrate each doc onto it. Visual styling matches across documents (header, footer, business chrome). Replace any browser-print-only HTML output with WeasyPrint where appropriate. **Soft-depends on #244 Phase 2** (which lands the WeasyPrint dep).


### PR DESCRIPTION
Closes #264 Phase 1 — foundation only. New `app/api/list_query.py` exposes `ListQuery` + `apply_list_query()` so future endpoints (and incremental refactors of existing ones) share one shape for q/sort/page/page_size/filters. **No existing endpoints modified.** Form templates, archive flag audit, and PDF parity are deferred and documented as Phase 2 in `docs/consistency_pass.md`. 502 tests pass (491 + 11 new).