### PR TITLE
fix: #283 P1 reject empty components for compound tax profiles (Codex review)

### DIFF
--- a/backend/app/services/tax_service.py
+++ b/backend/app/services/tax_service.py
@@ -57,6 +57,15 @@ async def compute_for_line(
                 .order_by(TaxProfileComponent.apply_order)
             )
         ).scalars().all()
+        if not components:
+            # #283 P1: a compound profile with no components must fail fast
+            # rather than silently returning [] — otherwise downstream tax
+            # posting skips tax entirely during partial setup, producing an
+            # under-collection bug.
+            raise ValueError(
+                f"Compound tax profile {profile.id} ({profile.name!r}) "
+                "has no components configured"
+            )
         running = base
         for c in components:
             amt = _q(running * Decimal(c.rate) / Decimal(100))

--- a/backend/tests/test_p1_283_compound_tax_no_components.py
+++ b/backend/tests/test_p1_283_compound_tax_no_components.py
@@ -1,0 +1,63 @@
+"""Regression: Codex P1 on PR #283.
+
+A compound tax profile with no `tax_profile_components` rows must fail
+fast — silently returning `[]` causes downstream tax posting to skip
+tax entirely, producing an under-collection bug during partial setup.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.models.tax_profile import TaxProfile, TaxProfileComponent
+from app.services.tax_service import compute_for_line
+
+
+@pytest.mark.asyncio
+async def test_compound_profile_with_no_components_raises(db_session):
+    p = TaxProfile(
+        name="Compound (no components)",
+        jurisdiction="X",
+        tax_rate=Decimal("0"),
+        is_compound=True,
+    )
+    db_session.add(p)
+    await db_session.flush()
+
+    with pytest.raises(ValueError, match="no components"):
+        await compute_for_line(
+            db_session, profile_id=p.id, subtotal=Decimal("100")
+        )
+
+
+@pytest.mark.asyncio
+async def test_compound_profile_with_components_still_works(db_session):
+    """Positive case: a normally-configured compound profile is unaffected."""
+    p = TaxProfile(
+        name="Compound (with components)",
+        jurisdiction="X",
+        tax_rate=Decimal("0"),
+        is_compound=True,
+    )
+    db_session.add(p)
+    await db_session.flush()
+    db_session.add(
+        TaxProfileComponent(
+            profile_id=p.id, name="A", rate=Decimal("5.000"), apply_order=0
+        )
+    )
+    db_session.add(
+        TaxProfileComponent(
+            profile_id=p.id, name="B", rate=Decimal("9.975"), apply_order=1
+        )
+    )
+    await db_session.flush()
+
+    out = await compute_for_line(
+        db_session, profile_id=p.id, subtotal=Decimal("100")
+    )
+    assert len(out) == 2
+    assert out[0].amount == Decimal("5.00")
+    assert out[1].amount == Decimal("10.47")


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on PR #283.

In `app/services/tax_service.py::compute_for_line`, when `profile.is_compound` is True the function iterates components and returns `out` as-is. If no `tax_profile_components` rows exist yet (e.g., the compound flag was enabled before components were created), the function silently returned `[]` and downstream tax posting skipped tax entirely — an under-collection bug during partial setup.

## Fix

- Compound branch now raises `ValueError` with the offending profile id/name when no components are found, instead of producing a zero-line result. Partial setup surfaces as a clear error rather than missing tax.

## Test plan
- [x] New regression test `backend/tests/test_p1_283_compound_tax_no_components.py`:
  - Compound profile with zero components -> `ValueError` (`match="no components"`)
  - Compound profile with normal components still computes both layers correctly (positive case, 100 -> 5.00 + 10.47)
- [x] Existing tax-service suites still pass (`test_tax_service.py`, `test_p2_329_tax.py`, `test_tax_compute_endpoint.py` -> 12 passed)

Generated with [Claude Code](https://claude.com/claude-code)