### PR TITLE
fix: #334 P1 drill-down missing account → 404 (Codex review)

### DIFF
--- a/backend/app/api/v1/endpoints/reports.py
+++ b/backend/app/api/v1/endpoints/reports.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 import uuid
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 
 from app.api.deps import DB
@@ -219,7 +219,10 @@ async def account_drill_down(
     date_to: datetime.date | None = Query(None),
 ):
     from app.services.report_service import drill_down_account
-    payload = await drill_down_account(db, account_id=account_id, date_from=date_from, date_to=date_to)
+    try:
+        payload = await drill_down_account(db, account_id=account_id, date_from=date_from, date_to=date_to)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     return AccountDrillDownResponse(**payload)
 
 

--- a/backend/tests/test_p1_334_drill_down_invalid_account.py
+++ b/backend/tests/test_p1_334_drill_down_invalid_account.py
@@ -1,0 +1,25 @@
+"""#334 P1 (Codex): account drill-down with a non-existent account_id must
+return a 404 client error instead of a 500 from an unhandled ValueError.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_account_drill_down_missing_account_returns_404(
+    client: AsyncClient, auth_headers
+):
+    bogus_account_id = uuid.uuid4()
+    r = await client.get(
+        "/api/v1/reports/account-drill-down",
+        params={"account_id": str(bogus_account_id)},
+        headers=auth_headers,
+    )
+    assert r.status_code == 404, r.text
+    detail = r.json()["detail"]
+    assert str(bogus_account_id) in detail


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on PR #334.

`/api/v1/reports/account-drill-down` raised a plain `ValueError` from `drill_down_account` when the supplied `account_id` did not exist, which FastAPI surfaced as a 500 Internal Server Error instead of a 404-style client error.

## Fix

- `app/api/v1/endpoints/reports.py` now catches `ValueError` from `drill_down_account` and re-raises it as `HTTPException(status_code=404)` so missing-account requests are reported as client errors.

## Test plan
- [x] New regression test `tests/test_p1_334_drill_down_invalid_account.py` asserts a 404 (not 500) when calling the endpoint with a random unknown UUID
- [x] `pytest tests/test_p1_334_drill_down_invalid_account.py` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)