### PR TITLE
frontend phase 1: accounting workspace (#298–#313)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,6 +44,26 @@ const UsersPage = lazy(() => import('@/pages/admin/UsersPage'));
 const DataPage = lazy(() => import('@/pages/admin/DataPage'));
 const CamerasPage = lazy(() => import('@/pages/admin/CamerasPage'));
 const PrinterMonitorPage = lazy(() => import('@/pages/PrinterMonitorPage'));
+const AccountingLayout = lazy(() => import('@/components/layout/AccountingLayout'));
+const AccountingIndexPage = lazy(() => import('@/pages/accounting/AccountingIndexPage'));
+const InvoicesPage = lazy(() => import('@/pages/accounting/InvoicesPage'));
+const QuotesPage = lazy(() => import('@/pages/accounting/QuotesPage'));
+const SalesOrdersPage = lazy(() => import('@/pages/accounting/SalesOrdersPage'));
+const PurchaseOrdersPage = lazy(() => import('@/pages/accounting/PurchaseOrdersPage'));
+const DeliveryNotesPage = lazy(() => import('@/pages/accounting/DeliveryNotesPage'));
+const CreditNotesPage = lazy(() => import('@/pages/accounting/CreditNotesPage'));
+const DebitNotesPage = lazy(() => import('@/pages/accounting/DebitNotesPage'));
+const RecurringInvoicesPage = lazy(() => import('@/pages/accounting/RecurringInvoicesPage'));
+const BankingPage = lazy(() => import('@/pages/accounting/BankingPage'));
+const ExpenseClaimsPage = lazy(() => import('@/pages/accounting/ExpenseClaimsPage'));
+const FixedAssetsPage = lazy(() => import('@/pages/accounting/FixedAssetsPage'));
+const IntangiblesPage = lazy(() => import('@/pages/accounting/IntangiblesPage'));
+const ProductionOrdersPage = lazy(() => import('@/pages/accounting/ProductionOrdersPage'));
+const LocationsPage = lazy(() => import('@/pages/accounting/LocationsPage'));
+const AccountingReportsPage = lazy(() => import('@/pages/accounting/AccountingReportsPage'));
+const MasterDataPage = lazy(() => import('@/pages/accounting/MasterDataPage'));
+const TaxProfilesPage = lazy(() => import('@/pages/accounting/TaxProfilesPage'));
+const FoundationsPage = lazy(() => import('@/pages/accounting/FoundationsPage'));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -159,6 +179,29 @@ export default function App() {
                   <Route path="inventory" element={<InventoryReportPage />} />
                   <Route path="sales" element={<SalesReportPage />} />
                   <Route path="pl" element={<PLReportPage />} />
+                </Route>
+
+                {/* Accounting workspace */}
+                <Route path="/accounting" element={<AccountingLayout />}>
+                  <Route index element={<AccountingIndexPage />} />
+                  <Route path="invoices" element={<InvoicesPage />} />
+                  <Route path="quotes" element={<QuotesPage />} />
+                  <Route path="sales-orders" element={<SalesOrdersPage />} />
+                  <Route path="purchase-orders" element={<PurchaseOrdersPage />} />
+                  <Route path="delivery-notes" element={<DeliveryNotesPage />} />
+                  <Route path="credit-notes" element={<CreditNotesPage />} />
+                  <Route path="debit-notes" element={<DebitNotesPage />} />
+                  <Route path="recurring-invoices" element={<RecurringInvoicesPage />} />
+                  <Route path="banking" element={<BankingPage />} />
+                  <Route path="expense-claims" element={<ExpenseClaimsPage />} />
+                  <Route path="fixed-assets" element={<FixedAssetsPage />} />
+                  <Route path="intangibles" element={<IntangiblesPage />} />
+                  <Route path="production-orders" element={<ProductionOrdersPage />} />
+                  <Route path="locations" element={<LocationsPage />} />
+                  <Route path="reports" element={<AccountingReportsPage />} />
+                  <Route path="master-data" element={<MasterDataPage />} />
+                  <Route path="tax-profiles" element={<TaxProfilesPage />} />
+                  <Route path="foundations" element={<FoundationsPage />} />
                 </Route>
 
                 {/* Admin section with sidebar */}

--- a/frontend/src/components/layout/AccountingLayout.tsx
+++ b/frontend/src/components/layout/AccountingLayout.tsx
@@ -1,0 +1,96 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import {
+  Banknote,
+  Building2,
+  ClipboardList,
+  CreditCard,
+  FileMinus,
+  FileText,
+  Layers,
+  MapPin,
+  Receipt,
+  RefreshCw,
+  Repeat,
+  ScrollText,
+  Truck,
+  Wallet,
+  type LucideIcon,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface Link {
+  to: string;
+  label: string;
+  icon: LucideIcon;
+}
+
+const links: Link[] = [
+  { to: '/accounting/invoices', label: 'Invoices', icon: FileText },
+  { to: '/accounting/quotes', label: 'Quotes', icon: ScrollText },
+  { to: '/accounting/sales-orders', label: 'Sales orders', icon: ClipboardList },
+  { to: '/accounting/purchase-orders', label: 'Purchase orders', icon: ClipboardList },
+  { to: '/accounting/delivery-notes', label: 'Delivery notes', icon: Truck },
+  { to: '/accounting/credit-notes', label: 'Credit notes', icon: FileMinus },
+  { to: '/accounting/debit-notes', label: 'Debit notes', icon: FileMinus },
+  { to: '/accounting/recurring-invoices', label: 'Recurring invoices', icon: Repeat },
+  { to: '/accounting/banking', label: 'Banking', icon: Banknote },
+  { to: '/accounting/expense-claims', label: 'Expense claims', icon: Wallet },
+  { to: '/accounting/fixed-assets', label: 'Fixed assets', icon: Building2 },
+  { to: '/accounting/intangibles', label: 'Intangibles', icon: Layers },
+  { to: '/accounting/production-orders', label: 'Production orders', icon: RefreshCw },
+  { to: '/accounting/locations', label: 'Locations', icon: MapPin },
+  { to: '/accounting/reports', label: 'Reports', icon: Receipt },
+  { to: '/accounting/foundations', label: 'Foundations', icon: CreditCard },
+  { to: '/accounting/master-data', label: 'Master data', icon: ClipboardList },
+];
+
+export default function AccountingLayout() {
+  return (
+    <div className="flex gap-8">
+      <aside className="hidden md:block w-56 shrink-0">
+        <nav className="sticky top-24 space-y-1">
+          <h3 className="mb-3 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Accounting
+          </h3>
+          {links.map(({ to, label, icon: Icon }) => (
+            <NavLink
+              key={to}
+              to={to}
+              className={({ isActive }) =>
+                cn(
+                  'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium no-underline transition-colors',
+                  isActive
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                )
+              }
+            >
+              <Icon className="h-4 w-4" />
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+      <div className="mb-6 flex w-full gap-1 overflow-x-auto pb-2 md:hidden">
+        {links.map(({ to, label, icon: Icon }) => (
+          <NavLink
+            key={to}
+            to={to}
+            className={({ isActive }) =>
+              cn(
+                'flex items-center gap-2 whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium no-underline transition-colors',
+                isActive ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-accent'
+              )
+            }
+          >
+            <Icon className="h-4 w-4" />
+            {label}
+          </NavLink>
+        ))}
+      </div>
+      <div className="min-w-0 flex-1">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/appNav.ts
+++ b/frontend/src/components/layout/appNav.ts
@@ -10,6 +10,7 @@ import {
   ShoppingCart,
   Users,
   ClipboardList,
+  BookOpenCheck,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -31,6 +32,7 @@ export const appNavLinks: AppNavLink[] = [
   { to: '/pos', label: 'POS', icon: Receipt },
   { to: '/sales', label: 'Sales', icon: ShoppingCart },
   { to: '/customers', label: 'Customers', icon: Users },
+  { to: '/accounting', label: 'Accounting', icon: BookOpenCheck },
   { to: '/reports', label: 'Reports', icon: BarChart3 },
   { to: '/calculator', label: 'Calculator', icon: Calculator },
 ];

--- a/frontend/src/components/ui/AttachmentsPanel.tsx
+++ b/frontend/src/components/ui/AttachmentsPanel.tsx
@@ -1,0 +1,164 @@
+import { useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Paperclip, Trash2, Upload, Download } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import { Button } from '@/components/ui/Button';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+export interface AttachmentRecord {
+  id: string;
+  scope: string;
+  record_id: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  description: string | null;
+  has_thumbnail: boolean;
+  sha256: string;
+  uploaded_at: string;
+}
+
+interface AttachmentsPanelProps {
+  scope: string;
+  recordId: string;
+  /** Hide upload button in read-only mode. */
+  readOnly?: boolean;
+}
+
+function fmtSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function AttachmentsPanel({ scope, recordId, readOnly = false }: AttachmentsPanelProps) {
+  const qc = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<AttachmentRecord | null>(null);
+
+  const { data, isLoading } = useQuery<AttachmentRecord[]>({
+    queryKey: ['attachments', scope, recordId],
+    queryFn: () => api.get(`/attachments/${scope}/${recordId}`).then((r) => r.data),
+    enabled: Boolean(recordId),
+  });
+
+  const onSelect = async (file: File | null) => {
+    if (!file) return;
+    setUploading(true);
+    const form = new FormData();
+    form.append('file', file);
+    try {
+      await api.post(`/attachments/${scope}/${recordId}`, form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+      toast.success('Attached');
+      qc.invalidateQueries({ queryKey: ['attachments', scope, recordId] });
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Upload failed'));
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
+
+  const onDelete = async (a: AttachmentRecord) => {
+    try {
+      await api.delete(`/attachments/${a.id}`);
+      toast.success('Removed');
+      qc.invalidateQueries({ queryKey: ['attachments', scope, recordId] });
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to remove'));
+    }
+  };
+
+  const onDownload = (a: AttachmentRecord) => {
+    const token = localStorage.getItem('token');
+    const url = `/api/v1/attachments/${a.id}/download`;
+    fetch(url, { headers: token ? { Authorization: `Bearer ${token}` } : {} })
+      .then((r) => r.blob())
+      .then((blob) => {
+        const objectUrl = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = objectUrl;
+        link.download = a.filename;
+        link.click();
+        URL.revokeObjectURL(objectUrl);
+      })
+      .catch(() => toast.error('Download failed'));
+  };
+
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="flex items-center gap-2 text-sm font-medium">
+          <Paperclip className="h-4 w-4" /> Attachments {data && data.length > 0 ? `(${data.length})` : ''}
+        </h3>
+        {!readOnly && (
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              onChange={(e) => onSelect(e.target.files?.[0] ?? null)}
+            />
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={uploading}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Upload className="mr-2 h-3.5 w-3.5" />
+              {uploading ? 'Uploading…' : 'Upload'}
+            </Button>
+          </>
+        )}
+      </div>
+      {isLoading ? (
+        <div className="text-sm text-muted-foreground">Loading…</div>
+      ) : !data || data.length === 0 ? (
+        <div className="text-sm text-muted-foreground">No attachments yet.</div>
+      ) : (
+        <ul className="divide-y">
+          {data.map((a) => (
+            <li key={a.id} className="flex items-center justify-between gap-2 py-2">
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium">{a.filename}</div>
+                <div className="text-xs text-muted-foreground">
+                  {a.content_type} · {fmtSize(a.size_bytes)} · {new Date(a.uploaded_at).toLocaleString()}
+                </div>
+              </div>
+              <Button size="icon" variant="ghost" onClick={() => onDownload(a)} aria-label="Download">
+                <Download className="h-4 w-4" />
+              </Button>
+              {!readOnly && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => setPendingDelete(a)}
+                  aria-label="Remove"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      <ConfirmDialog
+        open={Boolean(pendingDelete)}
+        onOpenChange={(o) => !o && setPendingDelete(null)}
+        title="Remove attachment?"
+        description={pendingDelete ? `"${pendingDelete.filename}" will be removed.` : ''}
+        confirmLabel="Remove"
+        tone="destructive"
+        onConfirm={() => {
+          if (pendingDelete) onDelete(pendingDelete);
+          setPendingDelete(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/hooks/useListQuery.ts
+++ b/frontend/src/hooks/useListQuery.ts
@@ -1,0 +1,85 @@
+import { useMemo, useState } from 'react';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import api from '@/api/client';
+
+interface UseListQueryOptions {
+  resource: string;
+  initialLimit?: number;
+  initialSearch?: string;
+  initialFilters?: Record<string, string | number | undefined>;
+  staleTime?: number;
+  enabled?: boolean;
+}
+
+export interface ListQueryState<T> {
+  data: T[];
+  total: number;
+  isLoading: boolean;
+  isError: boolean;
+  search: string;
+  setSearch: (s: string) => void;
+  page: number;
+  setPage: (p: number) => void;
+  limit: number;
+  setLimit: (n: number) => void;
+  filters: Record<string, string | number | undefined>;
+  setFilter: (key: string, value: string | number | undefined) => void;
+  refetch: () => void;
+  raw: UseQueryResult<{ items: T[]; total: number; skip: number; limit: number } | T[]>;
+}
+
+/**
+ * Generic list-query hook. Backend list endpoints either return
+ * `{items, total, skip, limit}` (paginated) or a bare array. Handles both.
+ */
+export function useListQuery<T>(opts: UseListQueryOptions): ListQueryState<T> {
+  const { resource, initialLimit = 50, initialSearch = '', initialFilters = {}, staleTime, enabled = true } = opts;
+  const [search, setSearch] = useState(initialSearch);
+  const [page, setPage] = useState(0);
+  const [limit, setLimit] = useState(initialLimit);
+  const [filters, setFilters] = useState<Record<string, string | number | undefined>>(initialFilters);
+
+  const setFilter = (key: string, value: string | number | undefined) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+    setPage(0);
+  };
+
+  const queryKey = useMemo(() => [resource, search, page, limit, filters], [resource, search, page, limit, filters]);
+
+  const raw = useQuery({
+    queryKey,
+    enabled,
+    staleTime,
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (search) params.set('search', search);
+      params.set('skip', String(page * limit));
+      params.set('limit', String(limit));
+      for (const [k, v] of Object.entries(filters)) {
+        if (v !== undefined && v !== '' && v !== null) params.set(k, String(v));
+      }
+      const r = await api.get(`/${resource}?${params.toString()}`);
+      return r.data;
+    },
+  });
+
+  const items: T[] = Array.isArray(raw.data) ? raw.data : raw.data?.items ?? [];
+  const total: number = Array.isArray(raw.data) ? raw.data.length : raw.data?.total ?? 0;
+
+  return {
+    data: items,
+    total,
+    isLoading: raw.isLoading,
+    isError: raw.isError,
+    search,
+    setSearch,
+    page,
+    setPage,
+    limit,
+    setLimit,
+    filters,
+    setFilter,
+    refetch: () => raw.refetch(),
+    raw,
+  };
+}

--- a/frontend/src/pages/accounting/AccountingIndexPage.tsx
+++ b/frontend/src/pages/accounting/AccountingIndexPage.tsx
@@ -1,0 +1,49 @@
+import { Link } from 'react-router-dom';
+import {
+  Banknote, Building2, ClipboardList, CreditCard, FileMinus, FileText,
+  Layers, MapPin, Receipt, RefreshCw, Repeat, ScrollText, Truck, Wallet,
+  type LucideIcon,
+} from 'lucide-react';
+import PageHeader from '@/components/layout/PageHeader';
+
+interface Tile { to: string; label: string; icon: LucideIcon; description: string }
+
+const tiles: Tile[] = [
+  { to: '/accounting/invoices', label: 'Invoices', icon: FileText, description: 'Customer invoices, payments, email send' },
+  { to: '/accounting/quotes', label: 'Quotes', icon: ScrollText, description: 'Customer quotes, accept, convert' },
+  { to: '/accounting/sales-orders', label: 'Sales orders', icon: ClipboardList, description: 'Confirm, then convert to invoice' },
+  { to: '/accounting/purchase-orders', label: 'Purchase orders', icon: ClipboardList, description: 'Confirm, then convert to bill' },
+  { to: '/accounting/delivery-notes', label: 'Delivery notes', icon: Truck, description: 'Dispatch documents (DLV-…)' },
+  { to: '/accounting/credit-notes', label: 'Credit notes', icon: FileMinus, description: 'Refunds applied to invoices' },
+  { to: '/accounting/debit-notes', label: 'Debit notes', icon: FileMinus, description: 'Vendor returns applied to bills' },
+  { to: '/accounting/recurring-invoices', label: 'Recurring invoices', icon: Repeat, description: 'Auto-generate on a schedule' },
+  { to: '/accounting/banking', label: 'Banking', icon: Banknote, description: 'Reconciliation, imports, rules, transfers' },
+  { to: '/accounting/expense-claims', label: 'Expense claims', icon: Wallet, description: 'Owner-paid reimbursable expenses' },
+  { to: '/accounting/fixed-assets', label: 'Fixed assets', icon: Building2, description: 'Depreciation schedule' },
+  { to: '/accounting/intangibles', label: 'Intangibles', icon: Layers, description: 'Amortization schedule' },
+  { to: '/accounting/production-orders', label: 'Production orders', icon: RefreshCw, description: 'FIFO consume + finished-goods layers' },
+  { to: '/accounting/locations', label: 'Locations & kits', icon: MapPin, description: 'Multi-location inventory + transfers + kits' },
+  { to: '/accounting/reports', label: 'Reports', icon: Receipt, description: 'Trial balance · Receipts/payments · Aging' },
+  { to: '/accounting/foundations', label: 'Foundations', icon: CreditCard, description: 'Recurring JEs · Suspense · Starting balances' },
+  { to: '/accounting/master-data', label: 'Master data', icon: ClipboardList, description: 'Divisions · Projects · Budgets · Custom fields · Batch' },
+  { to: '/accounting/tax-profiles', label: 'Tax profiles', icon: Receipt, description: 'Compound + reverse-charge tax profiles' },
+];
+
+export default function AccountingIndexPage() {
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Accounting" description="Manager.io-style finance suite — pick a module to start" />
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {tiles.map(({ to, label, icon: Icon, description }) => (
+          <Link key={to} to={to} className="group rounded-lg border bg-card p-4 no-underline transition-colors hover:bg-accent">
+            <div className="mb-2 flex items-center gap-2 text-foreground">
+              <Icon className="h-5 w-5 text-primary" />
+              <span className="font-medium">{label}</span>
+            </div>
+            <p className="text-sm text-muted-foreground">{description}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/AccountingReportsPage.tsx
+++ b/frontend/src/pages/accounting/AccountingReportsPage.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Download } from 'lucide-react';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs';
+
+interface TBRow { account_id: string; account_code: string; account_name: string; debit: number; credit: number }
+
+function TrialBalanceTab() {
+  const [asOf, setAsOf] = useState(new Date().toISOString().slice(0, 10));
+  const { data, isLoading } = useQuery<{ rows: TBRow[]; total_debit: number; total_credit: number }>({
+    queryKey: ['trial-balance', asOf],
+    queryFn: () => api.get('/reports/trial-balance', { params: { as_of_date: asOf } }).then((r) => r.data),
+  });
+  const csv = () => {
+    const token = localStorage.getItem('token');
+    const url = `/api/v1/reports/trial-balance.csv?as_of_date=${asOf}`;
+    fetch(url, { headers: token ? { Authorization: `Bearer ${token}` } : {} })
+      .then((r) => r.blob())
+      .then((b) => { const a = document.createElement('a'); a.href = URL.createObjectURL(b); a.download = `trial-balance-${asOf}.csv`; a.click(); });
+  };
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end gap-2 rounded-lg border bg-card p-3">
+        <div><Label>As of</Label><Input type="date" value={asOf} onChange={(e) => setAsOf(e.target.value)} /></div>
+        <Button variant="outline" onClick={csv}><Download className="mr-2 h-4 w-4" />CSV</Button>
+      </div>
+      {isLoading ? (
+        <div className="text-sm text-muted-foreground">Loading…</div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border bg-card">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40">
+              <tr><th className="px-3 py-2 text-left">Code</th><th className="px-3 py-2 text-left">Account</th><th className="px-3 py-2 text-right">Debit</th><th className="px-3 py-2 text-right">Credit</th></tr>
+            </thead>
+            <tbody>
+              {(data?.rows ?? []).map((r) => (
+                <tr key={r.account_id} className="border-t">
+                  <td className="px-3 py-1.5 font-mono">{r.account_code}</td>
+                  <td className="px-3 py-1.5">{r.account_name}</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums">{Number(r.debit).toFixed(2)}</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums">{Number(r.credit).toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+            {data && (
+              <tfoot className="bg-muted/20 font-medium">
+                <tr><td colSpan={2} className="px-3 py-2">Totals</td><td className="px-3 py-2 text-right tabular-nums">{Number(data.total_debit).toFixed(2)}</td><td className="px-3 py-2 text-right tabular-nums">{Number(data.total_credit).toFixed(2)}</td></tr>
+              </tfoot>
+            )}
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReceiptsPaymentsTab() {
+  const [start, setStart] = useState(new Date(Date.now() - 30 * 86400_000).toISOString().slice(0, 10));
+  const [end, setEnd] = useState(new Date().toISOString().slice(0, 10));
+  const csv = () => {
+    const token = localStorage.getItem('token');
+    const url = `/api/v1/reports/receipts-payments-summary.csv?start_date=${start}&end_date=${end}`;
+    fetch(url, { headers: token ? { Authorization: `Bearer ${token}` } : {} })
+      .then((r) => r.blob())
+      .then((b) => { const a = document.createElement('a'); a.href = URL.createObjectURL(b); a.download = `receipts-payments-${start}-${end}.csv`; a.click(); });
+  };
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end gap-2 rounded-lg border bg-card p-3">
+        <div><Label>Start</Label><Input type="date" value={start} onChange={(e) => setStart(e.target.value)} /></div>
+        <div><Label>End</Label><Input type="date" value={end} onChange={(e) => setEnd(e.target.value)} /></div>
+        <Button onClick={csv}><Download className="mr-2 h-4 w-4" />Download CSV</Button>
+      </div>
+      <div className="rounded-lg border bg-card p-4 text-sm text-muted-foreground">Receipts & Payments summary is exported as CSV.</div>
+    </div>
+  );
+}
+
+function ARAgingTab() {
+  const { data, isLoading } = useQuery<any>({ queryKey: ['ar-aging'], queryFn: () => api.get('/reports/ar-aging').then((r) => r.data) });
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      {isLoading ? <div className="text-sm text-muted-foreground">Loading…</div> : <pre className="overflow-auto text-xs">{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+}
+
+function APAgingTab() {
+  const { data, isLoading } = useQuery<any>({ queryKey: ['ap-aging'], queryFn: () => api.get('/reports/ap-aging').then((r) => r.data) });
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      {isLoading ? <div className="text-sm text-muted-foreground">Loading…</div> : <pre className="overflow-auto text-xs">{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+}
+
+export default function AccountingReportsPage() {
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Reports" description="Trial balance, receipts/payments, AR/AP aging" />
+      <Tabs defaultValue="tb">
+        <TabsList>
+          <TabsTrigger value="tb">Trial balance</TabsTrigger>
+          <TabsTrigger value="rp">Receipts & payments</TabsTrigger>
+          <TabsTrigger value="ar">AR aging</TabsTrigger>
+          <TabsTrigger value="ap">AP aging</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tb" className="mt-4"><TrialBalanceTab /></TabsContent>
+        <TabsContent value="rp" className="mt-4"><ReceiptsPaymentsTab /></TabsContent>
+        <TabsContent value="ar" className="mt-4"><ARAgingTab /></TabsContent>
+        <TabsContent value="ap" className="mt-4"><APAgingTab /></TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/BankingPage.tsx
+++ b/frontend/src/pages/accounting/BankingPage.tsx
@@ -1,0 +1,251 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Banknote, Upload, Plus, RefreshCw, ArrowRightLeft } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface BankAccount {
+  id: string;
+  code: string;
+  name: string;
+  bank_account_kind: string | null;
+  current_balance: number;
+}
+
+interface Reconciliation {
+  id: string;
+  account_id: string;
+  statement_end_date: string;
+  statement_ending_balance: number;
+  status: string;
+}
+
+interface Rule {
+  id: string;
+  name: string;
+  match_field: string;
+  match_pattern: string;
+  category_account_id: string | null;
+  active: boolean;
+}
+
+interface Transfer {
+  id: string;
+  from_account_id: string;
+  to_account_id: string;
+  amount: number;
+  paid_on: string;
+  received_on: string | null;
+}
+
+function AccountsTab() {
+  const { data, isLoading } = useQuery<BankAccount[]>({ queryKey: ['banking-accounts'], queryFn: () => api.get('/banking/accounts').then((r) => r.data) });
+  const cols: Column<BankAccount>[] = [
+    { key: 'c', header: 'Code', cell: (r) => <span className="font-mono">{r.code}</span> },
+    { key: 'n', header: 'Name', cell: (r) => <span className="font-medium">{r.name}</span> },
+    { key: 'k', header: 'Kind', cell: (r) => r.bank_account_kind || '—' },
+    { key: 'b', header: 'Balance', numeric: true, cell: (r) => `$${Number(r.current_balance).toFixed(2)}` },
+  ];
+  return <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />;
+}
+
+function ReconciliationsTab() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<Reconciliation[]>({ queryKey: ['reconciliations'], queryFn: () => api.get('/banking/reconciliations').then((r) => Array.isArray(r.data) ? r.data : r.data.items ?? []) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ account_id: '', statement_end_date: new Date().toISOString().slice(0, 10), statement_ending_balance: '0' });
+  const save = async () => {
+    try {
+      await api.post('/banking/reconciliations', form);
+      toast.success('Started');
+      qc.invalidateQueries({ queryKey: ['reconciliations'] });
+      setOpen(false);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const cols: Column<Reconciliation>[] = [
+    { key: 'a', header: 'Account', cell: (r) => r.account_id.slice(0, 8) },
+    { key: 'd', header: 'Stmt end', cell: (r) => r.statement_end_date },
+    { key: 'b', header: 'Stmt balance', numeric: true, cell: (r) => `$${Number(r.statement_ending_balance).toFixed(2)}` },
+    { key: 's', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+  ];
+  return (
+    <div className="space-y-3">
+      <Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />Start reconciliation</Button>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Start reconciliation</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Account ID</Label><Input value={form.account_id} onChange={(e) => setForm({ ...form, account_id: e.target.value })} /></div>
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Statement end date</Label><Input type="date" value={form.statement_end_date} onChange={(e) => setForm({ ...form, statement_end_date: e.target.value })} /></div>
+              <div><Label>Statement ending balance</Label><Input type="number" step="0.01" value={form.statement_ending_balance} onChange={(e) => setForm({ ...form, statement_ending_balance: e.target.value })} /></div>
+            </div>
+          </div>
+          <DialogFooter><Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button><Button onClick={save}>Start</Button></DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function ImportsTab() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<any[]>({ queryKey: ['statement-imports'], queryFn: () => api.get('/banking/imports').then((r) => r.data) });
+  const [accountId, setAccountId] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+
+  const upload = async () => {
+    if (!file || !accountId) return toast.error('Account ID + CSV required');
+    const fd = new FormData();
+    fd.append('file', file);
+    fd.append('account_id', accountId);
+    try {
+      await api.post('/banking/imports', fd, { headers: { 'Content-Type': 'multipart/form-data' } });
+      toast.success('Imported');
+      qc.invalidateQueries({ queryKey: ['statement-imports'] });
+      setFile(null);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+
+  const cols: Column<any>[] = [
+    { key: 'd', header: 'Imported', cell: (r) => new Date(r.imported_at || r.created_at || '').toLocaleString() },
+    { key: 'a', header: 'Account', cell: (r) => (r.account_id || '').slice(0, 8) },
+    { key: 'n', header: 'Lines', numeric: true, cell: (r) => r.line_count ?? '—' },
+    { key: 's', header: 'Status', cell: (r) => r.status || '—' },
+  ];
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-2 rounded-lg border bg-card p-3">
+        <div><Label>Account ID</Label><Input value={accountId} onChange={(e) => setAccountId(e.target.value)} /></div>
+        <div><Label>CSV file</Label><Input type="file" accept=".csv" onChange={(e) => setFile(e.target.files?.[0] ?? null)} /></div>
+        <Button onClick={upload}><Upload className="mr-2 h-4 w-4" />Import</Button>
+      </div>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+    </div>
+  );
+}
+
+function RulesTab() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<Rule[]>({ queryKey: ['statement-rules'], queryFn: () => api.get('/banking/rules').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ name: '', match_field: 'description', match_pattern: '', category_account_id: '' });
+  const save = async () => {
+    try {
+      await api.post('/banking/rules', { ...form, category_account_id: form.category_account_id || null });
+      toast.success('Rule created');
+      qc.invalidateQueries({ queryKey: ['statement-rules'] });
+      setOpen(false);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const cols: Column<Rule>[] = [
+    { key: 'n', header: 'Name', cell: (r) => <span className="font-medium">{r.name}</span> },
+    { key: 'f', header: 'Field', cell: (r) => r.match_field },
+    { key: 'p', header: 'Pattern', cell: (r) => <code>{r.match_pattern}</code> },
+    { key: 'c', header: 'Category', cell: (r) => (r.category_account_id || '—').slice(0, 8) },
+    { key: 'a', header: 'Active', cell: (r) => (r.active ? 'yes' : 'no') },
+  ];
+  return (
+    <div className="space-y-3">
+      <Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New rule</Button>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>New rule</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Name</Label><Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} /></div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label>Field</Label>
+                <select className="mt-1 block w-full rounded-md border bg-background px-2 py-2 text-sm" value={form.match_field} onChange={(e) => setForm({ ...form, match_field: e.target.value })}>
+                  <option value="description">description</option>
+                  <option value="counterparty">counterparty</option>
+                  <option value="memo">memo</option>
+                </select>
+              </div>
+              <div><Label>Pattern</Label><Input value={form.match_pattern} onChange={(e) => setForm({ ...form, match_pattern: e.target.value })} placeholder="regex or substring" /></div>
+            </div>
+            <div><Label>Category account ID</Label><Input value={form.category_account_id} onChange={(e) => setForm({ ...form, category_account_id: e.target.value })} /></div>
+          </div>
+          <DialogFooter><Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button><Button onClick={save}>Create</Button></DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function TransfersTab() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<Transfer[]>({ queryKey: ['inter-account-transfers'], queryFn: () => api.get('/banking/inter-account-transfers').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ from_account_id: '', to_account_id: '', amount: '0', paid_on: new Date().toISOString().slice(0, 10) });
+  const save = async () => {
+    try {
+      await api.post('/banking/inter-account-transfers', form);
+      toast.success('Transfer recorded');
+      qc.invalidateQueries({ queryKey: ['inter-account-transfers'] });
+      setOpen(false);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const cols: Column<Transfer>[] = [
+    { key: 'd', header: 'Paid on', cell: (r) => r.paid_on },
+    { key: 'f', header: 'From', cell: (r) => r.from_account_id.slice(0, 8) },
+    { key: 't', header: 'To', cell: (r) => r.to_account_id.slice(0, 8) },
+    { key: 'a', header: 'Amount', numeric: true, cell: (r) => `$${Number(r.amount).toFixed(2)}` },
+    { key: 'r', header: 'Received', cell: (r) => r.received_on || '—' },
+  ];
+  return (
+    <div className="space-y-3">
+      <Button onClick={() => setOpen(true)}><ArrowRightLeft className="mr-2 h-4 w-4" />New transfer</Button>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Inter-account transfer</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>From account ID</Label><Input value={form.from_account_id} onChange={(e) => setForm({ ...form, from_account_id: e.target.value })} /></div>
+              <div><Label>To account ID</Label><Input value={form.to_account_id} onChange={(e) => setForm({ ...form, to_account_id: e.target.value })} /></div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Amount</Label><Input type="number" step="0.01" value={form.amount} onChange={(e) => setForm({ ...form, amount: e.target.value })} /></div>
+              <div><Label>Paid on</Label><Input type="date" value={form.paid_on} onChange={(e) => setForm({ ...form, paid_on: e.target.value })} /></div>
+            </div>
+          </div>
+          <DialogFooter><Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button><Button onClick={save}>Create</Button></DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+export default function BankingPage() {
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Banking" description="Bank accounts, reconciliation, statement import, match rules, transfers" />
+      <Tabs defaultValue="accounts">
+        <TabsList>
+          <TabsTrigger value="accounts"><Banknote className="mr-2 h-4 w-4" />Accounts</TabsTrigger>
+          <TabsTrigger value="reconciliations"><RefreshCw className="mr-2 h-4 w-4" />Reconciliations</TabsTrigger>
+          <TabsTrigger value="imports"><Upload className="mr-2 h-4 w-4" />Imports</TabsTrigger>
+          <TabsTrigger value="rules">Rules</TabsTrigger>
+          <TabsTrigger value="transfers"><ArrowRightLeft className="mr-2 h-4 w-4" />Transfers</TabsTrigger>
+        </TabsList>
+        <TabsContent value="accounts" className="mt-4"><AccountsTab /></TabsContent>
+        <TabsContent value="reconciliations" className="mt-4"><ReconciliationsTab /></TabsContent>
+        <TabsContent value="imports" className="mt-4"><ImportsTab /></TabsContent>
+        <TabsContent value="rules" className="mt-4"><RulesTab /></TabsContent>
+        <TabsContent value="transfers" className="mt-4"><TransfersTab /></TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/CreditNotesPage.tsx
+++ b/frontend/src/pages/accounting/CreditNotesPage.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Plus } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Textarea } from '@/components/ui/Textarea';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { useListQuery } from '@/hooks/useListQuery';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface CN {
+  id: string;
+  note_number: string;
+  customer_id: string | null;
+  customer_name: string | null;
+  issue_date: string;
+  total_amount: number;
+  status: string;
+  reason: string | null;
+}
+
+interface LineDraft { description: string; quantity: string; unit_price: string }
+
+const empty = { customer_name: '', issue_date: new Date().toISOString().slice(0, 10), reason: '', lines: [{ description: '', quantity: '1', unit_price: '0' }] as LineDraft[] };
+
+export default function CreditNotesPage() {
+  const qc = useQueryClient();
+  const list = useListQuery<CN>({ resource: 'credit-notes' });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(empty);
+  const [saving, setSaving] = useState(false);
+  const [applying, setApplying] = useState<CN | null>(null);
+  const [applyTo, setApplyTo] = useState({ invoice_id: '', amount: '' });
+
+  const setLine = (i: number, p: Partial<LineDraft>) => setForm((f) => ({ ...f, lines: f.lines.map((l, idx) => (idx === i ? { ...l, ...p } : l)) }));
+
+  const save = async () => {
+    if (!form.customer_name) return toast.error('Customer required');
+    setSaving(true);
+    try {
+      await api.post('/credit-notes', { ...form, reason: form.reason || null });
+      toast.success('Credit note created');
+      qc.invalidateQueries({ queryKey: ['credit-notes'] });
+      setOpen(false); setForm(empty);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+    finally { setSaving(false); }
+  };
+
+  const action = async (id: string, verb: string, body?: any) => {
+    try {
+      await api.post(`/credit-notes/${id}/${verb}`, body);
+      toast.success(verb);
+      qc.invalidateQueries({ queryKey: ['credit-notes'] });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+
+  const apply = async () => {
+    if (!applying) return;
+    await action(applying.id, 'apply', { invoice_id: applyTo.invoice_id, amount: applyTo.amount });
+    setApplying(null);
+  };
+
+  const cols: Column<CN>[] = [
+    { key: 'n', header: 'CN #', cell: (r) => <span className="font-medium">{r.note_number}</span> },
+    { key: 'c', header: 'Customer', cell: (r) => r.customer_name || '—' },
+    { key: 'd', header: 'Issued', cell: (r) => r.issue_date },
+    { key: 't', header: 'Total', numeric: true, cell: (r) => `$${Number(r.total_amount).toFixed(2)}` },
+    { key: 's', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+    { key: 'a', header: '', width: '220px', cell: (r) => (
+      <div className="flex justify-end gap-1">
+        {r.status === 'draft' && <Button size="sm" variant="outline" onClick={() => action(r.id, 'issue')}>Issue</Button>}
+        {r.status === 'issued' && <Button size="sm" variant="outline" onClick={() => { setApplying(r); setApplyTo({ invoice_id: '', amount: String(r.total_amount) }); }}>Apply</Button>}
+        {r.status !== 'voided' && <Button size="sm" variant="ghost" onClick={() => action(r.id, 'void')}>Void</Button>}
+      </div>
+    ) },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Credit notes" description="Customer refunds/credits applied to invoices" actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New credit note</Button>} />
+      <DataTable data={list.data} columns={cols} rowKey={(r) => r.id} loading={list.isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>New credit note</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Customer name</Label><Input value={form.customer_name} onChange={(e) => setForm({ ...form, customer_name: e.target.value })} /></div>
+            <div><Label>Issue date</Label><Input type="date" value={form.issue_date} onChange={(e) => setForm({ ...form, issue_date: e.target.value })} /></div>
+            <div><Label>Reason</Label><Textarea rows={2} value={form.reason} onChange={(e) => setForm({ ...form, reason: e.target.value })} /></div>
+            <div className="space-y-2">
+              <Label>Lines</Label>
+              {form.lines.map((line, i) => (
+                <div key={i} className="grid grid-cols-12 gap-2">
+                  <Input className="col-span-7" placeholder="Description" value={line.description} onChange={(e) => setLine(i, { description: e.target.value })} />
+                  <Input className="col-span-2" value={line.quantity} onChange={(e) => setLine(i, { quantity: e.target.value })} />
+                  <Input className="col-span-3" type="number" step="0.01" value={line.unit_price} onChange={(e) => setLine(i, { unit_price: e.target.value })} />
+                </div>
+              ))}
+              <Button size="sm" variant="outline" onClick={() => setForm((f) => ({ ...f, lines: [...f.lines, { description: '', quantity: '1', unit_price: '0' }] }))}>+ Add line</Button>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Create'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={Boolean(applying)} onOpenChange={(o) => !o && setApplying(null)}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Apply credit note</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Invoice ID</Label><Input value={applyTo.invoice_id} onChange={(e) => setApplyTo({ ...applyTo, invoice_id: e.target.value })} /></div>
+            <div><Label>Amount</Label><Input type="number" step="0.01" value={applyTo.amount} onChange={(e) => setApplyTo({ ...applyTo, amount: e.target.value })} /></div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setApplying(null)}>Cancel</Button>
+            <Button onClick={apply}>Apply</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/DebitNotesPage.tsx
+++ b/frontend/src/pages/accounting/DebitNotesPage.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Plus } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Textarea } from '@/components/ui/Textarea';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { useListQuery } from '@/hooks/useListQuery';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface DN {
+  id: string;
+  note_number: string;
+  vendor_name: string | null;
+  issue_date: string;
+  total_amount: number;
+  status: string;
+}
+
+interface LineDraft { description: string; quantity: string; unit_price: string }
+const empty = { vendor_name: '', issue_date: new Date().toISOString().slice(0, 10), reason: '', lines: [{ description: '', quantity: '1', unit_price: '0' }] as LineDraft[] };
+
+export default function DebitNotesPage() {
+  const qc = useQueryClient();
+  const list = useListQuery<DN>({ resource: 'debit-notes' });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(empty);
+  const [saving, setSaving] = useState(false);
+  const [applying, setApplying] = useState<DN | null>(null);
+  const [applyTo, setApplyTo] = useState({ bill_id: '', amount: '' });
+
+  const setLine = (i: number, p: Partial<LineDraft>) => setForm((f) => ({ ...f, lines: f.lines.map((l, idx) => (idx === i ? { ...l, ...p } : l)) }));
+
+  const save = async () => {
+    if (!form.vendor_name) return toast.error('Vendor required');
+    setSaving(true);
+    try {
+      await api.post('/debit-notes', { ...form, reason: form.reason || null });
+      toast.success('Debit note created');
+      qc.invalidateQueries({ queryKey: ['debit-notes'] });
+      setOpen(false); setForm(empty);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+    finally { setSaving(false); }
+  };
+
+  const action = async (id: string, verb: string, body?: any) => {
+    try {
+      await api.post(`/debit-notes/${id}/${verb}`, body);
+      toast.success(verb);
+      qc.invalidateQueries({ queryKey: ['debit-notes'] });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+
+  const cols: Column<DN>[] = [
+    { key: 'n', header: 'DN #', cell: (r) => <span className="font-medium">{r.note_number}</span> },
+    { key: 'v', header: 'Vendor', cell: (r) => r.vendor_name || '—' },
+    { key: 'd', header: 'Issued', cell: (r) => r.issue_date },
+    { key: 't', header: 'Total', numeric: true, cell: (r) => `$${Number(r.total_amount).toFixed(2)}` },
+    { key: 's', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+    { key: 'a', header: '', width: '220px', cell: (r) => (
+      <div className="flex justify-end gap-1">
+        {r.status === 'draft' && <Button size="sm" variant="outline" onClick={() => action(r.id, 'issue')}>Issue</Button>}
+        {r.status === 'issued' && <Button size="sm" variant="outline" onClick={() => { setApplying(r); setApplyTo({ bill_id: '', amount: String(r.total_amount) }); }}>Apply</Button>}
+        {r.status !== 'voided' && <Button size="sm" variant="ghost" onClick={() => action(r.id, 'void')}>Void</Button>}
+      </div>
+    ) },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Debit notes" description="Vendor returns / supplier credits applied to bills" actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New debit note</Button>} />
+      <DataTable data={list.data} columns={cols} rowKey={(r) => r.id} loading={list.isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>New debit note</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Vendor name</Label><Input value={form.vendor_name} onChange={(e) => setForm({ ...form, vendor_name: e.target.value })} /></div>
+            <div><Label>Issue date</Label><Input type="date" value={form.issue_date} onChange={(e) => setForm({ ...form, issue_date: e.target.value })} /></div>
+            <div><Label>Reason</Label><Textarea rows={2} value={form.reason} onChange={(e) => setForm({ ...form, reason: e.target.value })} /></div>
+            <div className="space-y-2">
+              <Label>Lines</Label>
+              {form.lines.map((line, i) => (
+                <div key={i} className="grid grid-cols-12 gap-2">
+                  <Input className="col-span-7" placeholder="Description" value={line.description} onChange={(e) => setLine(i, { description: e.target.value })} />
+                  <Input className="col-span-2" value={line.quantity} onChange={(e) => setLine(i, { quantity: e.target.value })} />
+                  <Input className="col-span-3" type="number" step="0.01" value={line.unit_price} onChange={(e) => setLine(i, { unit_price: e.target.value })} />
+                </div>
+              ))}
+              <Button size="sm" variant="outline" onClick={() => setForm((f) => ({ ...f, lines: [...f.lines, { description: '', quantity: '1', unit_price: '0' }] }))}>+ Add line</Button>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Create'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={Boolean(applying)} onOpenChange={(o) => !o && setApplying(null)}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Apply debit note</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Bill ID</Label><Input value={applyTo.bill_id} onChange={(e) => setApplyTo({ ...applyTo, bill_id: e.target.value })} /></div>
+            <div><Label>Amount</Label><Input type="number" step="0.01" value={applyTo.amount} onChange={(e) => setApplyTo({ ...applyTo, amount: e.target.value })} /></div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setApplying(null)}>Cancel</Button>
+            <Button onClick={async () => { if (applying) { await action(applying.id, 'apply', applyTo); setApplying(null); } }}>Apply</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/DeliveryNotesPage.tsx
+++ b/frontend/src/pages/accounting/DeliveryNotesPage.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Plus } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { useListQuery } from '@/hooks/useListQuery';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface DN {
+  id: string;
+  delivery_number: string;
+  invoice_id: string | null;
+  customer_id: string | null;
+  customer_name: string | null;
+  issued_on: string;
+  shipped_on: string | null;
+  tracking_number: string | null;
+  status: string;
+}
+
+interface LineDraft { description: string; quantity: string; notes: string }
+
+const empty = {
+  customer_name: '',
+  invoice_id: '',
+  issued_on: new Date().toISOString().slice(0, 10),
+  tracking_number: '',
+  lines: [{ description: '', quantity: '1', notes: '' }] as LineDraft[],
+};
+
+export default function DeliveryNotesPage() {
+  const qc = useQueryClient();
+  const list = useListQuery<DN>({ resource: 'delivery-notes' });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(empty);
+  const [saving, setSaving] = useState(false);
+
+  const setLine = (i: number, p: Partial<LineDraft>) => setForm((f) => ({ ...f, lines: f.lines.map((l, idx) => (idx === i ? { ...l, ...p } : l)) }));
+
+  const save = async () => {
+    if (!form.customer_name && !form.invoice_id) return toast.error('Customer name or invoice ID required');
+    setSaving(true);
+    try {
+      await api.post('/delivery-notes', {
+        invoice_id: form.invoice_id || null,
+        customer_name: form.customer_name || null,
+        issued_on: form.issued_on,
+        tracking_number: form.tracking_number || null,
+        lines: form.lines.map((l) => ({ description: l.description, quantity: l.quantity, notes: l.notes || null })),
+      });
+      toast.success('Delivery note created');
+      qc.invalidateQueries({ queryKey: ['delivery-notes'] });
+      setOpen(false); setForm(empty);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+    finally { setSaving(false); }
+  };
+
+  const setStatus = async (r: DN, status: string) => {
+    try {
+      await api.patch(`/delivery-notes/${r.id}`, { status });
+      toast.success(status);
+      qc.invalidateQueries({ queryKey: ['delivery-notes'] });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+
+  const cols: Column<DN>[] = [
+    { key: 'n', header: 'DN #', cell: (r) => <span className="font-medium">{r.delivery_number}</span> },
+    { key: 'c', header: 'Customer', cell: (r) => r.customer_name || '—' },
+    { key: 'd', header: 'Issued', cell: (r) => r.issued_on },
+    { key: 'tk', header: 'Tracking', cell: (r) => r.tracking_number || '—' },
+    { key: 's', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+    { key: 'a', header: '', width: '180px', cell: (r) => (
+      <div className="flex justify-end gap-1">
+        {r.status === 'draft' && <Button size="sm" variant="outline" onClick={() => setStatus(r, 'shipped')}>Ship</Button>}
+        {r.status === 'shipped' && <Button size="sm" variant="outline" onClick={() => setStatus(r, 'delivered')}>Deliver</Button>}
+      </div>
+    ) },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Delivery notes" description="Dispatch documents (DLV-…). No GL impact." actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New DN</Button>} />
+      <DataTable data={list.data} columns={cols} rowKey={(r) => r.id} loading={list.isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>New delivery note</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Customer name</Label><Input value={form.customer_name} onChange={(e) => setForm({ ...form, customer_name: e.target.value })} /></div>
+              <div><Label>Invoice ID (opt.)</Label><Input value={form.invoice_id} onChange={(e) => setForm({ ...form, invoice_id: e.target.value })} /></div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Issued</Label><Input type="date" value={form.issued_on} onChange={(e) => setForm({ ...form, issued_on: e.target.value })} /></div>
+              <div><Label>Tracking #</Label><Input value={form.tracking_number} onChange={(e) => setForm({ ...form, tracking_number: e.target.value })} /></div>
+            </div>
+            <div className="space-y-2">
+              <Label>Lines</Label>
+              {form.lines.map((line, i) => (
+                <div key={i} className="grid grid-cols-12 gap-2">
+                  <Input className="col-span-9" placeholder="Description" value={line.description} onChange={(e) => setLine(i, { description: e.target.value })} />
+                  <Input className="col-span-3" placeholder="Qty" value={line.quantity} onChange={(e) => setLine(i, { quantity: e.target.value })} />
+                </div>
+              ))}
+              <Button size="sm" variant="outline" onClick={() => setForm((f) => ({ ...f, lines: [...f.lines, { description: '', quantity: '1', notes: '' }] }))}>+ Add line</Button>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Create'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/ExpenseClaimsPage.tsx
+++ b/frontend/src/pages/accounting/ExpenseClaimsPage.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Textarea } from '@/components/ui/Textarea';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface Claim {
+  id: string;
+  claim_number: string;
+  payer_name: string;
+  incurred_on: string;
+  total_amount: number;
+  status: string;
+}
+
+interface LineDraft { description: string; amount: string; expense_account_id: string }
+const empty = { payer_name: '', incurred_on: new Date().toISOString().slice(0, 10), notes: '', lines: [{ description: '', amount: '0', expense_account_id: '' }] as LineDraft[] };
+
+export default function ExpenseClaimsPage() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<Claim[]>({ queryKey: ['expense-claims'], queryFn: () => api.get('/expense-claims').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(empty);
+  const [saving, setSaving] = useState(false);
+
+  const setLine = (i: number, p: Partial<LineDraft>) => setForm((f) => ({ ...f, lines: f.lines.map((l, idx) => (idx === i ? { ...l, ...p } : l)) }));
+
+  const save = async () => {
+    if (!form.payer_name) return toast.error('Payer required');
+    setSaving(true);
+    try {
+      await api.post('/expense-claims', { ...form, notes: form.notes || null });
+      toast.success('Claim created');
+      qc.invalidateQueries({ queryKey: ['expense-claims'] });
+      setOpen(false); setForm(empty);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+    finally { setSaving(false); }
+  };
+
+  const action = async (id: string, verb: string) => {
+    try {
+      await api.post(`/expense-claims/${id}/${verb}`);
+      toast.success(verb);
+      qc.invalidateQueries({ queryKey: ['expense-claims'] });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+
+  const cols: Column<Claim>[] = [
+    { key: 'n', header: 'Claim #', cell: (r) => <span className="font-medium">{r.claim_number}</span> },
+    { key: 'p', header: 'Payer', cell: (r) => r.payer_name },
+    { key: 'd', header: 'Incurred', cell: (r) => r.incurred_on },
+    { key: 't', header: 'Total', numeric: true, cell: (r) => `$${Number(r.total_amount).toFixed(2)}` },
+    { key: 's', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+    { key: 'a', header: '', width: '260px', cell: (r) => (
+      <div className="flex justify-end gap-1">
+        {r.status === 'draft' && <Button size="sm" variant="outline" onClick={() => action(r.id, 'submit')}>Submit</Button>}
+        {r.status === 'submitted' && <Button size="sm" variant="outline" onClick={() => action(r.id, 'approve')}>Approve</Button>}
+        {r.status === 'approved' && <Button size="sm" variant="outline" onClick={() => action(r.id, 'reimburse')}>Reimburse</Button>}
+        {r.status !== 'cancelled' && r.status !== 'reimbursed' && <Button size="sm" variant="ghost" onClick={() => action(r.id, 'cancel')}>Cancel</Button>}
+      </div>
+    ) },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Expense claims" description="Owner-paid reimbursable expenses (posts to 2300)" actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New claim</Button>} />
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>New expense claim</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Payer name</Label><Input value={form.payer_name} onChange={(e) => setForm({ ...form, payer_name: e.target.value })} /></div>
+              <div><Label>Incurred on</Label><Input type="date" value={form.incurred_on} onChange={(e) => setForm({ ...form, incurred_on: e.target.value })} /></div>
+            </div>
+            <div><Label>Notes</Label><Textarea rows={2} value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} /></div>
+            <div className="space-y-2">
+              <Label>Lines</Label>
+              {form.lines.map((line, i) => (
+                <div key={i} className="grid grid-cols-12 gap-2">
+                  <Input className="col-span-6" placeholder="Description" value={line.description} onChange={(e) => setLine(i, { description: e.target.value })} />
+                  <Input className="col-span-3" type="number" step="0.01" value={line.amount} onChange={(e) => setLine(i, { amount: e.target.value })} />
+                  <Input className="col-span-3" placeholder="Expense acct ID" value={line.expense_account_id} onChange={(e) => setLine(i, { expense_account_id: e.target.value })} />
+                </div>
+              ))}
+              <Button size="sm" variant="outline" onClick={() => setForm((f) => ({ ...f, lines: [...f.lines, { description: '', amount: '0', expense_account_id: '' }] }))}>+ Add line</Button>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Create'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/FixedAssetsPage.tsx
+++ b/frontend/src/pages/accounting/FixedAssetsPage.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, RefreshCw } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface FA {
+  id: string;
+  name: string;
+  acquired_on: string;
+  cost: number;
+  salvage_value: number;
+  useful_life_months: number;
+  method: string;
+  status: string;
+  accumulated_depreciation: number;
+}
+
+const empty = { name: '', acquired_on: new Date().toISOString().slice(0, 10), cost: '0', salvage_value: '0', useful_life_months: '60', method: 'straight_line' };
+
+export default function FixedAssetsPage() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<FA[]>({ queryKey: ['fixed-assets'], queryFn: () => api.get('/fixed-assets').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(empty);
+  const [saving, setSaving] = useState(false);
+  const [throughDate, setThroughDate] = useState(new Date().toISOString().slice(0, 10));
+
+  const save = async () => {
+    if (!form.name) return toast.error('Name required');
+    setSaving(true);
+    try {
+      await api.post('/fixed-assets', form);
+      toast.success('Asset registered');
+      qc.invalidateQueries({ queryKey: ['fixed-assets'] });
+      setOpen(false); setForm(empty);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+    finally { setSaving(false); }
+  };
+
+  const post = async () => {
+    try {
+      await api.post('/fixed-assets/post-depreciation', { through_date: throughDate });
+      toast.success('Depreciation posted');
+      qc.invalidateQueries({ queryKey: ['fixed-assets'] });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+
+  const cols: Column<FA>[] = [
+    { key: 'n', header: 'Name', cell: (r) => <span className="font-medium">{r.name}</span> },
+    { key: 'd', header: 'Acquired', cell: (r) => r.acquired_on },
+    { key: 'c', header: 'Cost', numeric: true, cell: (r) => `$${Number(r.cost).toFixed(2)}` },
+    { key: 'a', header: 'Acc. dep.', numeric: true, cell: (r) => `$${Number(r.accumulated_depreciation).toFixed(2)}` },
+    { key: 'm', header: 'Method', cell: (r) => r.method },
+    { key: 'l', header: 'Life (mo)', numeric: true, cell: (r) => r.useful_life_months },
+    { key: 's', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Fixed assets" description="Capital assets with depreciation schedule" actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />Register asset</Button>} />
+      <div className="flex items-end gap-2 rounded-lg border bg-card p-3">
+        <div><Label>Post depreciation through</Label><Input type="date" value={throughDate} onChange={(e) => setThroughDate(e.target.value)} /></div>
+        <Button onClick={post}><RefreshCw className="mr-2 h-4 w-4" />Run</Button>
+      </div>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Register fixed asset</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Name</Label><Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} /></div>
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Acquired on</Label><Input type="date" value={form.acquired_on} onChange={(e) => setForm({ ...form, acquired_on: e.target.value })} /></div>
+              <div><Label>Cost</Label><Input type="number" step="0.01" value={form.cost} onChange={(e) => setForm({ ...form, cost: e.target.value })} /></div>
+            </div>
+            <div className="grid grid-cols-3 gap-3">
+              <div><Label>Salvage</Label><Input type="number" step="0.01" value={form.salvage_value} onChange={(e) => setForm({ ...form, salvage_value: e.target.value })} /></div>
+              <div><Label>Life (months)</Label><Input type="number" value={form.useful_life_months} onChange={(e) => setForm({ ...form, useful_life_months: e.target.value })} /></div>
+              <div>
+                <Label>Method</Label>
+                <select className="mt-1 block w-full rounded-md border bg-background px-2 py-2 text-sm" value={form.method} onChange={(e) => setForm({ ...form, method: e.target.value })}>
+                  <option value="straight_line">straight_line</option>
+                  <option value="double_declining">double_declining</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Register'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/FoundationsPage.tsx
+++ b/frontend/src/pages/accounting/FoundationsPage.tsx
@@ -1,0 +1,171 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, Play, SkipForward, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { Textarea } from '@/components/ui/Textarea';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface RJE {
+  id: string;
+  name: string;
+  cadence: string;
+  interval_count: number;
+  next_run_on: string;
+  active: boolean;
+}
+
+interface SuspenseLine {
+  id: string;
+  account_id: string;
+  amount: number;
+  posted_on: string;
+  description: string | null;
+}
+
+function RecurringJEsTab() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<RJE[]>({ queryKey: ['rjes'], queryFn: () => api.get('/accounting/recurring-journal-entries').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({
+    name: '',
+    cadence: 'monthly',
+    interval_count: '1',
+    start_on: new Date().toISOString().slice(0, 10),
+    description: '',
+    lines_template: '[{"account_id": "", "amount": "0", "side": "debit"}]',
+  });
+  const save = async () => {
+    if (!form.name) return toast.error('Name required');
+    let parsed;
+    try { parsed = JSON.parse(form.lines_template); }
+    catch { return toast.error('Invalid lines_template JSON'); }
+    try {
+      await api.post('/accounting/recurring-journal-entries', {
+        name: form.name,
+        cadence: form.cadence,
+        interval_count: Number(form.interval_count),
+        start_on: form.start_on,
+        next_run_on: form.start_on,
+        description: form.description || null,
+        lines_template: parsed,
+      });
+      toast.success('Created');
+      qc.invalidateQueries({ queryKey: ['rjes'] });
+      setOpen(false);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const action = async (id: string, verb: string) => {
+    try { await api.post(`/accounting/recurring-journal-entries/${id}/${verb}`); qc.invalidateQueries({ queryKey: ['rjes'] }); toast.success(verb); }
+    catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const remove = async (id: string) => {
+    try { await api.delete(`/accounting/recurring-journal-entries/${id}`); qc.invalidateQueries({ queryKey: ['rjes'] }); toast.success('Removed'); }
+    catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const cols: Column<RJE>[] = [
+    { key: 'n', header: 'Name', cell: (r) => <span className="font-medium">{r.name}</span> },
+    { key: 'c', header: 'Cadence', cell: (r) => `every ${r.interval_count} ${r.cadence}` },
+    { key: 'next', header: 'Next run', cell: (r) => r.next_run_on },
+    { key: 'a', header: 'Active', cell: (r) => (r.active ? 'yes' : 'no') },
+    { key: 'x', header: '', width: '180px', cell: (r) => (
+      <div className="flex justify-end gap-1">
+        <Button size="icon" variant="ghost" onClick={() => action(r.id, 'run-now')}><Play className="h-4 w-4" /></Button>
+        <Button size="icon" variant="ghost" onClick={() => action(r.id, 'skip-next')}><SkipForward className="h-4 w-4" /></Button>
+        <Button size="icon" variant="ghost" onClick={() => remove(r.id)}><Trash2 className="h-4 w-4" /></Button>
+      </div>
+    ) },
+  ];
+  return (
+    <div className="space-y-3">
+      <Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New recurring JE</Button>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>New recurring journal entry</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Name</Label><Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} /></div>
+            <div className="grid grid-cols-3 gap-3">
+              <div>
+                <Label>Cadence</Label>
+                <select className="mt-1 block w-full rounded-md border bg-background px-2 py-2 text-sm" value={form.cadence} onChange={(e) => setForm({ ...form, cadence: e.target.value })}>
+                  <option value="weekly">weekly</option><option value="monthly">monthly</option><option value="quarterly">quarterly</option><option value="yearly">yearly</option>
+                </select>
+              </div>
+              <div><Label>Every</Label><Input type="number" min={1} value={form.interval_count} onChange={(e) => setForm({ ...form, interval_count: e.target.value })} /></div>
+              <div><Label>Start on</Label><Input type="date" value={form.start_on} onChange={(e) => setForm({ ...form, start_on: e.target.value })} /></div>
+            </div>
+            <div><Label>Description</Label><Input value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} /></div>
+            <div>
+              <Label>Lines template (JSON)</Label>
+              <Textarea rows={6} value={form.lines_template} onChange={(e) => setForm({ ...form, lines_template: e.target.value })} className="font-mono text-xs" />
+            </div>
+          </div>
+          <DialogFooter><Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button><Button onClick={save}>Create</Button></DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function SuspenseTab() {
+  const { data, isLoading } = useQuery<SuspenseLine[]>({ queryKey: ['suspense'], queryFn: () => api.get('/accounting/suspense').then((r) => Array.isArray(r.data) ? r.data : r.data.items ?? []) });
+  const cols: Column<SuspenseLine>[] = [
+    { key: 'd', header: 'Posted', cell: (r) => r.posted_on },
+    { key: 'desc', header: 'Description', cell: (r) => r.description || '—' },
+    { key: 'a', header: 'Amount', numeric: true, cell: (r) => `$${Number(r.amount).toFixed(2)}` },
+    { key: 'id', header: 'Line ID', cell: (r) => <span className="font-mono text-xs">{r.id.slice(0, 12)}…</span> },
+  ];
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">Open journal lines posted to the Suspense account (1900). Reclassify these to their proper accounts via the journal-entry editor.</p>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+    </div>
+  );
+}
+
+function StartingBalancesTab() {
+  const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
+  const [json, setJson] = useState('[{"account_id":"","amount":"0","side":"debit"}]');
+  const submit = async () => {
+    let parsed;
+    try { parsed = JSON.parse(json); }
+    catch { return toast.error('Invalid JSON'); }
+    try {
+      await api.post('/accounting/starting-balances', { posted_on: date, lines: parsed });
+      toast.success('Starting balances posted');
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  return (
+    <div className="space-y-3 rounded-lg border bg-card p-4">
+      <div><Label>Posted on</Label><Input type="date" value={date} onChange={(e) => setDate(e.target.value)} /></div>
+      <div><Label>Lines (balanced; will offset to OBE 3300)</Label><Textarea rows={10} className="font-mono text-xs" value={json} onChange={(e) => setJson(e.target.value)} /></div>
+      <Button onClick={submit}>Post starting balances</Button>
+    </div>
+  );
+}
+
+export default function FoundationsPage() {
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Accounting foundations" description="Recurring JEs · Suspense · Starting balances" />
+      <Tabs defaultValue="rje">
+        <TabsList>
+          <TabsTrigger value="rje">Recurring JEs</TabsTrigger>
+          <TabsTrigger value="suspense">Suspense</TabsTrigger>
+          <TabsTrigger value="sb">Starting balances</TabsTrigger>
+        </TabsList>
+        <TabsContent value="rje" className="mt-4"><RecurringJEsTab /></TabsContent>
+        <TabsContent value="suspense" className="mt-4"><SuspenseTab /></TabsContent>
+        <TabsContent value="sb" className="mt-4"><StartingBalancesTab /></TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/IntangiblesPage.tsx
+++ b/frontend/src/pages/accounting/IntangiblesPage.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, RefreshCw } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface IA {
+  id: string;
+  name: string;
+  acquired_on: string;
+  cost: number;
+  useful_life_months: number;
+  status: string;
+  accumulated_amortization: number;
+}
+
+const empty = { name: '', acquired_on: new Date().toISOString().slice(0, 10), cost: '0', useful_life_months: '60' };
+
+export default function IntangiblesPage() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<IA[]>({ queryKey: ['intangible-assets'], queryFn: () => api.get('/intangible-assets').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(empty);
+  const [saving, setSaving] = useState(false);
+  const [throughDate, setThroughDate] = useState(new Date().toISOString().slice(0, 10));
+
+  const save = async () => {
+    if (!form.name) return toast.error('Name required');
+    setSaving(true);
+    try {
+      await api.post('/intangible-assets', form);
+      toast.success('Asset registered');
+      qc.invalidateQueries({ queryKey: ['intangible-assets'] });
+      setOpen(false); setForm(empty);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+    finally { setSaving(false); }
+  };
+
+  const post = async () => {
+    try {
+      await api.post('/intangible-assets/post-amortization', { through_date: throughDate });
+      toast.success('Amortization posted');
+      qc.invalidateQueries({ queryKey: ['intangible-assets'] });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+
+  const cols: Column<IA>[] = [
+    { key: 'n', header: 'Name', cell: (r) => <span className="font-medium">{r.name}</span> },
+    { key: 'd', header: 'Acquired', cell: (r) => r.acquired_on },
+    { key: 'c', header: 'Cost', numeric: true, cell: (r) => `$${Number(r.cost).toFixed(2)}` },
+    { key: 'a', header: 'Acc. amort.', numeric: true, cell: (r) => `$${Number(r.accumulated_amortization).toFixed(2)}` },
+    { key: 'l', header: 'Life (mo)', numeric: true, cell: (r) => r.useful_life_months },
+    { key: 's', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Intangible assets" description="Patents, trademarks, software with amortization schedule" actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />Register asset</Button>} />
+      <div className="flex items-end gap-2 rounded-lg border bg-card p-3">
+        <div><Label>Post amortization through</Label><Input type="date" value={throughDate} onChange={(e) => setThroughDate(e.target.value)} /></div>
+        <Button onClick={post}><RefreshCw className="mr-2 h-4 w-4" />Run</Button>
+      </div>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Register intangible asset</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Name</Label><Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} /></div>
+            <div className="grid grid-cols-3 gap-3">
+              <div><Label>Acquired on</Label><Input type="date" value={form.acquired_on} onChange={(e) => setForm({ ...form, acquired_on: e.target.value })} /></div>
+              <div><Label>Cost</Label><Input type="number" step="0.01" value={form.cost} onChange={(e) => setForm({ ...form, cost: e.target.value })} /></div>
+              <div><Label>Life (mo)</Label><Input type="number" value={form.useful_life_months} onChange={(e) => setForm({ ...form, useful_life_months: e.target.value })} /></div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Register'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/InvoicesPage.tsx
+++ b/frontend/src/pages/accounting/InvoicesPage.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Plus, Mail } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Textarea } from '@/components/ui/Textarea';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { useListQuery } from '@/hooks/useListQuery';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface Invoice {
+  id: string;
+  invoice_number: string;
+  customer_id: string | null;
+  customer_name: string | null;
+  issue_date: string;
+  due_date: string | null;
+  total_due: number;
+  amount_paid: number;
+  balance_due: number;
+  status: string;
+}
+
+interface LineDraft { description: string; quantity: number; unit_price: string }
+
+const emptyForm = {
+  customer_name: '',
+  issue_date: new Date().toISOString().slice(0, 10),
+  due_date: '',
+  notes: '',
+  tax_amount: '0',
+  shipping_amount: '0',
+  lines: [{ description: '', quantity: 1, unit_price: '0' }] as LineDraft[],
+};
+
+export default function InvoicesPage() {
+  const qc = useQueryClient();
+  const list = useListQuery<Invoice>({ resource: 'invoices' });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(emptyForm);
+  const [saving, setSaving] = useState(false);
+  const [emailing, setEmailing] = useState<Invoice | null>(null);
+  const [emailTo, setEmailTo] = useState('');
+  const [emailSending, setEmailSending] = useState(false);
+
+  const setLine = (i: number, patch: Partial<LineDraft>) => {
+    setForm((f) => ({ ...f, lines: f.lines.map((l, idx) => (idx === i ? { ...l, ...patch } : l)) }));
+  };
+  const addLine = () => setForm((f) => ({ ...f, lines: [...f.lines, { description: '', quantity: 1, unit_price: '0' }] }));
+  const removeLine = (i: number) => setForm((f) => ({ ...f, lines: f.lines.filter((_, idx) => idx !== i) }));
+
+  const save = async () => {
+    if (!form.customer_name) { toast.error('Customer name required'); return; }
+    if (form.lines.length === 0 || !form.lines[0].description) { toast.error('At least one line required'); return; }
+    setSaving(true);
+    try {
+      await api.post('/invoices', {
+        customer_name: form.customer_name,
+        issue_date: form.issue_date,
+        due_date: form.due_date || null,
+        notes: form.notes || null,
+        tax_amount: form.tax_amount,
+        shipping_amount: form.shipping_amount,
+        lines: form.lines.map((l) => ({ description: l.description, quantity: l.quantity, unit_price: l.unit_price })),
+      });
+      toast.success('Invoice created');
+      qc.invalidateQueries({ queryKey: ['invoices'] });
+      setOpen(false);
+      setForm(emptyForm);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed to create')); }
+    finally { setSaving(false); }
+  };
+
+  const sendEmail = async () => {
+    if (!emailing) return;
+    setEmailSending(true);
+    try {
+      await api.post(`/invoices/${emailing.id}/send-email`, { to_email: emailTo || null });
+      toast.success('Email queued');
+      setEmailing(null);
+      setEmailTo('');
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Email failed')); }
+    finally { setEmailSending(false); }
+  };
+
+  const columns: Column<Invoice>[] = [
+    { key: 'number', header: 'Invoice #', cell: (r) => <span className="font-medium">{r.invoice_number}</span> },
+    { key: 'customer', header: 'Customer', cell: (r) => r.customer_name || '—' },
+    { key: 'issue_date', header: 'Issued', cell: (r) => r.issue_date },
+    { key: 'due_date', header: 'Due', cell: (r) => r.due_date || '—' },
+    { key: 'total', header: 'Total', numeric: true, cell: (r) => `$${Number(r.total_due).toFixed(2)}` },
+    { key: 'balance', header: 'Balance', numeric: true, cell: (r) => `$${Number(r.balance_due).toFixed(2)}` },
+    { key: 'status', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+    {
+      key: 'actions', header: '', width: '100px',
+      cell: (r) => (
+        <div className="flex justify-end gap-1">
+          <Button size="icon" variant="ghost" onClick={() => { setEmailing(r); setEmailTo(''); }} aria-label="Email">
+            <Mail className="h-4 w-4" />
+          </Button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        title="Invoices"
+        description="Customer-facing invoices with email send"
+        actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New invoice</Button>}
+      />
+      <DataTable data={list.data} columns={columns} rowKey={(r) => r.id} loading={list.isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>New invoice</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Customer name</Label><Input value={form.customer_name} onChange={(e) => setForm({ ...form, customer_name: e.target.value })} /></div>
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Issue date</Label><Input type="date" value={form.issue_date} onChange={(e) => setForm({ ...form, issue_date: e.target.value })} /></div>
+              <div><Label>Due date</Label><Input type="date" value={form.due_date} onChange={(e) => setForm({ ...form, due_date: e.target.value })} /></div>
+            </div>
+            <div className="space-y-2">
+              <Label>Lines</Label>
+              {form.lines.map((line, i) => (
+                <div key={i} className="grid grid-cols-12 gap-2">
+                  <Input className="col-span-6" placeholder="Description" value={line.description} onChange={(e) => setLine(i, { description: e.target.value })} />
+                  <Input className="col-span-2" type="number" min={1} value={line.quantity} onChange={(e) => setLine(i, { quantity: Number(e.target.value) })} />
+                  <Input className="col-span-3" type="number" step="0.01" value={line.unit_price} onChange={(e) => setLine(i, { unit_price: e.target.value })} />
+                  <Button variant="ghost" size="sm" className="col-span-1" onClick={() => removeLine(i)} disabled={form.lines.length === 1}>×</Button>
+                </div>
+              ))}
+              <Button variant="outline" size="sm" onClick={addLine}>+ Add line</Button>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Tax</Label><Input type="number" step="0.01" value={form.tax_amount} onChange={(e) => setForm({ ...form, tax_amount: e.target.value })} /></div>
+              <div><Label>Shipping</Label><Input type="number" step="0.01" value={form.shipping_amount} onChange={(e) => setForm({ ...form, shipping_amount: e.target.value })} /></div>
+            </div>
+            <div><Label>Notes</Label><Textarea rows={2} value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} /></div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Create'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={Boolean(emailing)} onOpenChange={(o) => !o && setEmailing(null)}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Email invoice {emailing?.invoice_number}</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>To (override)</Label><Input value={emailTo} onChange={(e) => setEmailTo(e.target.value)} placeholder="leave blank to use customer email" /></div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEmailing(null)}>Cancel</Button>
+            <Button onClick={sendEmail} disabled={emailSending}>{emailSending ? 'Sending…' : 'Send'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/LocationsPage.tsx
+++ b/frontend/src/pages/accounting/LocationsPage.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, MapPin, Truck, Boxes, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface Location { id: string; code: string; name: string; kind: string | null; active: boolean }
+interface Transfer { id: string; from_location_id: string; to_location_id: string; status: string; created_at: string }
+interface Kit { id: string; kit_product_id: string; component_count: number }
+
+function LocationsTab() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<Location[]>({ queryKey: ['locations'], queryFn: () => api.get('/inventory/locations').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ code: '', name: '', kind: 'warehouse' });
+  const save = async () => {
+    try {
+      await api.post('/inventory/locations', form);
+      toast.success('Created');
+      qc.invalidateQueries({ queryKey: ['locations'] });
+      setOpen(false); setForm({ code: '', name: '', kind: 'warehouse' });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const remove = async (id: string) => {
+    try { await api.delete(`/inventory/locations/${id}`); qc.invalidateQueries({ queryKey: ['locations'] }); toast.success('Removed'); }
+    catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const cols: Column<Location>[] = [
+    { key: 'c', header: 'Code', cell: (r) => <span className="font-mono">{r.code}</span> },
+    { key: 'n', header: 'Name', cell: (r) => <span className="font-medium">{r.name}</span> },
+    { key: 'k', header: 'Kind', cell: (r) => r.kind || '—' },
+    { key: 'a', header: 'Active', cell: (r) => (r.active ? 'yes' : 'no') },
+    { key: 'x', header: '', width: '60px', cell: (r) => <Button size="icon" variant="ghost" onClick={() => remove(r.id)}><Trash2 className="h-4 w-4" /></Button> },
+  ];
+  return (
+    <div className="space-y-3">
+      <Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New location</Button>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>New location</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Code</Label><Input value={form.code} onChange={(e) => setForm({ ...form, code: e.target.value })} /></div>
+            <div><Label>Name</Label><Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} /></div>
+            <div>
+              <Label>Kind</Label>
+              <select className="mt-1 block w-full rounded-md border bg-background px-2 py-2 text-sm" value={form.kind} onChange={(e) => setForm({ ...form, kind: e.target.value })}>
+                <option value="warehouse">warehouse</option><option value="shop">shop</option><option value="staging">staging</option>
+              </select>
+            </div>
+          </div>
+          <DialogFooter><Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button><Button onClick={save}>Create</Button></DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function TransfersTab() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<Transfer[]>({ queryKey: ['inv-transfers'], queryFn: () => api.get('/inventory/transfers').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ from_location_id: '', to_location_id: '', notes: '' });
+  const save = async () => {
+    try {
+      await api.post('/inventory/transfers', { ...form, lines: [] });
+      toast.success('Transfer created');
+      qc.invalidateQueries({ queryKey: ['inv-transfers'] });
+      setOpen(false);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const action = async (id: string, verb: string) => {
+    try { await api.post(`/inventory/transfers/${id}/${verb}`); qc.invalidateQueries({ queryKey: ['inv-transfers'] }); toast.success(verb); }
+    catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const cols: Column<Transfer>[] = [
+    { key: 'f', header: 'From', cell: (r) => r.from_location_id.slice(0, 8) },
+    { key: 't', header: 'To', cell: (r) => r.to_location_id.slice(0, 8) },
+    { key: 'd', header: 'Created', cell: (r) => new Date(r.created_at).toLocaleString() },
+    { key: 's', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+    { key: 'a', header: '', width: '180px', cell: (r) => (
+      <div className="flex justify-end gap-1">
+        {r.status === 'pending' && <Button size="sm" variant="outline" onClick={() => action(r.id, 'ship')}>Ship</Button>}
+        {r.status === 'in_transit' && <Button size="sm" variant="outline" onClick={() => action(r.id, 'receive')}>Receive</Button>}
+        {r.status !== 'received' && r.status !== 'cancelled' && <Button size="sm" variant="ghost" onClick={() => action(r.id, 'cancel')}>Cancel</Button>}
+      </div>
+    ) },
+  ];
+  return (
+    <div className="space-y-3">
+      <Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New transfer</Button>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>New transfer</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>From location ID</Label><Input value={form.from_location_id} onChange={(e) => setForm({ ...form, from_location_id: e.target.value })} /></div>
+              <div><Label>To location ID</Label><Input value={form.to_location_id} onChange={(e) => setForm({ ...form, to_location_id: e.target.value })} /></div>
+            </div>
+            <div><Label>Notes</Label><Input value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} /></div>
+          </div>
+          <DialogFooter><Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button><Button onClick={save}>Create</Button></DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function KitsTab() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<Kit[]>({ queryKey: ['kits'], queryFn: () => api.get('/kits').then((r) => Array.isArray(r.data) ? r.data : r.data.items ?? []) });
+  const [editing, setEditing] = useState<string | null>(null);
+  const [components, setComponents] = useState<{ component_product_id: string; quantity: string }[]>([]);
+  const [productId, setProductId] = useState('');
+
+  const openEditor = async (kp: string) => {
+    setEditing(kp); setProductId(kp);
+    try {
+      const r = await api.get(`/kits/${kp}`);
+      setComponents((r.data.components ?? []).map((c: any) => ({ component_product_id: c.component_product_id, quantity: String(c.quantity) })));
+    } catch { setComponents([]); }
+  };
+
+  const openNew = () => { setEditing('new'); setProductId(''); setComponents([{ component_product_id: '', quantity: '1' }]); };
+
+  const save = async () => {
+    if (!productId) return toast.error('Kit product ID required');
+    try {
+      await api.put(`/kits/${productId}`, { components: components.map((c) => ({ component_product_id: c.component_product_id, quantity: Number(c.quantity) })) });
+      toast.success('Saved');
+      qc.invalidateQueries({ queryKey: ['kits'] });
+      setEditing(null);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+
+  const cols: Column<Kit>[] = [
+    { key: 'p', header: 'Kit product', cell: (r) => r.kit_product_id.slice(0, 12) },
+    { key: 'c', header: 'Components', numeric: true, cell: (r) => r.component_count },
+    { key: 'a', header: '', width: '100px', cell: (r) => <Button size="sm" variant="outline" onClick={() => openEditor(r.kit_product_id)}>Edit</Button> },
+  ];
+  return (
+    <div className="space-y-3">
+      <Button onClick={openNew}><Plus className="mr-2 h-4 w-4" />Define kit</Button>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.kit_product_id} loading={isLoading} />
+      <Dialog open={editing !== null} onOpenChange={(o) => !o && setEditing(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>{editing === 'new' ? 'Define kit' : 'Edit kit'}</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            {editing === 'new' && <div><Label>Kit product ID</Label><Input value={productId} onChange={(e) => setProductId(e.target.value)} /></div>}
+            <div className="space-y-2">
+              <Label>Components</Label>
+              {components.map((c, i) => (
+                <div key={i} className="grid grid-cols-12 gap-2">
+                  <Input className="col-span-9" placeholder="Component product ID" value={c.component_product_id} onChange={(e) => setComponents((cs) => cs.map((x, idx) => idx === i ? { ...x, component_product_id: e.target.value } : x))} />
+                  <Input className="col-span-2" type="number" min={1} value={c.quantity} onChange={(e) => setComponents((cs) => cs.map((x, idx) => idx === i ? { ...x, quantity: e.target.value } : x))} />
+                  <Button className="col-span-1" size="sm" variant="ghost" onClick={() => setComponents((cs) => cs.filter((_, idx) => idx !== i))}>×</Button>
+                </div>
+              ))}
+              <Button size="sm" variant="outline" onClick={() => setComponents((cs) => [...cs, { component_product_id: '', quantity: '1' }])}>+ Add component</Button>
+            </div>
+          </div>
+          <DialogFooter><Button variant="outline" onClick={() => setEditing(null)}>Cancel</Button><Button onClick={save}>Save</Button></DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+export default function LocationsPage() {
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Locations · Transfers · Kits" description="Multi-location inventory and product kits" />
+      <Tabs defaultValue="locations">
+        <TabsList>
+          <TabsTrigger value="locations"><MapPin className="mr-2 h-4 w-4" />Locations</TabsTrigger>
+          <TabsTrigger value="transfers"><Truck className="mr-2 h-4 w-4" />Transfers</TabsTrigger>
+          <TabsTrigger value="kits"><Boxes className="mr-2 h-4 w-4" />Kits</TabsTrigger>
+        </TabsList>
+        <TabsContent value="locations" className="mt-4"><LocationsTab /></TabsContent>
+        <TabsContent value="transfers" className="mt-4"><TransfersTab /></TabsContent>
+        <TabsContent value="kits" className="mt-4"><KitsTab /></TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/MasterDataPage.tsx
+++ b/frontend/src/pages/accounting/MasterDataPage.tsx
@@ -1,0 +1,225 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/Tabs';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface Division { id: string; code: string; name: string; active: boolean }
+interface Project { id: string; code: string; name: string; division_id: string | null; active: boolean }
+interface Budget { id: string; account_id: string; year: number; month: number; amount: number }
+interface CFDef { id: string; scope: string; field_name: string; label: string; field_type: string; required: boolean; active: boolean }
+
+function DivisionsTab() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<Division[]>({ queryKey: ['divisions'], queryFn: () => api.get('/divisions').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ code: '', name: '' });
+  const save = async () => {
+    try { await api.post('/divisions', form); toast.success('Created'); qc.invalidateQueries({ queryKey: ['divisions'] }); setOpen(false); setForm({ code: '', name: '' }); }
+    catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const cols: Column<Division>[] = [
+    { key: 'c', header: 'Code', cell: (r) => <span className="font-mono">{r.code}</span> },
+    { key: 'n', header: 'Name', cell: (r) => <span className="font-medium">{r.name}</span> },
+    { key: 'a', header: 'Active', cell: (r) => (r.active ? 'yes' : 'no') },
+  ];
+  return (
+    <div className="space-y-3">
+      <Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New division</Button>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>New division</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Code</Label><Input value={form.code} onChange={(e) => setForm({ ...form, code: e.target.value })} /></div>
+            <div><Label>Name</Label><Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} /></div>
+          </div>
+          <DialogFooter><Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button><Button onClick={save}>Create</Button></DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function ProjectsTab() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<Project[]>({ queryKey: ['projects'], queryFn: () => api.get('/projects').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ code: '', name: '', division_id: '' });
+  const save = async () => {
+    try { await api.post('/projects', { ...form, division_id: form.division_id || null }); toast.success('Created'); qc.invalidateQueries({ queryKey: ['projects'] }); setOpen(false); setForm({ code: '', name: '', division_id: '' }); }
+    catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const cols: Column<Project>[] = [
+    { key: 'c', header: 'Code', cell: (r) => <span className="font-mono">{r.code}</span> },
+    { key: 'n', header: 'Name', cell: (r) => <span className="font-medium">{r.name}</span> },
+    { key: 'd', header: 'Division', cell: (r) => (r.division_id || '—').slice(0, 8) },
+    { key: 'a', header: 'Active', cell: (r) => (r.active ? 'yes' : 'no') },
+  ];
+  return (
+    <div className="space-y-3">
+      <Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New project</Button>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>New project</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Code</Label><Input value={form.code} onChange={(e) => setForm({ ...form, code: e.target.value })} /></div>
+            <div><Label>Name</Label><Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} /></div>
+            <div><Label>Division ID (opt.)</Label><Input value={form.division_id} onChange={(e) => setForm({ ...form, division_id: e.target.value })} /></div>
+          </div>
+          <DialogFooter><Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button><Button onClick={save}>Create</Button></DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function BudgetsTab() {
+  const qc = useQueryClient();
+  const [year, setYear] = useState(new Date().getFullYear());
+  const { data, isLoading } = useQuery<Budget[]>({ queryKey: ['budgets', year], queryFn: () => api.get('/budgets', { params: { year } }).then((r) => r.data) });
+  const [form, setForm] = useState({ account_id: '', year: String(new Date().getFullYear()), month: '1', amount: '0' });
+  const upsert = async () => {
+    try {
+      await api.post('/budgets/upsert', [{ account_id: form.account_id, year: Number(form.year), month: Number(form.month), amount: form.amount }]);
+      toast.success('Saved');
+      qc.invalidateQueries({ queryKey: ['budgets'] });
+      setForm({ ...form, account_id: '', amount: '0' });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const remove = async (id: string) => {
+    try { await api.delete(`/budgets/${id}`); qc.invalidateQueries({ queryKey: ['budgets'] }); toast.success('Removed'); }
+    catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const cols: Column<Budget>[] = [
+    { key: 'a', header: 'Account', cell: (r) => r.account_id.slice(0, 8) },
+    { key: 'y', header: 'Year', numeric: true, cell: (r) => r.year },
+    { key: 'm', header: 'Month', numeric: true, cell: (r) => r.month },
+    { key: 'amt', header: 'Amount', numeric: true, cell: (r) => `$${Number(r.amount).toFixed(2)}` },
+    { key: 'x', header: '', width: '60px', cell: (r) => <Button size="icon" variant="ghost" onClick={() => remove(r.id)}><Trash2 className="h-4 w-4" /></Button> },
+  ];
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end gap-2 rounded-lg border bg-card p-3">
+        <div><Label>Year filter</Label><Input type="number" value={year} onChange={(e) => setYear(Number(e.target.value))} /></div>
+      </div>
+      <div className="flex flex-wrap items-end gap-2 rounded-lg border bg-card p-3">
+        <div><Label>Account ID</Label><Input value={form.account_id} onChange={(e) => setForm({ ...form, account_id: e.target.value })} /></div>
+        <div><Label>Year</Label><Input type="number" value={form.year} onChange={(e) => setForm({ ...form, year: e.target.value })} /></div>
+        <div><Label>Month</Label><Input type="number" min={1} max={12} value={form.month} onChange={(e) => setForm({ ...form, month: e.target.value })} /></div>
+        <div><Label>Amount</Label><Input type="number" step="0.01" value={form.amount} onChange={(e) => setForm({ ...form, amount: e.target.value })} /></div>
+        <Button onClick={upsert}>Upsert</Button>
+      </div>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+    </div>
+  );
+}
+
+function CustomFieldsTab() {
+  const qc = useQueryClient();
+  const [scope, setScope] = useState('customer');
+  const { data, isLoading } = useQuery<CFDef[]>({ queryKey: ['cf-defs', scope], queryFn: () => api.get(`/custom-fields/${scope}`).then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ scope: 'customer', field_name: '', label: '', field_type: 'text', required: false });
+  const save = async () => {
+    try { await api.post('/custom-fields', form); toast.success('Created'); qc.invalidateQueries({ queryKey: ['cf-defs'] }); setOpen(false); }
+    catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  const cols: Column<CFDef>[] = [
+    { key: 'f', header: 'Field name', cell: (r) => <span className="font-mono">{r.field_name}</span> },
+    { key: 'l', header: 'Label', cell: (r) => r.label },
+    { key: 't', header: 'Type', cell: (r) => r.field_type },
+    { key: 'r', header: 'Required', cell: (r) => (r.required ? 'yes' : 'no') },
+    { key: 'a', header: 'Active', cell: (r) => (r.active ? 'yes' : 'no') },
+  ];
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end gap-2">
+        <div>
+          <Label>Scope</Label>
+          <select className="mt-1 block rounded-md border bg-background px-2 py-2 text-sm" value={scope} onChange={(e) => setScope(e.target.value)}>
+            {['customer','vendor','product','material','supply','invoice','quote','sale','bill'].map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </div>
+        <Button onClick={() => { setForm({ ...form, scope }); setOpen(true); }}><Plus className="mr-2 h-4 w-4" />New field</Button>
+      </div>
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>New custom field</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Field name</Label><Input value={form.field_name} onChange={(e) => setForm({ ...form, field_name: e.target.value })} /></div>
+            <div><Label>Label</Label><Input value={form.label} onChange={(e) => setForm({ ...form, label: e.target.value })} /></div>
+            <div>
+              <Label>Type</Label>
+              <select className="mt-1 block w-full rounded-md border bg-background px-2 py-2 text-sm" value={form.field_type} onChange={(e) => setForm({ ...form, field_type: e.target.value })}>
+                <option value="text">text</option><option value="number">number</option><option value="date">date</option><option value="boolean">boolean</option><option value="select">select</option>
+              </select>
+            </div>
+            <div className="flex items-center gap-2"><input id="req" type="checkbox" checked={form.required} onChange={(e) => setForm({ ...form, required: e.target.checked })} /><Label htmlFor="req">Required</Label></div>
+          </div>
+          <DialogFooter><Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button><Button onClick={save}>Create</Button></DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function BatchOpsTab() {
+  const [scope, setScope] = useState('customer');
+  const [ids, setIds] = useState('');
+  const run = async (verb: 'deactivate' | 'activate' | 'delete') => {
+    try {
+      const arr = ids.split(',').map((s) => s.trim()).filter(Boolean);
+      const res = await api.post(`/batch/${scope}/${verb}`, { ids: arr });
+      toast.success(`Processed: ${res.data?.processed ?? arr.length}`);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+  return (
+    <div className="space-y-3 rounded-lg border bg-card p-4">
+      <div>
+        <Label>Scope</Label>
+        <select className="mt-1 block rounded-md border bg-background px-2 py-2 text-sm" value={scope} onChange={(e) => setScope(e.target.value)}>
+          {['customer','vendor','product','material','supply'].map(s => <option key={s} value={s}>{s}</option>)}
+        </select>
+      </div>
+      <div><Label>IDs (comma-separated)</Label><Input value={ids} onChange={(e) => setIds(e.target.value)} /></div>
+      <div className="flex gap-2">
+        <Button variant="outline" onClick={() => run('deactivate')}>Deactivate</Button>
+        <Button variant="outline" onClick={() => run('activate')}>Activate</Button>
+        <Button variant="destructive" onClick={() => run('delete')}>Delete</Button>
+      </div>
+    </div>
+  );
+}
+
+export default function MasterDataPage() {
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Master data" description="Divisions, projects, budgets, custom fields, batch operations" />
+      <Tabs defaultValue="divisions">
+        <TabsList>
+          <TabsTrigger value="divisions">Divisions</TabsTrigger>
+          <TabsTrigger value="projects">Projects</TabsTrigger>
+          <TabsTrigger value="budgets">Budgets</TabsTrigger>
+          <TabsTrigger value="custom-fields">Custom fields</TabsTrigger>
+          <TabsTrigger value="batch">Batch ops</TabsTrigger>
+        </TabsList>
+        <TabsContent value="divisions" className="mt-4"><DivisionsTab /></TabsContent>
+        <TabsContent value="projects" className="mt-4"><ProjectsTab /></TabsContent>
+        <TabsContent value="budgets" className="mt-4"><BudgetsTab /></TabsContent>
+        <TabsContent value="custom-fields" className="mt-4"><CustomFieldsTab /></TabsContent>
+        <TabsContent value="batch" className="mt-4"><BatchOpsTab /></TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/ProductionOrdersPage.tsx
+++ b/frontend/src/pages/accounting/ProductionOrdersPage.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, CheckCircle2, X } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface PO {
+  id: string;
+  order_number: string;
+  product_id: string;
+  product_name: string | null;
+  planned_quantity: number;
+  status: string;
+  planned_on: string;
+  closed_on: string | null;
+}
+
+const empty = { product_id: '', planned_quantity: '1', planned_on: new Date().toISOString().slice(0, 10) };
+
+export default function ProductionOrdersPage() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<PO[]>({ queryKey: ['production-orders'], queryFn: () => api.get('/production-orders').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(empty);
+  const [saving, setSaving] = useState(false);
+
+  const save = async () => {
+    if (!form.product_id) return toast.error('Product ID required');
+    setSaving(true);
+    try {
+      await api.post('/production-orders', { ...form, planned_quantity: Number(form.planned_quantity) });
+      toast.success('Created');
+      qc.invalidateQueries({ queryKey: ['production-orders'] });
+      setOpen(false); setForm(empty);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+    finally { setSaving(false); }
+  };
+
+  const action = async (id: string, verb: string) => {
+    try {
+      await api.post(`/production-orders/${id}/${verb}`);
+      toast.success(verb);
+      qc.invalidateQueries({ queryKey: ['production-orders'] });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+
+  const cols: Column<PO>[] = [
+    { key: 'n', header: 'Order #', cell: (r) => <span className="font-medium">{r.order_number}</span> },
+    { key: 'p', header: 'Product', cell: (r) => r.product_name || r.product_id },
+    { key: 'q', header: 'Qty', numeric: true, cell: (r) => r.planned_quantity },
+    { key: 'd', header: 'Planned', cell: (r) => r.planned_on },
+    { key: 'c', header: 'Closed', cell: (r) => r.closed_on || '—' },
+    { key: 's', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+    { key: 'a', header: '', width: '160px', cell: (r) => (
+      <div className="flex justify-end gap-1">
+        {r.status === 'planned' && <Button size="sm" variant="outline" onClick={() => action(r.id, 'close')}><CheckCircle2 className="mr-1 h-3.5 w-3.5" />Close</Button>}
+        {r.status === 'planned' && <Button size="sm" variant="ghost" onClick={() => action(r.id, 'cancel')}><X className="h-3.5 w-3.5" /></Button>}
+      </div>
+    ) },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Production orders" description="Plan production runs; closing FIFO-consumes materials and creates a finished-goods layer." actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New order</Button>} />
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>New production order</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Product ID</Label><Input value={form.product_id} onChange={(e) => setForm({ ...form, product_id: e.target.value })} /></div>
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Quantity</Label><Input type="number" min={1} value={form.planned_quantity} onChange={(e) => setForm({ ...form, planned_quantity: e.target.value })} /></div>
+              <div><Label>Planned on</Label><Input type="date" value={form.planned_on} onChange={(e) => setForm({ ...form, planned_on: e.target.value })} /></div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Create'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/accounting/PurchaseOrdersPage.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Plus, FileText, CheckCircle2, X } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { useListQuery } from '@/hooks/useListQuery';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface PO {
+  id: string;
+  order_number: string;
+  vendor_id: string | null;
+  vendor_name: string | null;
+  issue_date: string;
+  total_amount: number;
+  status: string;
+}
+
+interface LineDraft { description: string; quantity: string; unit_price: string }
+
+const empty = { vendor_name: '', issue_date: new Date().toISOString().slice(0, 10), lines: [{ description: '', quantity: '1', unit_price: '0' }] as LineDraft[] };
+
+export default function PurchaseOrdersPage() {
+  const qc = useQueryClient();
+  const list = useListQuery<PO>({ resource: 'purchase-orders' });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(empty);
+  const [saving, setSaving] = useState(false);
+
+  const setLine = (i: number, p: Partial<LineDraft>) => setForm((f) => ({ ...f, lines: f.lines.map((l, idx) => (idx === i ? { ...l, ...p } : l)) }));
+
+  const save = async () => {
+    if (!form.vendor_name) return toast.error('Vendor required');
+    setSaving(true);
+    try {
+      await api.post('/purchase-orders', form);
+      toast.success('Purchase order created');
+      qc.invalidateQueries({ queryKey: ['purchase-orders'] });
+      setOpen(false); setForm(empty);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+    finally { setSaving(false); }
+  };
+
+  const action = async (id: string, verb: string) => {
+    try {
+      await api.post(`/purchase-orders/${id}/${verb}`);
+      toast.success(verb);
+      qc.invalidateQueries({ queryKey: ['purchase-orders'] });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Action failed')); }
+  };
+
+  const cols: Column<PO>[] = [
+    { key: 'n', header: 'Order #', cell: (r) => <span className="font-medium">{r.order_number}</span> },
+    { key: 'v', header: 'Vendor', cell: (r) => r.vendor_name || '—' },
+    { key: 'd', header: 'Issued', cell: (r) => r.issue_date },
+    { key: 't', header: 'Total', numeric: true, cell: (r) => `$${Number(r.total_amount).toFixed(2)}` },
+    { key: 's', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+    { key: 'a', header: '', width: '160px', cell: (r) => (
+      <div className="flex justify-end gap-1">
+        {r.status === 'draft' && <Button size="sm" variant="outline" onClick={() => action(r.id, 'confirm')}><CheckCircle2 className="h-3.5 w-3.5" /></Button>}
+        {r.status === 'confirmed' && <Button size="sm" variant="outline" onClick={() => action(r.id, 'create-bill')}><FileText className="mr-1 h-3.5 w-3.5" />Bill</Button>}
+        {r.status !== 'fulfilled' && r.status !== 'cancelled' && <Button size="sm" variant="ghost" onClick={() => action(r.id, 'cancel')}><X className="h-3.5 w-3.5" /></Button>}
+      </div>
+    ) },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Purchase orders" description="Vendor commitments. Convert to bill when received." actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New PO</Button>} />
+      <DataTable data={list.data} columns={cols} rowKey={(r) => r.id} loading={list.isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>New purchase order</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Vendor name</Label><Input value={form.vendor_name} onChange={(e) => setForm({ ...form, vendor_name: e.target.value })} /></div>
+            <div><Label>Issue date</Label><Input type="date" value={form.issue_date} onChange={(e) => setForm({ ...form, issue_date: e.target.value })} /></div>
+            <div className="space-y-2">
+              <Label>Lines</Label>
+              {form.lines.map((line, i) => (
+                <div key={i} className="grid grid-cols-12 gap-2">
+                  <Input className="col-span-7" placeholder="Description" value={line.description} onChange={(e) => setLine(i, { description: e.target.value })} />
+                  <Input className="col-span-2" value={line.quantity} onChange={(e) => setLine(i, { quantity: e.target.value })} />
+                  <Input className="col-span-3" type="number" step="0.01" value={line.unit_price} onChange={(e) => setLine(i, { unit_price: e.target.value })} />
+                </div>
+              ))}
+              <Button size="sm" variant="outline" onClick={() => setForm((f) => ({ ...f, lines: [...f.lines, { description: '', quantity: '1', unit_price: '0' }] }))}>+ Add line</Button>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Create'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/QuotesPage.tsx
+++ b/frontend/src/pages/accounting/QuotesPage.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Plus, Mail } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Textarea } from '@/components/ui/Textarea';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { useListQuery } from '@/hooks/useListQuery';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface Quote {
+  id: string;
+  quote_number: string;
+  customer_name: string | null;
+  issue_date: string;
+  expiry_date: string | null;
+  total: number;
+  status: string;
+}
+
+interface LineDraft { description: string; quantity: number; unit_price: string }
+
+const empty = { customer_name: '', issue_date: new Date().toISOString().slice(0, 10), expiry_date: '', notes: '', lines: [{ description: '', quantity: 1, unit_price: '0' }] as LineDraft[] };
+
+export default function QuotesPage() {
+  const qc = useQueryClient();
+  const list = useListQuery<Quote>({ resource: 'quotes' });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(empty);
+  const [saving, setSaving] = useState(false);
+  const [emailing, setEmailing] = useState<Quote | null>(null);
+  const [emailTo, setEmailTo] = useState('');
+
+  const setLine = (i: number, p: Partial<LineDraft>) => setForm((f) => ({ ...f, lines: f.lines.map((l, idx) => (idx === i ? { ...l, ...p } : l)) }));
+
+  const save = async () => {
+    if (!form.customer_name) return toast.error('Customer required');
+    setSaving(true);
+    try {
+      await api.post('/quotes', { ...form, expiry_date: form.expiry_date || null, notes: form.notes || null });
+      toast.success('Quote created');
+      qc.invalidateQueries({ queryKey: ['quotes'] });
+      setOpen(false); setForm(empty);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+    finally { setSaving(false); }
+  };
+
+  const sendEmail = async () => {
+    if (!emailing) return;
+    try {
+      await api.post(`/quotes/${emailing.id}/send-email`, { to_email: emailTo || null });
+      toast.success('Email queued');
+      setEmailing(null); setEmailTo('');
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Email failed')); }
+  };
+
+  const columns: Column<Quote>[] = [
+    { key: 'n', header: 'Quote #', cell: (r) => <span className="font-medium">{r.quote_number}</span> },
+    { key: 'c', header: 'Customer', cell: (r) => r.customer_name || '—' },
+    { key: 'd', header: 'Issued', cell: (r) => r.issue_date },
+    { key: 'e', header: 'Expires', cell: (r) => r.expiry_date || '—' },
+    { key: 't', header: 'Total', numeric: true, cell: (r) => `$${Number(r.total).toFixed(2)}` },
+    { key: 's', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+    { key: 'a', header: '', width: '80px', cell: (r) => <Button size="icon" variant="ghost" onClick={() => setEmailing(r)}><Mail className="h-4 w-4" /></Button> },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Quotes" description="Customer quotes with email send" actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New quote</Button>} />
+      <DataTable data={list.data} columns={columns} rowKey={(r) => r.id} loading={list.isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>New quote</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Customer name</Label><Input value={form.customer_name} onChange={(e) => setForm({ ...form, customer_name: e.target.value })} /></div>
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Issue</Label><Input type="date" value={form.issue_date} onChange={(e) => setForm({ ...form, issue_date: e.target.value })} /></div>
+              <div><Label>Expires</Label><Input type="date" value={form.expiry_date} onChange={(e) => setForm({ ...form, expiry_date: e.target.value })} /></div>
+            </div>
+            <div className="space-y-2">
+              <Label>Lines</Label>
+              {form.lines.map((line, i) => (
+                <div key={i} className="grid grid-cols-12 gap-2">
+                  <Input className="col-span-7" placeholder="Description" value={line.description} onChange={(e) => setLine(i, { description: e.target.value })} />
+                  <Input className="col-span-2" type="number" min={1} value={line.quantity} onChange={(e) => setLine(i, { quantity: Number(e.target.value) })} />
+                  <Input className="col-span-3" type="number" step="0.01" value={line.unit_price} onChange={(e) => setLine(i, { unit_price: e.target.value })} />
+                </div>
+              ))}
+              <Button size="sm" variant="outline" onClick={() => setForm((f) => ({ ...f, lines: [...f.lines, { description: '', quantity: 1, unit_price: '0' }] }))}>+ Add line</Button>
+            </div>
+            <div><Label>Notes</Label><Textarea rows={2} value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} /></div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Create'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={Boolean(emailing)} onOpenChange={(o) => !o && setEmailing(null)}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Email quote {emailing?.quote_number}</DialogTitle></DialogHeader>
+          <div><Label>To (override)</Label><Input value={emailTo} onChange={(e) => setEmailTo(e.target.value)} /></div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEmailing(null)}>Cancel</Button>
+            <Button onClick={sendEmail}>Send</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/RecurringInvoicesPage.tsx
+++ b/frontend/src/pages/accounting/RecurringInvoicesPage.tsx
@@ -1,0 +1,151 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, Play, SkipForward, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface RI {
+  id: string;
+  name: string;
+  customer_id: string;
+  cadence: string;
+  interval_count: number;
+  next_run_on: string;
+  auto_email: boolean;
+  active: boolean;
+  last_error: string | null;
+}
+
+interface LineDraft { description: string; quantity: string; unit_price: string }
+const empty = {
+  name: '',
+  customer_id: '',
+  cadence: 'monthly',
+  interval_count: '1',
+  start_on: new Date().toISOString().slice(0, 10),
+  due_in_days: '30',
+  auto_email: false,
+  lines: [{ description: '', quantity: '1', unit_price: '0' }] as LineDraft[],
+};
+
+export default function RecurringInvoicesPage() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<RI[]>({ queryKey: ['recurring-invoices'], queryFn: () => api.get('/recurring-invoices').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(empty);
+  const [saving, setSaving] = useState(false);
+
+  const setLine = (i: number, p: Partial<LineDraft>) => setForm((f) => ({ ...f, lines: f.lines.map((l, idx) => (idx === i ? { ...l, ...p } : l)) }));
+
+  const save = async () => {
+    if (!form.name || !form.customer_id) return toast.error('Name + customer required');
+    setSaving(true);
+    try {
+      await api.post('/recurring-invoices', {
+        name: form.name,
+        customer_id: form.customer_id,
+        cadence: form.cadence,
+        interval_count: Number(form.interval_count),
+        start_on: form.start_on,
+        next_run_on: form.start_on,
+        due_in_days: Number(form.due_in_days),
+        auto_email: form.auto_email,
+        line_items_template: form.lines,
+      });
+      toast.success('Created');
+      qc.invalidateQueries({ queryKey: ['recurring-invoices'] });
+      setOpen(false); setForm(empty);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+    finally { setSaving(false); }
+  };
+
+  const action = async (id: string, verb: string) => {
+    try {
+      await api.post(`/recurring-invoices/${id}/${verb}`);
+      toast.success(verb);
+      qc.invalidateQueries({ queryKey: ['recurring-invoices'] });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+
+  const remove = async (id: string) => {
+    try {
+      await api.delete(`/recurring-invoices/${id}`);
+      toast.success('Removed');
+      qc.invalidateQueries({ queryKey: ['recurring-invoices'] });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+  };
+
+  const cols: Column<RI>[] = [
+    { key: 'n', header: 'Name', cell: (r) => <span className="font-medium">{r.name}</span> },
+    { key: 'c', header: 'Cadence', cell: (r) => `every ${r.interval_count} ${r.cadence}` },
+    { key: 'next', header: 'Next run', cell: (r) => r.next_run_on },
+    { key: 'e', header: 'Auto-email', cell: (r) => (r.auto_email ? 'yes' : 'no') },
+    { key: 'a', header: 'Active', cell: (r) => (r.active ? 'yes' : 'no') },
+    { key: 'err', header: 'Last error', cell: (r) => r.last_error || '—' },
+    { key: 'x', header: '', width: '180px', cell: (r) => (
+      <div className="flex justify-end gap-1">
+        <Button size="icon" variant="ghost" onClick={() => action(r.id, 'run-now')} aria-label="Run now"><Play className="h-4 w-4" /></Button>
+        <Button size="icon" variant="ghost" onClick={() => action(r.id, 'skip-next')} aria-label="Skip next"><SkipForward className="h-4 w-4" /></Button>
+        <Button size="icon" variant="ghost" onClick={() => remove(r.id)} aria-label="Delete"><Trash2 className="h-4 w-4" /></Button>
+      </div>
+    ) },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Recurring invoices" description="Auto-generate invoices on a schedule, optionally email" actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New rule</Button>} />
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>New recurring invoice</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Name</Label><Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} /></div>
+              <div><Label>Customer ID</Label><Input value={form.customer_id} onChange={(e) => setForm({ ...form, customer_id: e.target.value })} /></div>
+            </div>
+            <div className="grid grid-cols-3 gap-3">
+              <div>
+                <Label>Cadence</Label>
+                <select className="mt-1 block w-full rounded-md border bg-background px-2 py-2 text-sm" value={form.cadence} onChange={(e) => setForm({ ...form, cadence: e.target.value })}>
+                  <option value="weekly">weekly</option>
+                  <option value="monthly">monthly</option>
+                  <option value="quarterly">quarterly</option>
+                  <option value="yearly">yearly</option>
+                </select>
+              </div>
+              <div><Label>Every</Label><Input type="number" min={1} value={form.interval_count} onChange={(e) => setForm({ ...form, interval_count: e.target.value })} /></div>
+              <div><Label>Start on</Label><Input type="date" value={form.start_on} onChange={(e) => setForm({ ...form, start_on: e.target.value })} /></div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Due in (days)</Label><Input type="number" value={form.due_in_days} onChange={(e) => setForm({ ...form, due_in_days: e.target.value })} /></div>
+              <div className="flex items-end gap-2"><input type="checkbox" id="auto" checked={form.auto_email} onChange={(e) => setForm({ ...form, auto_email: e.target.checked })} /><Label htmlFor="auto">Auto-email</Label></div>
+            </div>
+            <div className="space-y-2">
+              <Label>Lines</Label>
+              {form.lines.map((line, i) => (
+                <div key={i} className="grid grid-cols-12 gap-2">
+                  <Input className="col-span-7" placeholder="Description" value={line.description} onChange={(e) => setLine(i, { description: e.target.value })} />
+                  <Input className="col-span-2" value={line.quantity} onChange={(e) => setLine(i, { quantity: e.target.value })} />
+                  <Input className="col-span-3" type="number" step="0.01" value={line.unit_price} onChange={(e) => setLine(i, { unit_price: e.target.value })} />
+                </div>
+              ))}
+              <Button size="sm" variant="outline" onClick={() => setForm((f) => ({ ...f, lines: [...f.lines, { description: '', quantity: '1', unit_price: '0' }] }))}>+ Add line</Button>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Create'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/SalesOrdersPage.tsx
+++ b/frontend/src/pages/accounting/SalesOrdersPage.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Plus, FileText, CheckCircle2, X } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { useListQuery } from '@/hooks/useListQuery';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface SO {
+  id: string;
+  order_number: string;
+  customer_id: string | null;
+  customer_name: string | null;
+  issue_date: string;
+  total_amount: number;
+  status: string;
+}
+
+interface LineDraft { description: string; quantity: string; unit_price: string }
+
+const empty = { customer_name: '', issue_date: new Date().toISOString().slice(0, 10), lines: [{ description: '', quantity: '1', unit_price: '0' }] as LineDraft[] };
+
+export default function SalesOrdersPage() {
+  const qc = useQueryClient();
+  const list = useListQuery<SO>({ resource: 'sales-orders' });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(empty);
+  const [saving, setSaving] = useState(false);
+
+  const setLine = (i: number, p: Partial<LineDraft>) => setForm((f) => ({ ...f, lines: f.lines.map((l, idx) => (idx === i ? { ...l, ...p } : l)) }));
+
+  const save = async () => {
+    if (!form.customer_name) return toast.error('Customer required');
+    setSaving(true);
+    try {
+      await api.post('/sales-orders', form);
+      toast.success('Sales order created');
+      qc.invalidateQueries({ queryKey: ['sales-orders'] });
+      setOpen(false); setForm(empty);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+    finally { setSaving(false); }
+  };
+
+  const action = async (id: string, verb: string) => {
+    try {
+      await api.post(`/sales-orders/${id}/${verb}`);
+      toast.success(verb);
+      qc.invalidateQueries({ queryKey: ['sales-orders'] });
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Action failed')); }
+  };
+
+  const cols: Column<SO>[] = [
+    { key: 'n', header: 'Order #', cell: (r) => <span className="font-medium">{r.order_number}</span> },
+    { key: 'c', header: 'Customer', cell: (r) => r.customer_name || '—' },
+    { key: 'd', header: 'Issued', cell: (r) => r.issue_date },
+    { key: 't', header: 'Total', numeric: true, cell: (r) => `$${Number(r.total_amount).toFixed(2)}` },
+    { key: 's', header: 'Status', cell: (r) => <span className="capitalize">{r.status}</span> },
+    { key: 'a', header: '', width: '160px', cell: (r) => (
+      <div className="flex justify-end gap-1">
+        {r.status === 'draft' && <Button size="sm" variant="outline" onClick={() => action(r.id, 'confirm')}><CheckCircle2 className="h-3.5 w-3.5" /></Button>}
+        {r.status === 'confirmed' && <Button size="sm" variant="outline" onClick={() => action(r.id, 'create-invoice')}><FileText className="mr-1 h-3.5 w-3.5" />Invoice</Button>}
+        {r.status !== 'fulfilled' && r.status !== 'cancelled' && <Button size="sm" variant="ghost" onClick={() => action(r.id, 'cancel')}><X className="h-3.5 w-3.5" /></Button>}
+      </div>
+    ) },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Sales orders" description="Customer commitments. Convert to invoice when ready." actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New SO</Button>} />
+      <DataTable data={list.data} columns={cols} rowKey={(r) => r.id} loading={list.isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>New sales order</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div><Label>Customer name</Label><Input value={form.customer_name} onChange={(e) => setForm({ ...form, customer_name: e.target.value })} /></div>
+            <div><Label>Issue date</Label><Input type="date" value={form.issue_date} onChange={(e) => setForm({ ...form, issue_date: e.target.value })} /></div>
+            <div className="space-y-2">
+              <Label>Lines</Label>
+              {form.lines.map((line, i) => (
+                <div key={i} className="grid grid-cols-12 gap-2">
+                  <Input className="col-span-7" placeholder="Description" value={line.description} onChange={(e) => setLine(i, { description: e.target.value })} />
+                  <Input className="col-span-2" value={line.quantity} onChange={(e) => setLine(i, { quantity: e.target.value })} />
+                  <Input className="col-span-3" type="number" step="0.01" value={line.unit_price} onChange={(e) => setLine(i, { unit_price: e.target.value })} />
+                </div>
+              ))}
+              <Button size="sm" variant="outline" onClick={() => setForm((f) => ({ ...f, lines: [...f.lines, { description: '', quantity: '1', unit_price: '0' }] }))}>+ Add line</Button>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Create'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/accounting/TaxProfilesPage.tsx
+++ b/frontend/src/pages/accounting/TaxProfilesPage.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/api/client';
+import PageHeader from '@/components/layout/PageHeader';
+import DataTable, { type Column } from '@/components/data/DataTable';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { getApiErrorMessage } from '@/lib/apiError';
+
+interface Component { id?: string; name: string; rate: string; apply_order: number }
+interface TaxProfile {
+  id: string;
+  name: string;
+  jurisdiction: string;
+  tax_rate: number;
+  is_compound: boolean;
+  is_reverse_charge: boolean;
+  components?: Component[];
+}
+
+const empty = { name: '', jurisdiction: '', tax_rate: '0', is_compound: false, is_reverse_charge: false, components: [] as Component[] };
+
+export default function TaxProfilesPage() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery<TaxProfile[]>({ queryKey: ['tax-profiles'], queryFn: () => api.get('/tax/profiles').then((r) => r.data) });
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(empty);
+  const [saving, setSaving] = useState(false);
+
+  const setComponent = (i: number, p: Partial<Component>) => setForm((f) => ({ ...f, components: f.components.map((c, idx) => idx === i ? { ...c, ...p } : c) }));
+
+  const save = async () => {
+    if (!form.name) return toast.error('Name required');
+    setSaving(true);
+    try {
+      await api.post('/tax/profiles', {
+        name: form.name,
+        jurisdiction: form.jurisdiction,
+        tax_rate: form.tax_rate,
+        is_compound: form.is_compound,
+        is_reverse_charge: form.is_reverse_charge,
+        components: form.components.map((c) => ({ name: c.name, rate: c.rate, apply_order: c.apply_order })),
+      });
+      toast.success('Created');
+      qc.invalidateQueries({ queryKey: ['tax-profiles'] });
+      setOpen(false); setForm(empty);
+    } catch (err) { toast.error(getApiErrorMessage(err, 'Failed')); }
+    finally { setSaving(false); }
+  };
+
+  const cols: Column<TaxProfile>[] = [
+    { key: 'n', header: 'Name', cell: (r) => <span className="font-medium">{r.name}</span> },
+    { key: 'j', header: 'Jurisdiction', cell: (r) => r.jurisdiction },
+    { key: 'r', header: 'Rate', numeric: true, cell: (r) => `${Number(r.tax_rate).toFixed(3)}%` },
+    { key: 'c', header: 'Compound', cell: (r) => (r.is_compound ? 'yes' : 'no') },
+    { key: 'rc', header: 'Reverse-charge', cell: (r) => (r.is_reverse_charge ? 'yes' : 'no') },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageHeader title="Tax profiles" description="Single-rate, compound (e.g. GST+QST), and reverse-charge profiles" actions={<Button onClick={() => setOpen(true)}><Plus className="mr-2 h-4 w-4" />New profile</Button>} />
+      <DataTable data={data ?? []} columns={cols} rowKey={(r) => r.id} loading={isLoading} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>New tax profile</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div><Label>Name</Label><Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} /></div>
+              <div><Label>Jurisdiction</Label><Input value={form.jurisdiction} onChange={(e) => setForm({ ...form, jurisdiction: e.target.value })} /></div>
+            </div>
+            <div className="grid grid-cols-3 gap-3">
+              <div><Label>Top-level rate %</Label><Input type="number" step="0.001" value={form.tax_rate} onChange={(e) => setForm({ ...form, tax_rate: e.target.value })} /></div>
+              <div className="flex items-end gap-2"><input id="comp" type="checkbox" checked={form.is_compound} onChange={(e) => setForm({ ...form, is_compound: e.target.checked })} /><Label htmlFor="comp">Compound</Label></div>
+              <div className="flex items-end gap-2"><input id="rc" type="checkbox" checked={form.is_reverse_charge} onChange={(e) => setForm({ ...form, is_reverse_charge: e.target.checked })} /><Label htmlFor="rc">Reverse-charge</Label></div>
+            </div>
+            {form.is_compound && (
+              <div className="space-y-2">
+                <Label>Components (e.g. GST 5%, QST 9.975%)</Label>
+                {form.components.map((c, i) => (
+                  <div key={i} className="grid grid-cols-12 gap-2">
+                    <Input className="col-span-5" placeholder="Component name" value={c.name} onChange={(e) => setComponent(i, { name: e.target.value })} />
+                    <Input className="col-span-3" type="number" step="0.001" placeholder="Rate %" value={c.rate} onChange={(e) => setComponent(i, { rate: e.target.value })} />
+                    <Input className="col-span-3" type="number" placeholder="Apply order" value={c.apply_order} onChange={(e) => setComponent(i, { apply_order: Number(e.target.value) })} />
+                    <Button className="col-span-1" size="sm" variant="ghost" onClick={() => setForm((f) => ({ ...f, components: f.components.filter((_, idx) => idx !== i) }))}><Trash2 className="h-4 w-4" /></Button>
+                  </div>
+                ))}
+                <Button size="sm" variant="outline" onClick={() => setForm((f) => ({ ...f, components: [...f.components, { name: '', rate: '0', apply_order: f.components.length }] }))}>+ Add component</Button>
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Create'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New \`/accounting\` workspace with sidebar nav covering all 16 frontend Phase 1 backlog issues.
- Each module: list view + create/edit dialog wired to existing backend APIs.
- Adds reusable \`AttachmentsPanel\` (#312) and \`useListQuery\` hook (#313).

## Modules
| Issue | Module |
|---|---|
| #298 | Invoices + Quotes (email-send modal) |
| #299 | Banking (accounts · reconciliations · imports · rules · transfers) |
| #300 | Fixed assets + Intangibles registers |
| #301 | Production orders |
| #302 | Credit notes + Debit notes |
| #303 | Sales orders + Purchase orders (convert) |
| #304 | Delivery notes (DLV-) |
| #305 | Recurring invoices |
| #306 | Expense claims |
| #307 | Locations · Transfers · Kits |
| #308 | Trial balance · Receipts/Payments · AR/AP aging |
| #309 | Divisions · Projects · Budgets · Custom fields · Batch ops |
| #310 | Tax profiles (compound + reverse-charge) |
| #311 | Recurring JEs · Suspense · Starting balances |
| #312 | AttachmentsPanel component |
| #313 | useListQuery hook |

## Scope notes
These are **Phase 1** surfaces — minimum-viable but functional. Each shows the data, lets the operator create/transition records, and exposes the actions that backend already supports. Detail pages, sortable tables, and per-module filters are intentionally deferred — let real usage drive what gets richer first.

## Test plan
- [x] \`cd frontend && npm run build\` passes
- [ ] Smoke-test each module against a populated dev DB
- [ ] Verify nav entry "Accounting" surfaces in top nav after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)