### PR TITLE
fix: #286 P1 enforce non-empty required custom field values (Codex review)

### DIFF
--- a/backend/app/services/custom_field_service.py
+++ b/backend/app/services/custom_field_service.py
@@ -131,10 +131,30 @@ async def upsert_values(
     defs = await list_definitions(db, scope=scope, include_inactive=False)
     by_key = {d.key: d for d in defs}
 
-    # Required-field check
+    # Required-field check: a required field must have a non-empty value.
+    # Either the caller submits a non-empty value in this payload, or there
+    # must already be a non-empty value stored. Submitting None / "" / [] for
+    # a required key is rejected so required fields cannot be silently
+    # cleared (or created empty).
+    def _is_empty(v: Any) -> bool:
+        if v is None:
+            return True
+        if isinstance(v, str) and v == "":
+            return True
+        if isinstance(v, (list, tuple, set, dict)) and len(v) == 0:
+            return True
+        return False
+
     for d in defs:
-        if d.is_required:
-            if d.key not in values and not await _has_existing_value(db, d.id, record_id):
+        if not d.is_required:
+            continue
+        if d.key in values:
+            if _is_empty(values[d.key]):
+                raise CustomFieldError(
+                    f"Required custom field cannot be empty: {d.key}"
+                )
+        else:
+            if not await _has_existing_value(db, d.id, record_id):
                 raise CustomFieldError(f"Required custom field missing: {d.key}")
 
     # Coerce + upsert
@@ -168,15 +188,24 @@ async def upsert_values(
 
 
 async def _has_existing_value(db: AsyncSession, definition_id: uuid.UUID, record_id: uuid.UUID) -> bool:
+    """Return True iff a non-empty value is already stored for this definition/record.
+
+    A row whose stored ``value`` is NULL or an empty string is treated as
+    missing so that required-field validation cannot be satisfied by an
+    empty placeholder row left behind from a previous write.
+    """
     row = (
         await db.execute(
-            select(CustomFieldValue.id).where(
+            select(CustomFieldValue.value).where(
                 CustomFieldValue.definition_id == definition_id,
                 CustomFieldValue.record_id == record_id,
             )
         )
     ).first()
-    return row is not None
+    if row is None:
+        return False
+    stored = row[0]
+    return stored is not None and stored != ""
 
 
 async def read_values(

--- a/backend/tests/test_p1_286_required_custom_field.py
+++ b/backend/tests/test_p1_286_required_custom_field.py
@@ -1,0 +1,152 @@
+"""Regression for Codex P1 review on PR #286.
+
+The required-field guard previously only checked whether the key was
+present in the submitted payload (or whether any row existed for the
+record), which let callers satisfy a required field with ``None`` /
+empty-string / empty-list values. ``coerce_value`` would then store
+``None``, leaving the supposedly required field empty.
+
+This test locks in the stricter behavior:
+
+* missing key without prior data --> rejected
+* explicit ``None`` --> rejected
+* explicit empty string --> rejected
+* explicit empty list --> rejected (defensive; covers any future
+  list-shaped field types)
+* a required field cannot later be cleared to empty
+* a non-empty value continues to round-trip successfully
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.models.custom_field import CustomFieldDefinition
+from app.services.custom_field_service import (
+    CustomFieldError,
+    upsert_values,
+    read_values,
+)
+
+
+async def _make_required_text(db_session) -> CustomFieldDefinition:
+    d = CustomFieldDefinition(
+        scope="customer",
+        key="account_manager",
+        name="Account manager",
+        field_type="text",
+        is_required=True,
+    )
+    db_session.add(d)
+    await db_session.flush()
+    return d
+
+
+@pytest.mark.asyncio
+async def test_required_field_rejects_missing_key(db_session):
+    await _make_required_text(db_session)
+    with pytest.raises(CustomFieldError):
+        await upsert_values(
+            db_session,
+            scope="customer",
+            record_id=uuid.uuid4(),
+            values={},
+        )
+
+
+@pytest.mark.asyncio
+async def test_required_field_rejects_none(db_session):
+    await _make_required_text(db_session)
+    with pytest.raises(CustomFieldError):
+        await upsert_values(
+            db_session,
+            scope="customer",
+            record_id=uuid.uuid4(),
+            values={"account_manager": None},
+        )
+
+
+@pytest.mark.asyncio
+async def test_required_field_rejects_empty_string(db_session):
+    await _make_required_text(db_session)
+    with pytest.raises(CustomFieldError):
+        await upsert_values(
+            db_session,
+            scope="customer",
+            record_id=uuid.uuid4(),
+            values={"account_manager": ""},
+        )
+
+
+@pytest.mark.asyncio
+async def test_required_field_rejects_empty_list(db_session):
+    """Defensive: list-shaped values must also be rejected as empty.
+
+    Even though current ``FIELD_TYPES`` are scalar, the guard should not
+    accept ``[]`` as a satisfying value for a required field — that
+    avoids regressing the constraint when list-style types
+    (multi-select) are added.
+    """
+    await _make_required_text(db_session)
+    with pytest.raises(CustomFieldError):
+        await upsert_values(
+            db_session,
+            scope="customer",
+            record_id=uuid.uuid4(),
+            values={"account_manager": []},
+        )
+
+
+@pytest.mark.asyncio
+async def test_required_field_accepts_non_empty(db_session):
+    await _make_required_text(db_session)
+    rec_id = uuid.uuid4()
+    out = await upsert_values(
+        db_session,
+        scope="customer",
+        record_id=rec_id,
+        values={"account_manager": "Alice"},
+    )
+    assert out == {"account_manager": "Alice"}
+
+    again = await read_values(db_session, scope="customer", record_id=rec_id)
+    assert again == {"account_manager": "Alice"}
+
+
+@pytest.mark.asyncio
+async def test_required_field_cannot_be_cleared_to_empty(db_session):
+    """Once set, a required field must not be clearable via "" / None."""
+    await _make_required_text(db_session)
+    rec_id = uuid.uuid4()
+
+    # Initial valid value
+    await upsert_values(
+        db_session,
+        scope="customer",
+        record_id=rec_id,
+        values={"account_manager": "Alice"},
+    )
+
+    # Try to clear with empty string
+    with pytest.raises(CustomFieldError):
+        await upsert_values(
+            db_session,
+            scope="customer",
+            record_id=rec_id,
+            values={"account_manager": ""},
+        )
+
+    # Try to clear with None
+    with pytest.raises(CustomFieldError):
+        await upsert_values(
+            db_session,
+            scope="customer",
+            record_id=rec_id,
+            values={"account_manager": None},
+        )
+
+    # Original value is still intact
+    again = await read_values(db_session, scope="customer", record_id=rec_id)
+    assert again == {"account_manager": "Alice"}


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on PR #286.

`custom_field_service.upsert_values` previously satisfied the required-field guard if the key was merely present in the payload (or any row existed for the record). A caller could submit `null` / `""` / `[]` and `coerce_value` would store `None` — silently violating the required-field constraint either at create time or via a later "clear" write.

`_has_existing_value` also returned True for rows whose stored value was `NULL` / `""`, so an empty placeholder row satisfied the guard on subsequent writes.

## Fix

- `app/services/custom_field_service.py`: when a required key is in the payload, reject `None`, `""`, and any empty list/tuple/set/dict. Tighten `_has_existing_value` to ignore rows whose stored value is `NULL` or `""` so empty placeholders cannot satisfy the guard.

## Test plan

- [x] New `backend/tests/test_p1_286_required_custom_field.py` covers: missing key, `None`, `""`, `[]`, valid value round-trip, and that an existing required value cannot be cleared via empty-string / `None`.
- [x] `pytest tests/test_p1_286_required_custom_field.py -x -q` — 6 passed
- [x] `pytest tests/test_custom_field_service.py -x -q` — 16 passed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)