### PR TITLE
fix: #288 P1 reject duplicate kit component IDs (Codex review)

### DIFF
--- a/backend/app/api/v1/endpoints/kits.py
+++ b/backend/app/api/v1/endpoints/kits.py
@@ -66,6 +66,23 @@ async def get_kit(kit_product_id: uuid.UUID, user: CurrentUser, db: DB):
 @router.put("/{kit_product_id}", response_model=KitResponse, summary="Define or replace the kit's component list")
 async def upsert_kit(kit_product_id: uuid.UUID, body: KitDefinitionRequest, user: CurrentUser, db: DB):
     kit = await _ensure_product(db, kit_product_id)
+    # Reject duplicate component_product_id values up front; otherwise the
+    # uq_kit_components_kit_component unique constraint would surface as a 500
+    # on flush (and the existing rows would already have been deleted).
+    seen: set[uuid.UUID] = set()
+    duplicates: list[uuid.UUID] = []
+    for c in body.components:
+        if c.component_product_id in seen:
+            if c.component_product_id not in duplicates:
+                duplicates.append(c.component_product_id)
+        else:
+            seen.add(c.component_product_id)
+    if duplicates:
+        dup_list = ", ".join(str(d) for d in duplicates)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Duplicate component_product_id values in components: {dup_list}",
+        )
     # Validate component products exist + none is the kit itself (no self-reference)
     for c in body.components:
         if c.component_product_id == kit_product_id:

--- a/backend/tests/test_p1_288_kit_dup_components.py
+++ b/backend/tests/test_p1_288_kit_dup_components.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models.kit_component import KitComponent
+from app.models.material import Material
+from app.models.product import Product
+
+
+async def _make_product(db_session, sku: str, name: str) -> Product:
+    mat = (await db_session.execute(select(Material))).scalars().first()
+    if mat is None:
+        mat = Material(
+            name="Test Material",
+            brand="TestBrand",
+            spool_weight_g=Decimal("1000"),
+            spool_price=Decimal("20"),
+            net_usable_g=Decimal("950"),
+            cost_per_g=Decimal("20") / Decimal("950"),
+        )
+        db_session.add(mat)
+        await db_session.flush()
+    p = Product(sku=sku, name=name, material_id=mat.id)
+    db_session.add(p)
+    await db_session.flush()
+    return p
+
+
+@pytest.mark.asyncio
+async def test_put_kit_rejects_duplicate_component_ids(
+    client: AsyncClient, auth_headers, db_session
+):
+    """P1 #288: PUT with duplicate component_product_id must 400 up front,
+    not surface as a 500 from the unique constraint on flush."""
+    kit = await _make_product(db_session, "KIT-DUP", "Dup Kit")
+    a = await _make_product(db_session, "DUP-A", "Component A")
+    b = await _make_product(db_session, "DUP-B", "Component B")
+    await db_session.commit()
+
+    # First, set up an existing valid kit definition so we can verify it is
+    # not destructively replaced by a bad request.
+    setup = await client.put(
+        f"/api/v1/kits/{kit.id}",
+        json={"components": [
+            {"component_product_id": str(a.id), "quantity": "2"},
+            {"component_product_id": str(b.id), "quantity": "1"},
+        ]},
+        headers=auth_headers,
+    )
+    assert setup.status_code == 200
+    original = {
+        c["component_product_id"]: Decimal(c["quantity"])
+        for c in setup.json()["components"]
+    }
+    assert len(original) == 2
+
+    # Now PUT with duplicate component_product_id values; should 400.
+    resp = await client.put(
+        f"/api/v1/kits/{kit.id}",
+        json={"components": [
+            {"component_product_id": str(a.id), "quantity": "1"},
+            {"component_product_id": str(a.id), "quantity": "5"},
+        ]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+    detail = resp.json().get("detail", "")
+    assert "duplicate" in detail.lower() or str(a.id) in detail
+
+    # Existing components must NOT have been touched (no destructive reset).
+    get_resp = await client.get(f"/api/v1/kits/{kit.id}", headers=auth_headers)
+    assert get_resp.status_code == 200
+    after = {
+        c["component_product_id"]: Decimal(c["quantity"])
+        for c in get_resp.json()["components"]
+    }
+    assert after == original
+
+    # And the DB rows should reflect the original definition.
+    rows = (
+        await db_session.execute(
+            select(KitComponent).where(KitComponent.kit_product_id == kit.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 2
+    db_ids = {str(r.component_product_id) for r in rows}
+    assert db_ids == {str(a.id), str(b.id)}
+
+
+@pytest.mark.asyncio
+async def test_put_kit_rejects_duplicates_on_first_definition(
+    client: AsyncClient, auth_headers, db_session
+):
+    """Even with no prior kit definition, duplicates must 400, and no rows
+    must be inserted."""
+    kit = await _make_product(db_session, "KIT-DUP2", "Dup Kit 2")
+    a = await _make_product(db_session, "DUP2-A", "Component A2")
+    await db_session.commit()
+
+    resp = await client.put(
+        f"/api/v1/kits/{kit.id}",
+        json={"components": [
+            {"component_product_id": str(a.id), "quantity": "1"},
+            {"component_product_id": str(a.id), "quantity": "2"},
+        ]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+    rows = (
+        await db_session.execute(
+            select(KitComponent).where(KitComponent.kit_product_id == kit.id)
+        )
+    ).scalars().all()
+    assert rows == []


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on closed PR #288.

`PUT /api/v1/kits/{kit_product_id}` did not validate that `components` had distinct `component_product_id` values. With a duplicate payload, the handler deleted the existing `kit_components` rows, re-inserted the first duplicate, then hit `uq_kit_components_kit_component` on flush of the second — surfacing as a 500 to the client and leaving the kit with a partial/wrong definition.

## Fix

- `backend/app/api/v1/endpoints/kits.py`: scan `body.components` for repeated `component_product_id` values before any DB mutation. On duplicates, raise `HTTPException(400)` listing the offending ids; the existing kit definition is untouched.

## Test plan
- [x] New `backend/tests/test_p1_288_kit_dup_components.py`:
  - PUT a valid kit, then PUT with a duplicate component id, assert 400, assert original components are preserved (in API and DB).
  - First-time PUT with duplicates also 400s and inserts no rows.
- [x] `pytest backend/tests/test_kits_api.py backend/tests/test_p1_288_kit_dup_components.py` — 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)