### PR TITLE
fix: #291 P1 reject null status on delivery note PATCH (Codex review)

### DIFF
--- a/backend/app/api/v1/endpoints/delivery_notes.py
+++ b/backend/app/api/v1/endpoints/delivery_notes.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from typing import Literal
 
 from fastapi import APIRouter, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser
@@ -37,8 +37,19 @@ class DNCreate(BaseModel):
 class DNUpdate(BaseModel):
     shipped_on: date | None = None
     tracking_number: str | None = Field(None, max_length=120)
+    # `status` is optional-by-omission, but if the client sends the key it
+    # must be a valid non-null value. The underlying column is non-nullable,
+    # so accepting `null` here would surface as a 500 at commit time
+    # (Codex P1 review on PR #291).
     status: Literal["draft", "shipped", "delivered", "cancelled"] | None = None
     notes: str | None = None
+
+    @field_validator("status")
+    @classmethod
+    def _status_not_null(cls, v):
+        if v is None:
+            raise ValueError("status may not be null")
+        return v
 
 
 def _to_dict(dn: DeliveryNote) -> dict:

--- a/backend/tests/test_p1_291_delivery_note_null_status.py
+++ b/backend/tests/test_p1_291_delivery_note_null_status.py
@@ -1,0 +1,90 @@
+"""Regression: PATCH /delivery-notes/{id} must reject ``{"status": null}``.
+
+Codex P1 review on PR #291: ``DNUpdate`` permitted ``status: null`` and the
+generic ``setattr`` update loop applied that value, but ``delivery_notes.status``
+is non-nullable. The request would surface as a 500 IntegrityError at commit
+time. Reject the null at the schema layer (422) instead.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from app.models.customer import Customer
+
+
+async def _create_dn(client: AsyncClient, auth_headers, db_session) -> str:
+    c = Customer(name="P1-291", email="p1-291@example.com")
+    db_session.add(c)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/v1/delivery-notes",
+        json={
+            "customer_id": str(c.id),
+            "issued_on": "2026-05-01",
+            "lines": [{"description": "Widget", "quantity": "1"}],
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_patch_with_null_status_returns_422(
+    client: AsyncClient, auth_headers, db_session
+):
+    dn_id = await _create_dn(client, auth_headers, db_session)
+    resp = await client.patch(
+        f"/api/v1/delivery-notes/{dn_id}",
+        json={"status": None},
+        headers=auth_headers,
+    )
+    # Must be a client error (validation), not a 500 from the DB integrity
+    # error that would otherwise occur at commit time.
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_patch_with_status_omitted_succeeds(
+    client: AsyncClient, auth_headers, db_session
+):
+    dn_id = await _create_dn(client, auth_headers, db_session)
+    resp = await client.patch(
+        f"/api/v1/delivery-notes/{dn_id}",
+        json={"tracking_number": "ABC123"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["tracking_number"] == "ABC123"
+    # status must remain at its prior (default) value, not be wiped to null.
+    assert body["status"] == "draft"
+
+
+@pytest.mark.asyncio
+async def test_patch_with_valid_status_succeeds(
+    client: AsyncClient, auth_headers, db_session
+):
+    dn_id = await _create_dn(client, auth_headers, db_session)
+    resp = await client.patch(
+        f"/api/v1/delivery-notes/{dn_id}",
+        json={"status": "shipped"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "shipped"
+
+
+@pytest.mark.asyncio
+async def test_patch_with_empty_body_succeeds(
+    client: AsyncClient, auth_headers, db_session
+):
+    dn_id = await _create_dn(client, auth_headers, db_session)
+    resp = await client.patch(
+        f"/api/v1/delivery-notes/{dn_id}",
+        json={},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "draft"


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on closed PR #291.

`DNUpdate.status` was typed as `Literal[...] | None = None`, so a request
like `PATCH /delivery-notes/{id}` with `{"status": null}` passed schema
validation. The generic update loop then ran `setattr(dn, "status", None)`,
but `delivery_notes.status` is non-nullable, so the request failed at commit
time with an `IntegrityError` that surfaced as a 500 instead of a 4xx
client error.

## Fix

- Add a `field_validator` on `DNUpdate.status` that rejects explicit `null`.
- Field stays optional-by-omission (empty PATCH body, or PATCH that only
  updates other fields, still works).
- Invalid input now fails fast at the schema layer with a 422.

## Test plan

- [x] PATCH `{"status": null}` -> 422
- [x] PATCH `{}` -> 200, status unchanged
- [x] PATCH `{"tracking_number": "..."}` -> 200, status unchanged
- [x] PATCH `{"status": "shipped"}` -> 200, status updated
- [x] Existing `tests/test_delivery_notes_api.py` still passes (no regressions)

Run: `pytest backend/tests/test_p1_291_delivery_note_null_status.py -x -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)