### PR TITLE
fix: #333 P1 map JournalLineLockedError to client error on reverse (Codex review)

### DIFF
--- a/backend/app/api/v1/endpoints/accounting.py
+++ b/backend/app/api/v1/endpoints/accounting.py
@@ -583,8 +583,16 @@ async def create_entry(body: JournalEntryCreate, admin: CurrentAdmin, db: DB):
     summary="Reverse a posted journal entry (admin only)",
 )
 async def reverse_entry(entry_id: uuid.UUID, body: JournalEntryReverse, admin: CurrentAdmin, db: DB):
+    # Lazy import: bank_reconciliation_service imports from accounting paths;
+    # keep the dependency arrow one-way at module import time.
+    from app.services.bank_reconciliation_service import JournalLineLockedError
+
     try:
         entry = await reverse_journal_entry(db, entry_id=entry_id, payload=body)
+    except JournalLineLockedError as exc:
+        # #333 Codex P1: reconciled source line blocks reversal -> 409 Conflict
+        # (operator must reopen the bank reconciliation first).
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except AccountingValidationError as exc:
         detail = str(exc)
         code = 404 if detail == "Journal entry not found." else 400

--- a/backend/tests/test_p1_333_reverse_reconciled_je.py
+++ b/backend/tests/test_p1_333_reverse_reconciled_je.py
@@ -1,0 +1,93 @@
+"""#333 Codex P1: API handler must map JournalLineLockedError -> client error.
+
+`POST /accounting/journal-entries/{entry_id}/reverse` raises
+`JournalLineLockedError` when any source line has `cleared_status="reconciled"`.
+Previously the handler only caught `AccountingValidationError`, so this
+condition surfaced as an unhandled HTTP 500. It must surface as a 4xx (409
+Conflict — the operator needs to reopen the bank reconciliation first).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.journal_entry import JournalEntry
+from app.models.journal_line import JournalLine
+from app.services.accounting_service import (
+    ensure_accounting_period,
+    seed_chart_of_accounts,
+)
+from app.services.bank_reconciliation_service import CLEARED_STATUS_RECONCILED
+
+
+@pytest.mark.asyncio
+async def test_reverse_returns_409_when_any_source_line_is_reconciled(
+    client, auth_headers, db_session: AsyncSession
+):
+    await seed_chart_of_accounts(db_session)
+    period = await ensure_accounting_period(
+        db_session,
+        period_key="2026-04",
+        name="April 2026",
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 4, 30),
+    )
+
+    accounts = (await client.get("/api/v1/accounting/accounts", headers=auth_headers)).json()
+    cash = next(a for a in accounts if a["code"] == "1000")
+    sales = next(a for a in accounts if a["code"] == "4000")
+
+    create_payload = {
+        "entry_date": "2026-04-15",
+        "accounting_period_id": str(period.id),
+        "source_type": "sale",
+        "source_id": "S-2026-0333",
+        "lines": [
+            {"account_id": cash["id"], "entry_type": "debit", "amount": "42.00"},
+            {"account_id": sales["id"], "entry_type": "credit", "amount": "42.00"},
+        ],
+    }
+    create_resp = await client.post(
+        "/api/v1/accounting/journal-entries", headers=auth_headers, json=create_payload
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    entry = create_resp.json()
+    entry_id = uuid.UUID(entry["id"])
+
+    # Mark the cash leg as reconciled at the model level — this is the state
+    # `finalize_reconciliation` would persist after a successful bank recon.
+    cash_account_id = uuid.UUID(cash["id"])
+    cash_line = (
+        await db_session.execute(
+            select(JournalLine).where(
+                JournalLine.journal_entry_id == entry_id,
+                JournalLine.account_id == cash_account_id,
+            )
+        )
+    ).scalar_one()
+    cash_line.cleared_status = CLEARED_STATUS_RECONCILED
+    await db_session.commit()
+
+    # Attempt reversal — must be a client error, not a 500.
+    reverse_resp = await client.post(
+        f"/api/v1/accounting/journal-entries/{entry['id']}/reverse",
+        headers=auth_headers,
+        json={"reversal_date": "2026-04-20", "memo": "Should be blocked"},
+    )
+    assert 400 <= reverse_resp.status_code < 500, reverse_resp.text
+    assert reverse_resp.status_code == 409, reverse_resp.text
+    detail = reverse_resp.json()["detail"]
+    assert "reconciled" in detail.lower()
+
+    # Original JE must remain un-reversed: no reversal_of_id pointing at it.
+    existing = (
+        await db_session.execute(
+            select(JournalEntry).where(JournalEntry.reversal_of_id == entry_id)
+        )
+    ).scalar_one_or_none()
+    assert existing is None


### PR DESCRIPTION
## Summary
- Codex P1 on closed PR #333: `reverse_journal_entry` now raises `JournalLineLockedError` when any source line has `cleared_status="reconciled"`, but the `POST /accounting/journal-entries/{entry_id}/reverse` handler only caught `AccountingValidationError`. The new exception leaked as an unhandled HTTP 500 instead of a client error.
- Add a `JournalLineLockedError` catch in `reverse_entry` that maps to HTTP 409 Conflict (operator must reopen the bank reconciliation first). Imported lazily inside the handler so the module-import dependency arrow stays one-way.
- Regression test creates a JE, flips the bank leg's `cleared_status` to `"reconciled"` (the post-`finalize_reconciliation` state), POSTs `/reverse`, and asserts 409 + no reversal entry persisted.

## Test plan
- [x] `cd backend && .venv/bin/python -m pytest tests/test_p1_333_reverse_reconciled_je.py -x -q` (1 passed)
- [x] `cd backend && .venv/bin/python -m pytest tests/test_api_accounting.py tests/test_p2_314_period_close.py -q` (16 passed — no regressions in adjacent suites)

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)