### PR TITLE
fix: #271 P1 recon line date bound + cross-recon reuse (Codex review)

### DIFF
--- a/backend/app/services/bank_reconciliation_service.py
+++ b/backend/app/services/bank_reconciliation_service.py
@@ -157,13 +157,30 @@ async def include_line(
 ) -> BankReconciliationLine:
     recon = await _get_in_progress_recon(db, reconciliation_id)
 
-    line = (await db.execute(select(JournalLine).where(JournalLine.id == journal_line_id))).scalar_one_or_none()
-    if line is None:
+    line_row = (
+        await db.execute(
+            select(JournalLine, JournalEntry)
+            .join(JournalEntry, JournalEntry.id == JournalLine.journal_entry_id)
+            .where(JournalLine.id == journal_line_id)
+        )
+    ).first()
+    if line_row is None:
         raise BankReconciliationError(f"Journal line {journal_line_id} not found")
+    line, entry = line_row
     if line.account_id != recon.account_id:
         raise BankReconciliationError("Journal line account does not match reconciliation account")
     if line.cleared_status == CLEARED_STATUS_RECONCILED:
         raise BankReconciliationError("Journal line is already reconciled in another recon")
+    # #271 P1: enforce statement-end-date bound — `/toggle-line` accepts an
+    # arbitrary journal_line_id, so without this guard a client could fold a
+    # future-dated transaction into an older statement reconciliation and
+    # still finalize if totals happened to balance. Mirror the predicate
+    # used in `list_eligible_lines`.
+    if entry.entry_date > recon.statement_end_date:
+        raise BankReconciliationError(
+            f"Journal line entry date {entry.entry_date} is after statement end date "
+            f"{recon.statement_end_date}; cannot include in this reconciliation"
+        )
 
     existing = (
         await db.execute(
@@ -175,6 +192,30 @@ async def include_line(
     ).scalar_one_or_none()
     if existing:
         return existing
+
+    # #271 P1: cross-reconciliation guard — a journal line must not be linked
+    # to more than one active (non-finalized) reconciliation at a time, or
+    # overlapping drafts/reopens would double-count the same transaction and
+    # could leave one line represented in multiple finalized reconciliations.
+    other_active = (
+        await db.execute(
+            select(BankReconciliationLine.reconciliation_id)
+            .join(
+                BankReconciliation,
+                BankReconciliation.id == BankReconciliationLine.reconciliation_id,
+            )
+            .where(
+                BankReconciliationLine.journal_line_id == journal_line_id,
+                BankReconciliationLine.reconciliation_id != reconciliation_id,
+                BankReconciliation.status == STATUS_IN_PROGRESS,
+            )
+        )
+    ).first()
+    if other_active is not None:
+        raise BankReconciliationError(
+            f"Journal line {journal_line_id} is already linked to another "
+            f"active reconciliation ({other_active[0]})"
+        )
 
     rline = BankReconciliationLine(
         reconciliation_id=reconciliation_id,

--- a/backend/tests/test_p1_271_recon_bounds_and_reuse.py
+++ b/backend/tests/test_p1_271_recon_bounds_and_reuse.py
@@ -1,0 +1,125 @@
+"""Regression tests for #271 P1 (Codex review on PR #271).
+
+Two bugs in `include_line`:
+
+1. The function never validated the journal line's `entry_date` against the
+   reconciliation's `statement_end_date`, so a client could include a
+   future-dated transaction in an older statement reconciliation.
+2. The duplicate check only scoped to the current reconciliation, so a line
+   could be linked into multiple active (in_progress) reconciliations
+   simultaneously, double-counting the same transaction.
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+
+from app.models.account import Account
+from app.models.journal_entry import JournalEntry
+from app.models.journal_line import JournalLine
+from app.services.bank_reconciliation_service import (
+    BankReconciliationError,
+    include_line,
+    start_reconciliation,
+)
+
+
+async def _make_bank_account(db_session, code="1010"):
+    a = Account(
+        code=code,
+        name="Operating Checking",
+        account_type="asset",
+        normal_balance="debit",
+        is_active=True,
+        is_bank_account=True,
+        bank_account_kind="checking",
+    )
+    db_session.add(a)
+    await db_session.flush()
+    return a
+
+
+async def _post_je(db_session, account, *, entry_date, debit=None, credit=None, n=1):
+    e = JournalEntry(
+        entry_number=f"JE-{n}",
+        entry_date=entry_date,
+        status="posted",
+    )
+    db_session.add(e)
+    await db_session.flush()
+    line = JournalLine(
+        journal_entry_id=e.id,
+        account_id=account.id,
+        line_number=1,
+        entry_type="debit" if debit is not None else "credit",
+        amount=Decimal(debit if debit is not None else credit),
+    )
+    db_session.add(line)
+    await db_session.flush()
+    return e, line
+
+
+@pytest.mark.asyncio
+async def test_include_line_rejects_entry_after_statement_end_date(db_session):
+    """A journal line dated AFTER the statement_end_date must not be
+    includable, even though `/toggle-line` accepts an arbitrary
+    journal_line_id."""
+    a = await _make_bank_account(db_session)
+    # Reconciliation through Jan 31
+    recon = await start_reconciliation(
+        db_session,
+        account_id=a.id,
+        statement_end_date=datetime.date(2026, 1, 31),
+        statement_ending_balance=Decimal("0"),
+    )
+    # Journal line dated Feb 5 — outside the statement window
+    _, future_line = await _post_je(
+        db_session, a, entry_date=datetime.date(2026, 2, 5), debit=100, n=1
+    )
+
+    with pytest.raises(BankReconciliationError) as excinfo:
+        await include_line(
+            db_session,
+            reconciliation_id=recon.id,
+            journal_line_id=future_line.id,
+        )
+    assert "statement end date" in str(excinfo.value).lower() or "after" in str(excinfo.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_include_line_blocks_reuse_across_active_recons(db_session):
+    """A journal line already linked to one in-progress reconciliation must
+    not be includable into a second active reconciliation; otherwise the
+    same transaction can be double-counted."""
+    a = await _make_bank_account(db_session, code="1011")
+    _, line = await _post_je(
+        db_session, a, entry_date=datetime.date(2026, 1, 10), debit=100, n=1
+    )
+
+    r1 = await start_reconciliation(
+        db_session,
+        account_id=a.id,
+        statement_end_date=datetime.date(2026, 1, 31),
+        statement_ending_balance=Decimal("100"),
+    )
+    await include_line(db_session, reconciliation_id=r1.id, journal_line_id=line.id)
+
+    # Operator opens a second, overlapping in-progress reconciliation that
+    # also covers this date range.
+    r2 = await start_reconciliation(
+        db_session,
+        account_id=a.id,
+        statement_end_date=datetime.date(2026, 2, 28),
+        statement_ending_balance=Decimal("100"),
+    )
+
+    with pytest.raises(BankReconciliationError) as excinfo:
+        await include_line(
+            db_session,
+            reconciliation_id=r2.id,
+            journal_line_id=line.id,
+        )
+    assert "another" in str(excinfo.value).lower() or "active" in str(excinfo.value).lower()


### PR DESCRIPTION
## Summary

Addresses two Codex P1 review comments on PR #271 in `backend/app/services/bank_reconciliation_service.py::include_line`.

1. `include_line` validated account/status but never enforced
   `entry.entry_date <= recon.statement_end_date`. Because `/toggle-line`
   accepts an arbitrary `journal_line_id`, a client could fold a
   future-dated transaction into an older statement reconciliation and
   still finalize it if totals happened to balance.
2. The duplicate check only scoped to the current `reconciliation_id`, so
   the same `journal_line_id` could be linked into multiple
   in-progress reconciliations at the same time. That permitted
   overlapping drafts/reopens to double-count the transaction and could
   leave one line represented in multiple finalized reconciliations.

## Fix

- `include_line` now joins `JournalEntry` and rejects lines whose
  `entry_date` is after `recon.statement_end_date`, mirroring the
  predicate in `list_eligible_lines`.
- Added a cross-reconciliation guard query that rejects inclusion when
  the journal line is already linked to any other reconciliation in
  status `in_progress`. Implemented as a service-level guard (consistent
  with the existing `exclude_line` cross-recon check) rather than a DB
  unique index, since the constraint is conditional on
  `bank_reconciliations.status` and that's awkward to express portably
  across SQLite (test) and Postgres (prod) without a partial index that
  references another table.

## Test plan

- [x] New regression suite `backend/tests/test_p1_271_recon_bounds_and_reuse.py` covers:
  - Including a journal line whose `entry_date` is after the
    `statement_end_date` raises `BankReconciliationError`.
  - Including a journal line that's already linked to another active
    reconciliation raises `BankReconciliationError`.
- [x] `pytest backend/tests/test_p1_271_recon_bounds_and_reuse.py` passes locally.
- [x] Existing `pytest backend/tests/test_bank_reconciliation_service.py` still passes (9/9), so no regression in the lifecycle suite.

Generated with [Claude Code](https://claude.com/claude-code)