### PR TITLE
fix: #269 P1 register ORM models before create_all (Codex review)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+import app.models  # noqa: F401 — register all ORM models with Base.metadata before create_all
 from app.api.v1.router import api_router
 from app.core.config import settings
 from app.core.database import engine, Base

--- a/backend/tests/test_p1_269_reference_sequence_registration.py
+++ b/backend/tests/test_p1_269_reference_sequence_registration.py
@@ -1,0 +1,29 @@
+"""#269 P1: ensure ReferenceSequence is registered with Base.metadata at startup.
+
+Regression: `next_number` is imported lazily inside request-time functions, so
+unless `app.models` (or `ReferenceSequence` directly) is imported during
+application startup, the `reference_sequences` table is missing from
+`Base.metadata` and the lifespan `Base.metadata.create_all` (with
+`AUTO_CREATE_SCHEMA=True`) creates a fresh DB without it. The first
+sale/invoice/quote auto-number allocation then fails with a missing-table
+error.
+
+The fix: `app.main` imports `app.models` explicitly so the registration is
+deterministic and not dependent on transitive imports through the router.
+"""
+
+from __future__ import annotations
+
+
+def test_app_main_registers_reference_sequences_table() -> None:
+    import app.main  # noqa: F401
+    from app.core.database import Base
+
+    assert "reference_sequences" in Base.metadata.tables
+
+
+def test_app_models_package_registers_reference_sequences_table() -> None:
+    import app.models  # noqa: F401
+    from app.core.database import Base
+
+    assert "reference_sequences" in Base.metadata.tables


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on PR #269.

`next_number` was imported lazily inside request-time functions, so `ReferenceSequence` registration depended on transitive imports through the router. With `AUTO_CREATE_SCHEMA=True`, a fresh DB could be created without `reference_sequences`, causing the first sale/invoice/quote auto-number allocation to fail at runtime.

## Fix

- `app/main.py` now imports `app.models` explicitly before `Base.metadata.create_all`, making model registration deterministic.

## Test plan
- [x] New regression tests verify both `app.main` import and `app.models` package import register `reference_sequences` in `Base.metadata.tables`
- [x] `pytest backend/tests/test_p1_269_reference_sequence_registration.py` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)