### PR TITLE
fix: #278 P1 expense claim invalid account → client error (Codex review)

### DIFF
--- a/backend/app/api/v1/endpoints/expense_claims.py
+++ b/backend/app/api/v1/endpoints/expense_claims.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser
+from app.models.account import Account
 from app.models.expense_claim import ExpenseClaim, ExpenseClaimLine
 from app.services.expense_claim_service import (
     ExpenseClaimError,
@@ -121,6 +122,26 @@ async def list_claims(user: CurrentUser, db: DB, status_filter: str | None = Non
 
 @router.post("", response_model=ClaimResponse, status_code=status.HTTP_201_CREATED, summary="Create an expense claim")
 async def create(body: ClaimCreate, user: CurrentUser, db: DB):
+    # #278 P1 (Codex): pre-validate expense_account_id FKs so a missing account
+    # surfaces as a 404 instead of a Postgres IntegrityError -> 500 (which would
+    # also leave the session in a failed state for the rest of the request).
+    requested_account_ids = {l.expense_account_id for l in body.lines}
+    found_account_ids = set(
+        (
+            await db.execute(
+                select(Account.id).where(Account.id.in_(requested_account_ids))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    missing = requested_account_ids - found_account_ids
+    if missing:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Expense account(s) not found: {', '.join(str(i) for i in sorted(missing, key=str))}",
+        )
+
     try:
         claim = await create_claim(
             db,

--- a/backend/tests/test_p1_278_expense_claim_invalid_account.py
+++ b/backend/tests/test_p1_278_expense_claim_invalid_account.py
@@ -1,0 +1,46 @@
+"""#278 P1 (Codex): expense claim with non-existent expense_account_id must
+return a 4xx client error instead of a 500 from a foreign-key violation, and
+must not leave a partial claim row behind.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+
+from app.models.expense_claim import ExpenseClaim
+
+
+@pytest.mark.asyncio
+async def test_create_claim_invalid_expense_account_returns_404(
+    client: AsyncClient, auth_headers, db_session
+):
+    bogus_account_id = uuid.uuid4()
+    r = await client.post(
+        "/api/v1/expense-claims",
+        json={
+            "payer_kind": "owner",
+            "payer_name": "Brent",
+            "lines": [
+                {
+                    "description": "Coffee",
+                    "expense_account_id": str(bogus_account_id),
+                    "amount": "12.50",
+                }
+            ],
+        },
+        headers=auth_headers,
+    )
+    assert r.status_code == 404, r.text
+    detail = r.json()["detail"]
+    assert "Expense account" in detail
+    assert str(bogus_account_id) in detail
+
+    # No claim row should have been created.
+    count = (
+        await db_session.execute(select(func.count()).select_from(ExpenseClaim))
+    ).scalar_one()
+    assert count == 0


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on PR #278.

Creating an expense claim with a non-existent `expense_account_id` hit a foreign-key violation on `flush` inside `create_claim`. The endpoint only caught `ExpenseClaimError`, so on Postgres this surfaced as an uncaught `IntegrityError` → 500 and left the SQLAlchemy session in a failed state for the rest of the request.

## Fix

- Pre-validate every line's `expense_account_id` in a single `SELECT account.id WHERE id IN (...)` before calling the service. Missing IDs return `404` with the unknown id(s) in the detail.
- Service-layer validation (e.g. mileage rate, line amounts) still returns `400` via `ExpenseClaimError` — no behaviour change there.

## Test plan
- [x] New regression test `backend/tests/test_p1_278_expense_claim_invalid_account.py` posts a claim with a random UUID account, asserts `404`, and verifies no `ExpenseClaim` row was created.
- [x] Existing `test_p2_324_mileage.py` and `test_expense_claim_service.py` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)