### PR TITLE
fix: #297 P1 reject unknown tax profile on invoice creation (Codex review)

### DIFF
--- a/backend/app/api/v1/endpoints/invoices.py
+++ b/backend/app/api/v1/endpoints/invoices.py
@@ -122,8 +122,12 @@ async def create_invoice(body: InvoiceCreate, user: CurrentUser, db: DB):
         rows = await compute_for_line(
             db, profile_id=body.tax_profile_id, subtotal=line_subtotal
         )
-        if rows:
-            tax_amount = sum((r.amount for r in rows), Decimal("0"))
+        if not rows:
+            # #297 P1: a typo/stale tax_profile_id must surface as 404 rather
+            # than silently producing a zero-tax invoice that hides the bad
+            # reference from the operator.
+            raise HTTPException(status_code=404, detail="Tax profile not found")
+        tax_amount = sum((r.amount for r in rows), Decimal("0"))
 
     invoice = Invoice(
         invoice_number=invoice_number,

--- a/backend/tests/test_p1_297_invoice_unknown_tax_profile.py
+++ b/backend/tests/test_p1_297_invoice_unknown_tax_profile.py
@@ -1,0 +1,70 @@
+"""Regression: Codex P1 on PR #297.
+
+When `tax_profile_id` is provided with `tax_amount=0`, a typo or stale UUID
+caused the invoice creation flow to silently leave tax at zero (because the
+profile lookup returned no rows) instead of signaling a bad reference. The
+create flow must raise 4xx and refuse to persist the invoice when
+`tax_profile_id` is supplied but no profile is found.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models.invoice import Invoice
+
+
+def _payload(customer_id: str, tax_profile_id: str):
+    issue_date = date.today() + timedelta(days=1)
+    due_date = issue_date + timedelta(days=7)
+    return {
+        "invoice_number": "INV-P1-297-0001",
+        "issue_date": issue_date.isoformat(),
+        "due_date": due_date.isoformat(),
+        "customer_id": customer_id,
+        "customer_name": "Wholesale Buyer",
+        "tax_amount": "0.00",
+        "tax_profile_id": tax_profile_id,
+        "shipping_amount": "10.00",
+        "credits_applied": "0.00",
+        "status": "sent",
+        "lines": [
+            {"description": "Brackets", "quantity": 10, "unit_price": "12.50"},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_invoice_with_unknown_tax_profile_rejected(
+    client, auth_headers, db_session
+):
+    customer_resp = await client.post(
+        "/api/v1/customers",
+        headers=auth_headers,
+        json={"name": "Wholesale Buyer", "email": "buyer@example.com"},
+    )
+    assert customer_resp.status_code in (200, 201)
+    customer_id = customer_resp.json()["id"]
+
+    before = (
+        await db_session.execute(select(func.count()).select_from(Invoice))
+    ).scalar() or 0
+
+    bogus_profile_id = str(uuid.uuid4())
+    create_resp = await client.post(
+        "/api/v1/invoices",
+        headers=auth_headers,
+        json=_payload(customer_id, bogus_profile_id),
+    )
+
+    assert 400 <= create_resp.status_code < 500, create_resp.text
+    assert create_resp.status_code in (400, 404)
+
+    after = (
+        await db_session.execute(select(func.count()).select_from(Invoice))
+    ).scalar() or 0
+    assert after == before, "no invoice should be persisted on bad tax profile"


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on closed PR #297.

When `tax_profile_id` was provided with `tax_amount=0`, the invoice create flow called `compute_for_line` and only updated `tax_amount` when rows were returned. A typo or stale UUID caused the lookup to return `[]`, so the invoice was happily created with zero tax instead of surfacing the bad reference to the operator.

## Fix

- `app/api/v1/endpoints/invoices.py` now raises `HTTPException(404, "Tax profile not found")` when `tax_profile_id` is supplied but `compute_for_line` returns no rows, matching the existing "not found" semantics on related endpoints.

## Test plan
- [x] New regression test `tests/test_p1_297_invoice_unknown_tax_profile.py` POSTs an invoice with a random UUID for `tax_profile_id` and asserts 4xx response and zero new invoice rows
- [x] `pytest tests/test_p1_297_invoice_unknown_tax_profile.py` passes locally
- [x] Existing `tests/test_api_invoices.py` and `tests/test_p1_283_compound_tax_no_components.py` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)