### PR TITLE
fix(nav): wire Accounting workspace into top nav

### DIFF
--- a/frontend/src/components/layout/appNav.ts
+++ b/frontend/src/components/layout/appNav.ts
@@ -10,7 +10,6 @@ import {
   ShoppingCart,
   Users,
   ClipboardList,
-  BookOpenCheck,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -32,7 +31,6 @@ export const appNavLinks: AppNavLink[] = [
   { to: '/pos', label: 'POS', icon: Receipt },
   { to: '/sales', label: 'Sales', icon: ShoppingCart },
   { to: '/customers', label: 'Customers', icon: Users },
-  { to: '/accounting', label: 'Accounting', icon: BookOpenCheck },
   { to: '/reports', label: 'Reports', icon: BarChart3 },
   { to: '/calculator', label: 'Calculator', icon: Calculator },
 ];

--- a/frontend/src/components/layout/workspaces.ts
+++ b/frontend/src/components/layout/workspaces.ts
@@ -1,6 +1,7 @@
 import {
   BarChart3,
   Blocks,
+  BookOpenCheck,
   ClipboardList,
   Gauge,
   type LucideIcon,
@@ -117,6 +118,22 @@ export const workspaces: WorkspaceDefinition[] = [
       { to: '/orders', label: 'Queue', matchPrefixes: ['/orders'] },
       { to: '/orders/jobs', label: 'Jobs', matchPrefixes: ['/orders/jobs', '/jobs'] },
       { to: '/orders/customers', label: 'Customers', matchPrefixes: ['/orders/customers', '/customers'] },
+    ],
+  },
+  {
+    key: 'accounting',
+    label: 'Accounting',
+    description: 'Invoices, banking, reports, and the rest of the finance suite.',
+    to: '/accounting',
+    icon: BookOpenCheck,
+    roles: ['admin', 'analyst', 'general'],
+    matchPrefixes: ['/accounting'],
+    localLinks: [
+      { to: '/accounting', label: 'Overview', matchPrefixes: ['/accounting'] },
+      { to: '/accounting/invoices', label: 'Invoices', matchPrefixes: ['/accounting/invoices'] },
+      { to: '/accounting/quotes', label: 'Quotes', matchPrefixes: ['/accounting/quotes'] },
+      { to: '/accounting/banking', label: 'Banking', matchPrefixes: ['/accounting/banking'] },
+      { to: '/accounting/reports', label: 'Reports', matchPrefixes: ['/accounting/reports'] },
     ],
   },
   {


### PR DESCRIPTION
Original PR put the entry in the unused appNav.ts. This adds it to workspaces.ts where the real top nav reads from.