### PR TITLE
fix: #335 P1 validate as_of CSV date (Codex review)

### DIFF
--- a/backend/app/api/v1/endpoints/accounting_foundations.py
+++ b/backend/app/api/v1/endpoints/accounting_foundations.py
@@ -301,7 +301,17 @@ async def post_starting_balances_csv(
                 status_code=400, detail=f"Invalid amount for {code}: {r.get('amount')!r}"
             )
         if target_as_of is None and r.get("as_of"):
-            target_as_of = date.fromisoformat(r["as_of"].strip())
+            as_of_value = r["as_of"].strip()
+            try:
+                target_as_of = date.fromisoformat(as_of_value)
+            except ValueError:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Invalid as_of for {code}: {as_of_value!r}; "
+                        "expected ISO 8601 date (YYYY-MM-DD)"
+                    ),
+                )
         balances.append({"account_id": by_code[code].id, "amount": amt})
 
     if target_as_of is None:

--- a/backend/tests/test_p1_335_csv_as_of_invalid.py
+++ b/backend/tests/test_p1_335_csv_as_of_invalid.py
@@ -1,0 +1,71 @@
+"""#335 P1 (Codex): reject malformed `as_of` values supplied via CSV column.
+
+Previously, when a row included an `as_of` cell, the endpoint called
+``date.fromisoformat`` directly. A malformed value like ``2026/01/01`` raised
+``ValueError`` and bubbled up as a 500. Validate it the same way the other
+CSV field checks do and return a 400 instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models.account import Account
+
+
+async def _ensure_obe_and_account(db_session, code, name, account_type, normal_balance):
+    obe = (
+        await db_session.execute(select(Account).where(Account.code == "3300"))
+    ).scalar_one_or_none()
+    if obe is None:
+        db_session.add(
+            Account(
+                code="3300",
+                name="Opening Balance Equity",
+                account_type="equity",
+                normal_balance="credit",
+            )
+        )
+    a = Account(code=code, name=name, account_type=account_type, normal_balance=normal_balance)
+    db_session.add(a)
+    await db_session.flush()
+    return a
+
+
+@pytest.mark.asyncio
+async def test_starting_balances_csv_rejects_malformed_as_of(
+    client: AsyncClient, auth_headers, db_session
+):
+    await _ensure_obe_and_account(db_session, "1098", "Test Asset Bad", "asset", "debit")
+    await db_session.commit()
+    csv = b"account_code,amount,as_of\n1098,1500,2026/01/01\n"
+    files = {"file": ("sb.csv", csv, "text/csv")}
+    r = await client.post(
+        "/api/v1/accounting/starting-balances.csv",
+        files=files,
+        headers=auth_headers,
+    )
+    assert r.status_code == 400, r.text
+    detail = r.json()["detail"]
+    assert "as_of" in detail
+    assert "2026/01/01" in detail
+
+
+@pytest.mark.asyncio
+async def test_starting_balances_csv_accepts_valid_as_of(
+    client: AsyncClient, auth_headers, db_session
+):
+    await _ensure_obe_and_account(db_session, "1097", "Test Asset Good", "asset", "debit")
+    await db_session.commit()
+    csv = b"account_code,amount,as_of\n1097,1500,2026-01-01\n"
+    files = {"file": ("sb.csv", csv, "text/csv")}
+    r = await client.post(
+        "/api/v1/accounting/starting-balances.csv",
+        files=files,
+        headers=auth_headers,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["rows_processed"] == 1


### PR DESCRIPTION
## Summary

Addresses Codex P1 review on closed PR #335.

In `backend/app/api/v1/endpoints/accounting_foundations.py`, the `starting-balances.csv` upload handler called `date.fromisoformat(r["as_of"].strip())` without error handling. A malformed value such as `2026/01/01` raised `ValueError`, which surfaced to clients as a 500 instead of the expected 4xx.

## Fix

- Wrap the per-row `as_of` parse in a `try`/`except ValueError`.
- Raise `HTTPException(status_code=400, detail=...)` including the offending value and the expected ISO 8601 (`YYYY-MM-DD`) format.
- Mirrors the existing per-row validation pattern used for invalid `amount` values in the same loop.

## Test plan

- [x] New regression test `backend/tests/test_p1_335_csv_as_of_invalid.py`:
  - POST CSV with `as_of=2026/01/01` -> expects 400, detail mentions `as_of` and the bad value.
  - POST CSV with `as_of=2026-01-01` -> expects 200 with `rows_processed == 1`.
- [x] `tests/test_p2_330_foundations_extras.py` (sibling foundations CSV tests) still passes.

Run locally:

```
cd backend && .venv/bin/python -m pytest tests/test_p1_335_csv_as_of_invalid.py -x -q
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)