### PR TITLE
fix: #285 P1 restrict budget mutations to admin (Codex review)

### DIFF
--- a/backend/app/api/v1/endpoints/budgets.py
+++ b/backend/app/api/v1/endpoints/budgets.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 
-from app.api.deps import DB, CurrentUser
+from app.api.deps import DB, CurrentAdmin, CurrentUser
 from app.models.account import Account
 from app.models.account_budget import AccountBudget
 
@@ -52,7 +52,7 @@ async def list_budgets(user: CurrentUser, db: DB, year: int | None = None, accou
 
 
 @router.post("/upsert", response_model=list[BudgetResponse], status_code=status.HTTP_200_OK, summary="Upsert per (account, year, month)")
-async def upsert_budgets(body: BudgetUpsertRequest, user: CurrentUser, db: DB):
+async def upsert_budgets(body: BudgetUpsertRequest, user: CurrentAdmin, db: DB):
     # Validate all account ids exist + are income/expense (refuses balance-sheet accts)
     account_ids = {r.account_id for r in body.rows}
     accounts = (
@@ -93,7 +93,7 @@ async def upsert_budgets(body: BudgetUpsertRequest, user: CurrentUser, db: DB):
 
 
 @router.delete("/{budget_id}", status_code=204, summary="Delete a budget row")
-async def delete_budget(budget_id: uuid.UUID, user: CurrentUser, db: DB):
+async def delete_budget(budget_id: uuid.UUID, user: CurrentAdmin, db: DB):
     b = (await db.execute(select(AccountBudget).where(AccountBudget.id == budget_id))).scalar_one_or_none()
     if not b:
         raise HTTPException(status_code=404, detail="Budget row not found")
@@ -102,7 +102,7 @@ async def delete_budget(budget_id: uuid.UUID, user: CurrentUser, db: DB):
 
 
 @router.post("/copy-year", response_model=dict, summary="Copy all budgets from one year to another (idempotent — skips existing)")
-async def copy_year(user: CurrentUser, db: DB, from_year: int, to_year: int):
+async def copy_year(user: CurrentAdmin, db: DB, from_year: int, to_year: int):
     if from_year == to_year:
         raise HTTPException(status_code=400, detail="from_year and to_year must differ")
     src = (

--- a/backend/tests/test_p1_285_budgets_admin_only.py
+++ b/backend/tests/test_p1_285_budgets_admin_only.py
@@ -1,0 +1,151 @@
+"""Regression test for Codex P1 review on PR #285.
+
+Budget mutating endpoints must require admin privileges. Non-admin
+authenticated users were previously able to upsert/delete/copy budget
+rows via the financial planning endpoints.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models.account import Account
+
+
+async def _expense_account_id(db_session) -> str:
+    a = (
+        await db_session.execute(select(Account).where(Account.code == "6500"))
+    ).scalar_one()
+    return str(a.id)
+
+
+# ---------------------------------------------------------------------------
+# Non-admin users get 403 on every mutating endpoint.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_upsert_budgets(
+    client: AsyncClient, user_headers, db_session
+):
+    aid = await _expense_account_id(db_session)
+    resp = await client.post(
+        "/api/v1/budgets/upsert",
+        json={
+            "rows": [
+                {"account_id": aid, "year": 2026, "month": 1, "amount": "500"}
+            ]
+        },
+        headers=user_headers,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_delete_budget(
+    client: AsyncClient, auth_headers, user_headers, db_session
+):
+    # Admin seeds a row first so the delete target exists.
+    aid = await _expense_account_id(db_session)
+    create = await client.post(
+        "/api/v1/budgets/upsert",
+        json={
+            "rows": [
+                {"account_id": aid, "year": 2026, "month": 6, "amount": "75"}
+            ]
+        },
+        headers=auth_headers,
+    )
+    assert create.status_code == 200
+    bid = create.json()[0]["id"]
+
+    resp = await client.delete(f"/api/v1/budgets/{bid}", headers=user_headers)
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_copy_year(client: AsyncClient, user_headers):
+    resp = await client.post(
+        "/api/v1/budgets/copy-year?from_year=2026&to_year=2027",
+        headers=user_headers,
+    )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Read endpoints remain accessible to regular users.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_admin_can_list_budgets(client: AsyncClient, user_headers):
+    resp = await client.get("/api/v1/budgets", headers=user_headers)
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+# ---------------------------------------------------------------------------
+# Admins still pass the auth gate for mutations.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_can_upsert_budgets(
+    client: AsyncClient, auth_headers, db_session
+):
+    aid = await _expense_account_id(db_session)
+    resp = await client.post(
+        "/api/v1/budgets/upsert",
+        json={
+            "rows": [
+                {"account_id": aid, "year": 2026, "month": 1, "amount": "500"}
+            ]
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_admin_can_copy_year(
+    client: AsyncClient, auth_headers, db_session
+):
+    aid = await _expense_account_id(db_session)
+    seed = await client.post(
+        "/api/v1/budgets/upsert",
+        json={
+            "rows": [
+                {"account_id": aid, "year": 2026, "month": 1, "amount": "100"}
+            ]
+        },
+        headers=auth_headers,
+    )
+    assert seed.status_code == 200
+    resp = await client.post(
+        "/api/v1/budgets/copy-year?from_year=2026&to_year=2027",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_admin_can_delete_budget(
+    client: AsyncClient, auth_headers, db_session
+):
+    aid = await _expense_account_id(db_session)
+    create = await client.post(
+        "/api/v1/budgets/upsert",
+        json={
+            "rows": [
+                {"account_id": aid, "year": 2026, "month": 6, "amount": "75"}
+            ]
+        },
+        headers=auth_headers,
+    )
+    assert create.status_code == 200
+    bid = create.json()[0]["id"]
+    resp = await client.delete(
+        f"/api/v1/budgets/{bid}", headers=auth_headers
+    )
+    assert resp.status_code == 204


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on closed PR #285.

The new budget mutating handlers (`POST /budgets/upsert`,
`DELETE /budgets/{id}`, `POST /budgets/copy-year`) used `CurrentUser`,
so any authenticated non-admin could upsert, delete, or bulk-copy
financial-planning rows. Comparable accounting data-management
endpoints in `backend/app/api/v1/endpoints/accounting.py` are gated
behind `CurrentAdmin`, so this was a privilege-escalation gap on
company budgeting records.

## Fix

- `backend/app/api/v1/endpoints/budgets.py`: switch the three mutating
  handlers from `CurrentUser` to `CurrentAdmin`. The `GET /budgets`
  list endpoint stays on `CurrentUser` so regular users can still see
  budgets in dashboards.

## Test plan
- [x] New regression test `backend/tests/test_p1_285_budgets_admin_only.py`
      covers: non-admin gets 403 on upsert/delete/copy-year; non-admin
      can still GET; admin still passes the auth gate on each mutation.
- [x] `pytest backend/tests/test_p1_285_budgets_admin_only.py` — 7 passed
- [x] `pytest backend/tests/test_budgets_api.py` (existing admin-driven
      suite) — 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)