### PR TITLE
fix: #274 P1 inventory transfer invalid location → client error (Codex review)

### DIFF
--- a/backend/app/api/v1/endpoints/locations.py
+++ b/backend/app/api/v1/endpoints/locations.py
@@ -180,6 +180,25 @@ async def list_transfers(user: CurrentUser, db: DB, status_filter: str | None = 
 
 @router.post("/transfers", response_model=TransferResponse, status_code=status.HTTP_201_CREATED, summary="Create a transfer")
 async def create_transfer_ep(body: TransferCreate, user: CurrentUser, db: DB):
+    # #274 P1 (Codex): pre-validate location FKs so a missing from_/to_location_id
+    # surfaces as a 404 instead of a Postgres IntegrityError -> 500 on commit.
+    requested_ids = {body.from_location_id, body.to_location_id}
+    found_ids = set(
+        (
+            await db.execute(
+                select(InventoryLocation.id).where(InventoryLocation.id.in_(requested_ids))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    missing = requested_ids - found_ids
+    if missing:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Location(s) not found: {', '.join(str(i) for i in sorted(missing, key=str))}",
+        )
+
     try:
         transfer = await create_transfer(
             db,

--- a/backend/tests/test_p1_274_transfer_invalid_location.py
+++ b/backend/tests/test_p1_274_transfer_invalid_location.py
@@ -1,0 +1,139 @@
+"""#274 P1 (Codex review): creating a transfer with a non-existent
+from_location_id / to_location_id must return a client error (404),
+not surface as an uncaught Postgres IntegrityError -> 500.
+
+The endpoint pre-validates the location IDs so the failure mode is
+the same regardless of DB-level FK enforcement (SQLite tests do not
+enforce FKs by default, but the bug surfaces in production on
+Postgres).
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+
+from app.models.inventory_location import InventoryLocation
+from app.models.material import Material
+
+
+async def _location(db_session, name: str) -> InventoryLocation:
+    loc = InventoryLocation(name=name)
+    db_session.add(loc)
+    await db_session.flush()
+    return loc
+
+
+async def _material(db_session) -> Material:
+    m = Material(
+        name="PLA",
+        brand="Generic",
+        spool_weight_g=1000,
+        spool_price=Decimal("20"),
+        net_usable_g=950,
+        cost_per_g=Decimal("0.02"),
+    )
+    db_session.add(m)
+    await db_session.flush()
+    return m
+
+
+@pytest.mark.asyncio
+async def test_create_transfer_unknown_from_location_returns_404(
+    client: AsyncClient, auth_headers, db_session
+):
+    to_loc = await _location(db_session, "Showroom")
+    mat = await _material(db_session)
+    await db_session.commit()
+
+    bogus = str(uuid.uuid4())
+    r = await client.post(
+        "/api/v1/inventory/transfers",
+        headers=auth_headers,
+        json={
+            "from_location_id": bogus,
+            "to_location_id": str(to_loc.id),
+            "lines": [
+                {"kind": "material", "material_id": str(mat.id), "quantity": "1"}
+            ],
+        },
+    )
+    assert r.status_code == 404, r.text
+    assert "not found" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_create_transfer_unknown_to_location_returns_404(
+    client: AsyncClient, auth_headers, db_session
+):
+    from_loc = await _location(db_session, "Workshop")
+    mat = await _material(db_session)
+    await db_session.commit()
+
+    bogus = str(uuid.uuid4())
+    r = await client.post(
+        "/api/v1/inventory/transfers",
+        headers=auth_headers,
+        json={
+            "from_location_id": str(from_loc.id),
+            "to_location_id": bogus,
+            "lines": [
+                {"kind": "material", "material_id": str(mat.id), "quantity": "1"}
+            ],
+        },
+    )
+    assert r.status_code == 404, r.text
+    assert "not found" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_create_transfer_both_locations_unknown_returns_404(
+    client: AsyncClient, auth_headers, db_session
+):
+    mat = await _material(db_session)
+    await db_session.commit()
+
+    bogus_a = str(uuid.uuid4())
+    bogus_b = str(uuid.uuid4())
+    r = await client.post(
+        "/api/v1/inventory/transfers",
+        headers=auth_headers,
+        json={
+            "from_location_id": bogus_a,
+            "to_location_id": bogus_b,
+            "lines": [
+                {"kind": "material", "material_id": str(mat.id), "quantity": "1"}
+            ],
+        },
+    )
+    assert r.status_code == 404, r.text
+
+
+@pytest.mark.asyncio
+async def test_create_transfer_valid_locations_still_succeeds(
+    client: AsyncClient, auth_headers, db_session
+):
+    """Sanity check: pre-validation does not break the happy path."""
+    from_loc = await _location(db_session, "Workshop")
+    to_loc = await _location(db_session, "Showroom")
+    mat = await _material(db_session)
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/inventory/transfers",
+        headers=auth_headers,
+        json={
+            "from_location_id": str(from_loc.id),
+            "to_location_id": str(to_loc.id),
+            "lines": [
+                {"kind": "material", "material_id": str(mat.id), "quantity": "2"}
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["from_location_id"] == str(from_loc.id)
+    assert body["to_location_id"] == str(to_loc.id)


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on closed PR #274.

Creating a transfer via `POST /api/v1/inventory/transfers` with a non-existent `from_location_id` and/or `to_location_id` previously hit a foreign-key violation inside `create_transfer`. The endpoint only caught `InventoryTransferError`, so on Postgres this surfaced as an uncaught `sqlalchemy.exc.IntegrityError` and returned a 500 instead of a 4xx client error — malformed IDs could crash the request path.

## Fix

- `backend/app/api/v1/endpoints/locations.py`: pre-validate the requested location ids in a single `SELECT id ... WHERE id IN (...)` and raise `HTTPException(404, "Location(s) not found: ...")` if any are missing. Cheap (one round trip, two ids), explicit, and DB-agnostic — works the same regardless of whether the underlying engine enforces FKs.
- Existing service-layer validation errors (`from == to`, empty lines, bad kind, non-positive qty) still return 400 via the existing `InventoryTransferError` handler.

## Test plan

- [x] `backend/tests/test_p1_274_transfer_invalid_location.py` covers:
  - unknown `from_location_id` → 404
  - unknown `to_location_id` → 404
  - both unknown → 404
  - happy path (both valid) still 201
- [x] `pytest tests/test_p1_274_transfer_invalid_location.py -x -q` → 4 passed
- [x] `pytest tests/test_p2_318_multilocation.py tests/test_inventory_transfer_service.py -x -q` → 13 passed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)