### PR TITLE
fix: #281 P1 cache active rules per import pass (Codex review)

### DIFF
--- a/backend/app/services/statement_match_rule_service.py
+++ b/backend/app/services/statement_match_rule_service.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import re
 import uuid
 from decimal import Decimal
+from typing import Sequence
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -51,17 +52,37 @@ def _matches_sign(rule: StatementMatchRule, amount: Decimal) -> bool:
     return False
 
 
-async def evaluate_rules_for_line(
-    db: AsyncSession, line: StatementLine
-) -> StatementMatchRule | None:
-    """Return the highest-priority active rule that matches the line, or None."""
-    rules = (
+async def _load_active_rules(db: AsyncSession) -> Sequence[StatementMatchRule]:
+    """Single ordered SELECT of all active rules (Codex P1 on #281).
+
+    Hoisted out of `evaluate_rules_for_line` so per-import passes can fetch
+    the rule set once and reuse it across every unmatched line, instead of
+    re-running the SELECT for each line (N+1).
+    """
+    return (
         await db.execute(
             select(StatementMatchRule).where(
                 StatementMatchRule.is_active == True,  # noqa: E712
             ).order_by(StatementMatchRule.priority.asc(), StatementMatchRule.created_at.asc())
         )
     ).scalars().all()
+
+
+async def evaluate_rules_for_line(
+    db: AsyncSession,
+    line: StatementLine,
+    rules: Sequence[StatementMatchRule] | None = None,
+) -> StatementMatchRule | None:
+    """Return the highest-priority active rule that matches the line, or None.
+
+    `rules` is an optional pre-fetched ordered list of active rules. When
+    omitted, the function falls back to executing the SELECT itself so
+    standalone single-line callers keep working unchanged. Bulk callers
+    (e.g. `apply_rules_to_import`) should pass a cached list to avoid the
+    N+1 query that the Codex P1 review on #281 flagged.
+    """
+    if rules is None:
+        rules = await _load_active_rules(db)
     for rule in rules:
         if rule.account_id is not None and rule.account_id != line.account_id:
             continue
@@ -98,11 +119,16 @@ async def apply_rules_to_import(
         )
     ).scalars().all()
 
+    # Codex P1 on #281: load active rules once and reuse across every line,
+    # instead of re-running the SELECT inside `evaluate_rules_for_line` per
+    # line (N+1 on large imports).
+    active_rules = await _load_active_rules(db)
+
     auto_ignored = 0
     auto_je = 0
     skipped_unsupported = 0
     for line in lines:
-        rule = await evaluate_rules_for_line(db, line)
+        rule = await evaluate_rules_for_line(db, line, rules=active_rules)
         if rule is None:
             continue
         if rule.action == "ignore":
@@ -183,9 +209,12 @@ async def preview_rules_for_import(
         )
     ).scalars().all()
 
+    # Same N+1 cache as `apply_rules_to_import` (Codex P1 on #281).
+    active_rules = await _load_active_rules(db)
+
     out = []
     for line in lines:
-        rule = await evaluate_rules_for_line(db, line)
+        rule = await evaluate_rules_for_line(db, line, rules=active_rules)
         if rule is None:
             out.append(
                 {

--- a/backend/tests/test_p1_281_rules_cached_per_import.py
+++ b/backend/tests/test_p1_281_rules_cached_per_import.py
@@ -1,0 +1,143 @@
+"""Codex P1 on PR #281: load active rules once per import pass.
+
+Before the fix, `apply_rules_to_import` called `evaluate_rules_for_line`
+for every unmatched line, and that function executed a fresh
+`SELECT StatementMatchRule WHERE is_active` each time — N+1 against the
+rule table on every statement upload / manual re-apply.
+
+The fix hoists the rule fetch into a single `_load_active_rules` call at
+the top of `apply_rules_to_import` (and `preview_rules_for_import`),
+passing the cached list down. This regression test wraps that helper and
+asserts it executes exactly once per pass, regardless of how many
+unmatched lines an import contains.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.account import Account
+from app.models.statement_match_rule import StatementMatchRule
+from app.services import statement_match_rule_service as svc
+from app.services.statement_import_service import import_statement
+
+
+# Three unmatched lines so a regression (per-line SELECT) would surface as
+# 3 calls vs the expected 1.
+SAMPLE_CSV = """Date,Amount,Description,FITID
+2026-05-01,-25.00,Filament supplier,FITID001
+2026-05-02,-12.50,Filament other supplier,FITID002
+2026-05-03,500.00,Etsy payout,FITID003
+"""
+
+
+async def _bank(db_session, code="1010", name="Operating"):
+    a = Account(
+        code=code, name=name, account_type="asset", normal_balance="debit",
+        is_bank_account=True, bank_account_kind="checking",
+    )
+    db_session.add(a)
+    await db_session.flush()
+    return a
+
+
+@pytest.mark.asyncio
+async def test_apply_rules_to_import_loads_rules_once(db_session, monkeypatch):
+    bank = await _bank(db_session)
+    imp = await import_statement(
+        db_session,
+        account_id=bank.id,
+        source_format="csv",
+        source_filename="x.csv",
+        content=SAMPLE_CSV.encode(),
+    )
+    db_session.add(StatementMatchRule(
+        name="Filament rule",
+        account_id=bank.id,
+        match_type="contains",
+        match_pattern="Filament",
+        match_amount_sign="debit",
+        action="ignore",
+    ))
+    await db_session.commit()
+
+    # Sanity: this import has at least 3 unmatched lines, so an N+1 bug
+    # would manifest as >=3 calls instead of 1.
+    from sqlalchemy import select as _sel
+    from app.models.statement_import import StatementLine
+    unmatched = (
+        await db_session.execute(
+            _sel(StatementLine).where(
+                StatementLine.import_id == imp.id,
+                StatementLine.match_status == "unmatched",
+            )
+        )
+    ).scalars().all()
+    assert len(unmatched) >= 3
+
+    calls = {"n": 0}
+    real_loader = svc._load_active_rules
+
+    async def counting_loader(db):
+        calls["n"] += 1
+        return await real_loader(db)
+
+    monkeypatch.setattr(svc, "_load_active_rules", counting_loader)
+
+    summary = await svc.apply_rules_to_import(db_session, import_id=imp.id)
+
+    assert calls["n"] == 1, (
+        f"_load_active_rules ran {calls['n']} times for "
+        f"{summary['considered']} unmatched lines — expected exactly 1 "
+        "(Codex P1 on #281: rules cache per import pass)."
+    )
+    # And the rule still actually fires under the cached path.
+    assert summary["auto_ignored"] == 2
+
+
+@pytest.mark.asyncio
+async def test_evaluate_rules_for_line_standalone_still_self_loads(
+    db_session, monkeypatch
+):
+    """Backward-compat: single-line callers that don't pass `rules=` must
+    still work — the function self-fetches in that case."""
+    bank = await _bank(db_session)
+    imp = await import_statement(
+        db_session,
+        account_id=bank.id,
+        source_format="csv",
+        source_filename="x.csv",
+        content=SAMPLE_CSV.encode(),
+    )
+    db_session.add(StatementMatchRule(
+        name="Filament rule",
+        account_id=bank.id,
+        match_type="contains",
+        match_pattern="Filament",
+        match_amount_sign="debit",
+        action="ignore",
+    ))
+    await db_session.commit()
+
+    from sqlalchemy import select as _sel
+    from app.models.statement_import import StatementLine
+    line = (
+        await db_session.execute(
+            _sel(StatementLine).where(StatementLine.fitid == "FITID001")
+        )
+    ).scalar_one()
+
+    calls = {"n": 0}
+    real_loader = svc._load_active_rules
+
+    async def counting_loader(db):
+        calls["n"] += 1
+        return await real_loader(db)
+
+    monkeypatch.setattr(svc, "_load_active_rules", counting_loader)
+
+    rule = await svc.evaluate_rules_for_line(db_session, line)
+
+    assert rule is not None
+    assert rule.action == "ignore"
+    assert calls["n"] == 1  # self-loaded once for this single-line call


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on PR #281.

`apply_rules_to_import` walks every unmatched statement line and called `evaluate_rules_for_line` for each, which executed a fresh `SELECT StatementMatchRule WHERE is_active` per line. On large statement imports / manual re-applies this is N+1 against the rule table — one rules query per line — and makes uploads dramatically slower in production.

## Fix

- New `_load_active_rules(db)` helper does the single ordered SELECT.
- `apply_rules_to_import` and `preview_rules_for_import` now call it once at the top of the pass and pass the cached list down via a new optional `rules=` parameter on `evaluate_rules_for_line`.
- When `rules=` is omitted, `evaluate_rules_for_line` still self-fetches, so existing single-line callers keep working unchanged.

## Test plan
- [x] New regression test (`tests/test_p1_281_rules_cached_per_import.py`) wraps `_load_active_rules`, runs `apply_rules_to_import` on an import with 3 unmatched lines, asserts the loader fires exactly once (not 3x).
- [x] Second case asserts standalone `evaluate_rules_for_line(db, line)` still self-loads (back-compat).
- [x] `pytest tests/test_p1_281_rules_cached_per_import.py` passes (2/2).
- [x] Existing rule/statement-match suites still green (17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)