### PR TITLE
fix: #275 P1 inter-account transfer per-leg posted dates (Codex review)

### DIFF
--- a/backend/app/services/bank_reconciliation_service.py
+++ b/backend/app/services/bank_reconciliation_service.py
@@ -25,7 +25,7 @@ import uuid
 from datetime import date, datetime, timezone
 from decimal import Decimal
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
@@ -72,6 +72,15 @@ def _signed_amount(line: JournalLine, account: Account) -> Decimal:
     return Decimal(line.amount) * (-sign)
 
 
+def _effective_date(line: JournalLine, entry: JournalEntry) -> date:
+    """Per-leg posted date. Inter-account transfers (#246) carry independent
+    `posted_on` per JournalLine so each leg reconciles against the
+    appropriate statement (Codex P1 #275). Falls back to the parent JE's
+    `entry_date` when the line has no per-leg date.
+    """
+    return line.posted_on if line.posted_on is not None else entry.entry_date
+
+
 async def compute_account_balance(
     db: AsyncSession,
     account_id: uuid.UUID,
@@ -92,7 +101,7 @@ async def compute_account_balance(
 
     total = Decimal("0")
     for line, entry in rows:
-        if through_date is not None and entry.entry_date > through_date:
+        if through_date is not None and _effective_date(line, entry) > through_date:
             continue
         if only_cleared and line.cleared_status not in (CLEARED_STATUS_CLEARED, CLEARED_STATUS_RECONCILED):
             continue
@@ -135,16 +144,23 @@ async def list_eligible_lines(
 ) -> list[tuple[JournalLine, JournalEntry]]:
     """Return (line, entry) pairs for lines posting to this account on or
     before statement_end_date and not yet reconciled.
+
+    Filters by the per-leg effective date — `JournalLine.posted_on` when
+    set (used by inter-account transfers #246 to carry paid_on/received_on
+    independently), otherwise the parent JE's `entry_date`. This keeps the
+    receiving leg of a delayed-receipt transfer invisible until its own
+    `received_on` (Codex P1 #275).
     """
+    effective = func.coalesce(JournalLine.posted_on, JournalEntry.entry_date)
     stmt = (
         select(JournalLine, JournalEntry)
         .join(JournalEntry, JournalEntry.id == JournalLine.journal_entry_id)
         .where(
             JournalLine.account_id == account_id,
             JournalLine.cleared_status != CLEARED_STATUS_RECONCILED,
-            JournalEntry.entry_date <= statement_end_date,
+            effective <= statement_end_date,
         )
-        .order_by(JournalEntry.entry_date, JournalLine.line_number)
+        .order_by(effective, JournalLine.line_number)
     )
     return list((await db.execute(stmt)).all())
 

--- a/backend/tests/test_p1_275_transfer_per_leg_dates.py
+++ b/backend/tests/test_p1_275_transfer_per_leg_dates.py
@@ -1,0 +1,166 @@
+"""Codex P1 review on PR #275: inter-account transfer legs must reconcile by
+their own posted dates.
+
+Before the fix, `list_eligible_lines` and `compute_account_balance` filtered
+by `JournalEntry.entry_date` (set to `min(paid_on, received_on)`), so the
+receiving leg of a delayed-receipt transfer became visible on the source
+account's earlier statement date — letting it reconcile against the wrong
+statement. The fix uses each line's `posted_on` (falling back to
+`entry_date`) as the effective per-leg date.
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.journal_line import JournalLine
+from app.services.bank_reconciliation_service import (
+    compute_account_balance,
+    list_eligible_lines,
+)
+from app.services.inter_account_transfer_service import (
+    create_inter_account_transfer,
+)
+
+
+async def _bank(db_session, code, name):
+    a = Account(
+        code=code,
+        name=name,
+        account_type="asset",
+        normal_balance="debit",
+        is_bank_account=True,
+        bank_account_kind="checking",
+    )
+    db_session.add(a)
+    await db_session.flush()
+    return a
+
+
+@pytest.mark.asyncio
+async def test_each_leg_dated_by_its_own_posted_on(db_session):
+    """Source line carries paid_on; destination line carries received_on."""
+    src = await _bank(db_session, "1010", "Operating")
+    dst = await _bank(db_session, "1011", "Savings")
+
+    paid_on = datetime.date(2026, 5, 1)
+    received_on = datetime.date(2026, 5, 3)
+
+    await create_inter_account_transfer(
+        db_session,
+        from_account_id=src.id,
+        to_account_id=dst.id,
+        amount=Decimal("500"),
+        paid_on=paid_on,
+        received_on=received_on,
+    )
+
+    src_line = (
+        await db_session.execute(
+            select(JournalLine).where(JournalLine.account_id == src.id)
+        )
+    ).scalar_one()
+    dst_line = (
+        await db_session.execute(
+            select(JournalLine).where(JournalLine.account_id == dst.id)
+        )
+    ).scalar_one()
+
+    assert src_line.posted_on == paid_on
+    assert dst_line.posted_on == received_on
+
+
+@pytest.mark.asyncio
+async def test_destination_leg_not_eligible_before_received_on(db_session):
+    """A May-1 statement on the destination account must NOT see a May-3
+    receiving leg, even though the JE's entry_date is May 1.
+    """
+    src = await _bank(db_session, "1010", "Operating")
+    dst = await _bank(db_session, "1011", "Savings")
+
+    paid_on = datetime.date(2026, 5, 1)
+    received_on = datetime.date(2026, 5, 3)
+
+    await create_inter_account_transfer(
+        db_session,
+        from_account_id=src.id,
+        to_account_id=dst.id,
+        amount=Decimal("500"),
+        paid_on=paid_on,
+        received_on=received_on,
+    )
+
+    # On May 1 (the statement-end-date), the destination account should
+    # have NO eligible lines: the receiving leg is dated May 3.
+    eligible_dst_may1 = await list_eligible_lines(
+        db_session,
+        account_id=dst.id,
+        statement_end_date=paid_on,
+    )
+    assert eligible_dst_may1 == []
+
+    # On May 1, the source account *should* see its outgoing leg.
+    eligible_src_may1 = await list_eligible_lines(
+        db_session,
+        account_id=src.id,
+        statement_end_date=paid_on,
+    )
+    assert len(eligible_src_may1) == 1
+    line, _entry = eligible_src_may1[0]
+    assert line.account_id == src.id
+    assert line.posted_on == paid_on
+
+    # On May 3, the destination leg is now eligible.
+    eligible_dst_may3 = await list_eligible_lines(
+        db_session,
+        account_id=dst.id,
+        statement_end_date=received_on,
+    )
+    assert len(eligible_dst_may3) == 1
+    line, _entry = eligible_dst_may3[0]
+    assert line.account_id == dst.id
+    assert line.posted_on == received_on
+
+
+@pytest.mark.asyncio
+async def test_through_date_balance_uses_per_leg_date(db_session):
+    """Opening balance computed through_date=May-1 on the destination
+    account must NOT include the May-3 receiving leg.
+    """
+    src = await _bank(db_session, "1010", "Operating")
+    dst = await _bank(db_session, "1011", "Savings")
+
+    paid_on = datetime.date(2026, 5, 1)
+    received_on = datetime.date(2026, 5, 3)
+
+    await create_inter_account_transfer(
+        db_session,
+        from_account_id=src.id,
+        to_account_id=dst.id,
+        amount=Decimal("500"),
+        paid_on=paid_on,
+        received_on=received_on,
+    )
+
+    # Through May 1: destination has zero (receipt is in the future).
+    bal_dst_may1 = await compute_account_balance(
+        db_session, dst.id, through_date=paid_on
+    )
+    assert bal_dst_may1 == Decimal("0")
+
+    # Through May 3: destination shows +500.
+    bal_dst_may3 = await compute_account_balance(
+        db_session, dst.id, through_date=received_on
+    )
+    assert bal_dst_may3 == Decimal("500")
+
+    # Through May 1: source already shows -500 (paid out on May 1).
+    bal_src_may1 = await compute_account_balance(
+        db_session, src.id, through_date=paid_on
+    )
+    assert bal_src_may1 == Decimal("-500")


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on closed PR #275.

`InterAccountTransfer` legs each carry their own `posted_on` on the underlying `JournalLine` (paid_on for the source leg, received_on for the destination leg), but the parent `JournalEntry.entry_date` was set to `min(paid_on, received_on)`. `bank_reconciliation_service.compute_account_balance` and `list_eligible_lines` filtered by `JournalEntry.entry_date`, which meant a delayed-receipt transfer (e.g. paid May 1, received May 3) made the receiving leg visible to a May-1 statement on the destination account — so both legs could reconcile against the same earlier statement.

## Fix

- `compute_account_balance` and `list_eligible_lines` now use the per-leg effective date: `JournalLine.posted_on` when set, otherwise `JournalEntry.entry_date`.
- No schema change — `posted_on` was added by migration `20260509_06_add_inter_account_transfers` (#246) and the IAT service already populates it on each leg.
- Two-JE alternative considered but skipped: would require an `inter_account_transfers` schema migration plus a refactor of edit/delete flows for no observable behavioral gain over the predicate fix, given `posted_on` already exists for this purpose.

## Test plan
- [x] New regression `backend/tests/test_p1_275_transfer_per_leg_dates.py` covers the May-1/May-3 scenario:
  - source line dated paid_on, destination line dated received_on
  - destination account on a May-1 statement sees no eligible lines; on a May-3 statement it sees the receiving leg
  - `compute_account_balance(through_date=May-1)` excludes the future receipt
- [x] `pytest backend/tests/test_p1_275_transfer_per_leg_dates.py -x -q` passes (3/3)
- [x] `pytest backend/tests/ -k "transfer or iat or reconcil" -q` passes (42/42, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)