### PR TITLE
fix: #293 P1 atomic production-order close + serialize concurrent close (Codex review)

### DIFF
--- a/backend/app/services/accounting_service.py
+++ b/backend/app/services/accounting_service.py
@@ -137,7 +137,22 @@ async def ensure_accounting_period(
     return period
 
 
-async def create_journal_entry(db: AsyncSession, payload: JournalEntryCreate) -> JournalEntry:
+async def create_journal_entry(
+    db: AsyncSession,
+    payload: JournalEntryCreate,
+    *,
+    commit: bool = True,
+) -> JournalEntry:
+    """Create a posted journal entry.
+
+    By default the call commits internally so the JE is durable on return.
+    Callers that need to bundle the JE write into a larger atomic unit
+    (e.g. `production_order_service.close_order`, where a later
+    finished-goods layer insert must not leave the JE persisted on its own
+    if the layer step fails) can pass ``commit=False`` — the entry is
+    flushed (so its id is available) but the surrounding transaction is
+    left open for the caller to commit or roll back.
+    """
     if not payload.lines or len(payload.lines) < 2:
         raise AccountingValidationError("Journal entries require at least two lines.")
 
@@ -196,7 +211,10 @@ async def create_journal_entry(db: AsyncSession, payload: JournalEntryCreate) ->
             )
         )
 
-    await db.commit()
+    if commit:
+        await db.commit()
+    else:
+        await db.flush()
     result = await db.execute(
         select(JournalEntry)
         .options(selectinload(JournalEntry.lines))

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -108,7 +108,20 @@ async def create_order(
 
 
 async def close_order(db: AsyncSession, order_id: uuid.UUID) -> ProductionOrder:
-    order = (await db.execute(select(ProductionOrder).where(ProductionOrder.id == order_id))).scalar_one_or_none()
+    # #293 Codex P1: serialize concurrent /close requests so two callers
+    # cannot both pass the `status == "planned"` guard and each consume
+    # receipts + post their own JE/finished-goods layer. `with_for_update`
+    # takes a row-level lock for the duration of the surrounding
+    # transaction; on databases without row locks (SQLite in tests) it is
+    # silently a no-op, which is acceptable since SQLite serializes writes
+    # at the file level anyway.
+    order = (
+        await db.execute(
+            select(ProductionOrder)
+            .where(ProductionOrder.id == order_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
     if order is None:
         raise ProductionOrderError("Production order not found")
     if order.status != "planned":
@@ -144,7 +157,14 @@ async def close_order(db: AsyncSession, order_id: uuid.UUID) -> ProductionOrder:
         else Decimal("0")
     )
 
-    # Post JE: Cr Material Inventory / Dr Finished Goods Inventory
+    # Post JE: Cr Material Inventory / Dr Finished Goods Inventory.
+    #
+    # #293 Codex P1: pass `commit=False` so the JE write does NOT commit
+    # mid-close. The surrounding endpoint commits once at the end, so the
+    # JE, the order's status/completed_at update, and the finished-goods
+    # layer insert all live in a single transaction — if any step below
+    # raises, the JE rolls back with the rest instead of leaving books
+    # mutated while the order remains 'planned'.
     if total_value > 0:
         material_inv = await _account_by_code(db, "1200")  # Raw Materials Inventory
         finished_goods = await _account_by_code(db, "1400")  # Finished Goods Inventory
@@ -171,6 +191,7 @@ async def close_order(db: AsyncSession, order_id: uuid.UUID) -> ProductionOrder:
                         ),
                     ],
                 ),
+                commit=False,
             )
         except AccountingValidationError as e:
             raise ProductionOrderError(str(e)) from e

--- a/backend/tests/test_p1_293_production_close_atomic.py
+++ b/backend/tests/test_p1_293_production_close_atomic.py
@@ -1,0 +1,193 @@
+"""Regression for Codex P1 review on PR #293.
+
+`production_order_service.close_order` previously called
+`create_journal_entry` (which commits internally) BEFORE setting the order
+to `completed` and BEFORE inserting the finished-goods layer. If any later
+step raised, the JE — and the receipt FIFO draws — were already durable
+while the order remained `planned`, leaving inventory and accounting
+mutated without a corresponding closed order.
+
+The fix passes `commit=False` to `create_journal_entry` so the JE write,
+the status/completed_at update, and the finished-goods layer insert all
+share the surrounding transaction. A failure after the JE write must roll
+back every effect of the close attempt.
+
+This test forces a layer-insert failure AFTER the JE row has been added
+(via monkeypatching `FinishedGoodsLayer.__init__` to raise) and asserts:
+
+  - close_order raises
+  - no JournalEntry was persisted for the production order
+  - the production order's status is still 'planned'
+  - the order has no journal_entry_id pointer
+  - no FinishedGoodsLayer was persisted for the order
+  - no MaterialReceipt FIFO draw persisted (quantity_remaining_g restored)
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.journal_entry import JournalEntry
+from app.models.material import Material
+from app.models.material_receipt import MaterialReceipt
+from app.models.product import Product
+from app.models.product_bom_item import ProductBOMItem
+from app.models.production_order import (
+    FinishedGoodsLayer,
+    ProductionOrder,
+)
+from app.services import production_order_service
+from app.services.production_order_service import close_order, create_order
+
+
+async def _seed(db_session):
+    mat = Material(
+        name="PLA Atomic",
+        brand="TestBrand",
+        spool_weight_g=Decimal("1000"),
+        spool_price=Decimal("100"),
+        net_usable_g=Decimal("950"),
+        cost_per_g=Decimal("0.10"),
+    )
+    db_session.add(mat)
+    await db_session.flush()
+    receipt = MaterialReceipt(
+        material_id=mat.id,
+        vendor_name="Acme",
+        purchase_date=datetime.date(2026, 4, 1),
+        quantity_purchased_g=Decimal("1000"),
+        quantity_remaining_g=Decimal("1000"),
+        unit_cost_per_g=Decimal("0.10"),
+        landed_cost_total=Decimal("0"),
+        landed_cost_per_g=Decimal("0"),
+        total_cost=Decimal("100"),
+    )
+    db_session.add(receipt)
+    product = Product(sku="WIDGET-ATOMIC", name="Widget", material_id=mat.id)
+    db_session.add(product)
+    await db_session.flush()
+    bom = ProductBOMItem(
+        product_id=product.id,
+        component_type="material",
+        material_id=mat.id,
+        quantity=Decimal("50"),
+        unit="g",
+    )
+    db_session.add(bom)
+    await db_session.flush()
+    # Commit seed so an outer rollback inside close_order would not erase
+    # the test's own setup. The behaviour under test is whether close_order's
+    # own work is rolled back as a unit when a later step raises.
+    await db_session.commit()
+    return mat, product, receipt
+
+
+@pytest.mark.asyncio
+async def test_close_order_rolls_back_je_when_layer_insert_fails(
+    db_session, monkeypatch
+):
+    mat, product, receipt = await _seed(db_session)
+    receipt_id = receipt.id
+    order = await create_order(
+        db_session, product_id=product.id, output_quantity=Decimal("10")
+    )
+    await db_session.commit()
+    order_id = order.id
+
+    boom = RuntimeError("simulated finished-goods layer insertion failure")
+
+    real_init = FinishedGoodsLayer.__init__
+
+    def exploding_init(self, *args, **kwargs):  # noqa: ANN001 - test stub
+        # Detonate only when close_order tries to materialise the new
+        # layer; this runs AFTER `create_journal_entry` has already added
+        # the JE row to the session.
+        raise boom
+
+    monkeypatch.setattr(FinishedGoodsLayer, "__init__", exploding_init)
+
+    with pytest.raises(RuntimeError, match="simulated finished-goods layer"):
+        await close_order(db_session, order_id)
+
+    # Restore so post-failure assertions can construct ORM objects normally
+    # (and so the rollback below isn't poisoned by the patch).
+    monkeypatch.setattr(FinishedGoodsLayer, "__init__", real_init)
+
+    # The session is in a failed state; roll it back so we can read.
+    await db_session.rollback()
+
+    # No journal entry persisted for this order.
+    persisted_entries = (
+        await db_session.execute(
+            select(JournalEntry).where(
+                JournalEntry.source_type == "production_order",
+                JournalEntry.source_id == str(order_id),
+            )
+        )
+    ).scalars().all()
+    assert persisted_entries == [], (
+        "JE was persisted despite a later step failing — close_order is "
+        "not atomic across journal posting and layer creation."
+    )
+
+    # Order is still 'planned' and has no JE pointer.
+    refreshed = (
+        await db_session.execute(
+            select(ProductionOrder).where(ProductionOrder.id == order_id)
+        )
+    ).scalar_one()
+    assert refreshed.status == "planned", (
+        f"Order status leaked to {refreshed.status!r} after a failed close"
+    )
+    assert refreshed.completed_at is None
+    assert refreshed.journal_entry_id is None
+
+    # No finished-goods layer for this order.
+    layers = (
+        await db_session.execute(
+            select(FinishedGoodsLayer).where(
+                FinishedGoodsLayer.production_order_id == order_id
+            )
+        )
+    ).scalars().all()
+    assert layers == []
+
+    # FIFO draw rolled back: receipt is back at its full balance.
+    refreshed_receipt = (
+        await db_session.execute(
+            select(MaterialReceipt).where(MaterialReceipt.id == receipt_id)
+        )
+    ).scalar_one()
+    assert refreshed_receipt.quantity_remaining_g == Decimal("1000"), (
+        "Material receipt FIFO draw persisted despite the close failing — "
+        "the JE/layer/consumption writes must share one transaction."
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_order_uses_row_lock(db_session):
+    """Smoke test that the SELECT for the production order is emitted with
+    `FOR UPDATE` semantics on dialects that support it. SQLite (test DB)
+    silently ignores the clause, so we just exercise the path to make sure
+    the lock hint does not break the close on the supported test backend.
+    """
+    mat, product, _ = await _seed(db_session)
+    order = await create_order(
+        db_session, product_id=product.id, output_quantity=Decimal("10")
+    )
+    await db_session.commit()
+    closed = await close_order(db_session, order.id)
+    assert closed.status == "completed"
+    # And `with_for_update()` is still wired on the read — guard against
+    # someone removing it inadvertently.
+    import inspect
+
+    src = inspect.getsource(production_order_service.close_order)
+    assert "with_for_update" in src, (
+        "close_order must use with_for_update() to serialize concurrent "
+        "/close requests against the same production order."
+    )


### PR DESCRIPTION
## Summary

Codex P1 review on PR #293. `production_order_service.close_order` was calling `accounting_service.create_journal_entry` — which commits internally — **before** the order's status update and the finished-goods layer insert. If any later step raised, the JE and its receipt FIFO draws were already durable while the order remained `planned`. Books mutated, order unchanged, no easy way to reconcile.

## Changes

- **`accounting_service.create_journal_entry`** gains a keyword-only `commit: bool = True` param. When `False`, the JE row is flushed (so `id` is available) but the surrounding transaction stays open for the caller to commit or roll back. Default behavior is unchanged for every existing caller.
- **`production_order_service.close_order`** passes `commit=False` to the JE write so the JE, the status/`completed_at` update, and the finished-goods layer insert all live in one transaction. A failure after the JE write rolls back every effect of the close attempt.
- Also adds `with_for_update()` on the order `SELECT` so two concurrent `/close` requests cannot both pass the `status == "planned"` guard and each consume receipts. Row-lock is a no-op on SQLite (used in tests), which is fine because SQLite serializes writes at file level anyway.

## Test plan

- [x] New regression `tests/test_p1_293_production_close_atomic.py` — forces a layer-insert failure after the JE has been added (monkeypatches `FinishedGoodsLayer.__init__`) and asserts:
  - `close_order` raises
  - no `JournalEntry` persisted for the production order
  - status remains `planned`, no `journal_entry_id` pointer
  - no `FinishedGoodsLayer` persisted
  - no `MaterialReceipt` FIFO draw applied (`quantity_remaining_g` restored)
- [x] Second test asserts the row-level lock is requested (`with_for_update`).
- [x] Local: `pytest tests/ -k "accounting or journal or production_order"` → 46 passed
- [ ] CI: backend tests + frontend validation

## Risk

Signature change to `create_journal_entry` is keyword-only with a default — every existing caller keeps the old behavior. The `commit=False` path is exercised only by the new `close_order` flow.