### PR TITLE
fix: #287 P1 isolate batch delete failures with savepoints (Codex review)

### DIFF
--- a/backend/app/services/batch_ops_service.py
+++ b/backend/app/services/batch_ops_service.py
@@ -102,12 +102,16 @@ async def batch_delete(db: AsyncSession, *, scope: str, ids: list[uuid.UUID]) ->
         if row is None:
             errors.append({"id": str(rid), "error": "not found"})
             continue
+        # #287 P1: wrap each delete in a SAVEPOINT so a per-row FK
+        # IntegrityError only rolls back that row, not the entire
+        # transaction (which would discard earlier successful deletes
+        # in this batch and break documented partial-success behavior).
         try:
-            await db.delete(row)
-            await db.flush()
+            async with db.begin_nested():
+                await db.delete(row)
+                await db.flush()
             deleted += 1
         except IntegrityError as e:
-            await db.rollback()
             errors.append({"id": str(rid), "error": f"foreign-key dependency: {e.orig}"})
     return {"deleted": deleted, "errors": errors}
 

--- a/backend/tests/test_p1_287_batch_delete_partial.py
+++ b/backend/tests/test_p1_287_batch_delete_partial.py
@@ -1,0 +1,73 @@
+"""Regression test for issue #287 P1 (Codex review on PR #287).
+
+Earlier `batch_delete` called `await db.rollback()` inside the per-row
+loop. When the 2nd of 3 rows hit a FK `IntegrityError`, the rollback
+discarded the 1st row's already-flushed delete even though `deleted`
+had been incremented for it. The reported success count was right but
+the database state didn't match — a misleading partial-success.
+
+The fix wraps each per-row delete in a SAVEPOINT
+(`async with db.begin_nested():`). On IntegrityError the savepoint
+rolls back ONLY that row; earlier successful deletes survive and the
+final count matches reality.
+
+This test creates 3 vendors, makes the middle one fail on delete by
+hooking a `before_delete` event that raises StatementError wrapping an
+IntegrityError, and asserts:
+
+    - deleted == 2
+    - vendors[0] and vendors[2] are gone from the DB
+    - vendors[1] (the failing one) is still present
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import event, select
+from sqlalchemy.exc import IntegrityError
+
+from app.models.vendor import Vendor
+from app.services.batch_ops_service import batch_delete
+
+
+@pytest.mark.asyncio
+async def test_batch_delete_partial_success_isolated_with_savepoints(db_session):
+    vendors = [Vendor(name=f"P1-287-{i}") for i in range(3)]
+    for v in vendors:
+        db_session.add(v)
+    await db_session.flush()
+    ids = [v.id for v in vendors]
+    fail_id = ids[1]
+
+    # Simulate an FK constraint blocking the middle vendor's delete.
+    # We hook the mapper before_delete event and raise an IntegrityError
+    # for that specific row. SQLAlchemy will surface it from flush()
+    # exactly like a real FK violation would.
+    def block_middle_delete(mapper, connection, target):  # noqa: ARG001
+        if target.id == fail_id:
+            raise IntegrityError(
+                statement="DELETE FROM vendors",
+                params={},
+                orig=Exception("simulated FK constraint"),
+            )
+
+    event.listen(Vendor, "before_delete", block_middle_delete)
+    try:
+        out = await batch_delete(db_session, scope="vendor", ids=ids)
+    finally:
+        event.remove(Vendor, "before_delete", block_middle_delete)
+
+    # Reported counts.
+    assert out["deleted"] == 2, out
+    assert len(out["errors"]) == 1, out
+    assert out["errors"][0]["id"] == str(fail_id)
+
+    # Database state must match the reported counts: the savepoint
+    # rollback should have only discarded the failing row's delete.
+    # Earlier and later successful deletes must persist.
+    remaining = (
+        await db_session.execute(select(Vendor.id).where(Vendor.id.in_(ids)))
+    ).scalars().all()
+    assert remaining == [fail_id], (
+        f"Expected only the failing vendor ({fail_id}) to remain; got {remaining}"
+    )


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on closed PR #287.

`batch_delete` in `backend/app/services/batch_ops_service.py` iterated over the requested IDs and on per-row `IntegrityError` called `await db.rollback()`. That rolls back the **entire** outer transaction, so any earlier successful deletes in the same batch were undone even though `deleted` had already been incremented for them. The returned success count was therefore higher than the number of rows actually persisted whenever a constrained row appeared after a deletable row in the same request — silently breaking the documented per-row partial-success behavior.

## Fix

- Wrap each row's delete in a SAVEPOINT via `async with db.begin_nested():`. On `IntegrityError` the savepoint rolls back **only** that row; the outer transaction and earlier successful deletes survive.
- Increment `deleted` only when the per-row savepoint block exits cleanly.

## Test plan
- [x] New regression test `backend/tests/test_p1_287_batch_delete_partial.py` creates 3 vendors, uses a `before_delete` mapper event to raise `IntegrityError` on the middle row, and asserts `deleted == 2` with vendors[0]/vendors[2] gone from the DB and vendors[1] still present.
- [x] Verified the same test fails against the pre-fix code (returns `deleted=1` and even reports the third vendor as "not found", because the rollback expunged it from the session) — exact symptom Codex described.
- [x] Existing `tests/test_batch_ops_service.py` (7 tests) still passes.

\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)