### PR TITLE
fix(ops): #386 #387 deploy workflow — migrate against new image + poll container health

### DIFF
--- a/docs/deployment_n8n_workflow.md
+++ b/docs/deployment_n8n_workflow.md
@@ -26,10 +26,10 @@ In order:
 6. `git fetch` and `git pull` the target branch.
 7. Captures the new commit SHA (`after_sha`).
 8. Diffs `backend/alembic/versions/` between the two SHAs to decide whether migrations are needed (or honours an explicit `run_migrations: true|false`).
-9. If migrations needed: runs `scripts/web01-compose.sh exec -T backend alembic upgrade head`.
-10. Runs `scripts/web01-compose.sh up -d --build` to rebuild and restart containers.
-11. Waits 15 seconds for containers to settle.
-12. Verifies all three containers (`db`, `backend`, `frontend`) are healthy via `scripts/web01-compose.sh ps`.
+9. If migrations needed: builds the new backend image (`compose build backend`) and runs migrations as a one-shot container from that new image (`compose run --rm --no-deps -T backend alembic upgrade head`). Running against the **new** image is critical — the old running container does not have the new migration files in its `/app/alembic/versions/`, so executing alembic inside it would silently no-op. See #387 for the historical bug this fixes.
+10. Runs `scripts/web01-compose.sh up -d --build` to bring up (or rebuild and restart) all containers with the new image.
+11. Waits 5 seconds for containers to start initializing.
+12. Polls `scripts/web01-compose.sh ps --format json` every 2 seconds for up to 30 seconds, exiting as soon as all three required containers (`db`, `backend`, `frontend`) report `Health: healthy`. If the budget is exhausted with at least one container still not healthy, the workflow fails with the latest observed state (see #386).
 13. Verifies `GET /health` returns 200.
 14. Verifies `GET /` returns 200.
 15. Builds a success summary and fires the success notification webhook (if configured).
@@ -187,6 +187,7 @@ Store `N8N_WEBHOOK` and `N8N_DEPLOY_TOKEN` in whatever env/keychain Claude has a
   "before_sha": "30e19bf74f84fd21a86f225512234b16c6a60d25",
   "after_sha": "c3decb32cbbf765723a1bd2192ad6a64c5e75d5a",
   "migrations_run": true,
+  "migrations_applied": ["20260412_01"],
   "migration_files": ["backend/alembic/versions/20260412_01_add_cameras.py"],
   "duration_seconds": 142,
   "containers": [
@@ -245,7 +246,7 @@ This can be wired to Slack/Discord/Mattermost inbound webhooks, a custom relay, 
 Every step is a discrete node. Common changes:
 
 - **Add a post-deploy smoke test** — add an SSH node between `SSH: GET / (frontend)` and `Build Success Summary` that hits another endpoint (e.g. `curl /api/v1/auth/me` with a known token).
-- **Change the wait time** — edit the `Wait for containers` node's duration.
+- **Change the wait time** — edit the `Wait for containers` node's duration (initial settle delay) and/or the `SSH: Compose ps` loop (the `seq 1 15` upper bound is the max number of 2-second polls before failing).
 - **Extend the branch allowlist** — edit the `ALLOWED_BRANCHES` array in the `Validate Input` node.
 - **Change the notification destination** — set the `DEPLOY_NOTIFICATION_URL` n8n variable.
 - **Run a pre-deploy DB backup** — insert a new SSH node before `SSH: Compose up --build` that runs `pg_dump` into a dated file on the host.

--- a/ops/n8n/web01-deploy.json
+++ b/ops/n8n/web01-deploy.json
@@ -242,7 +242,7 @@
     {
       "parameters": {
         "resource": "command",
-        "command": "cd /srv/3d-print-sales/repo && scripts/web01-compose.sh exec -T backend alembic upgrade head"
+        "command": "cd /srv/3d-print-sales/repo && scripts/web01-compose.sh build backend && scripts/web01-compose.sh run --rm --no-deps -T backend alembic upgrade head"
       },
       "id": "11111111-1111-1111-1111-111111111013",
       "name": "SSH: Run Migrations",
@@ -283,7 +283,7 @@
     },
     {
       "parameters": {
-        "amount": 15,
+        "amount": 5,
         "unit": "seconds"
       },
       "id": "11111111-1111-1111-1111-111111111015",
@@ -299,7 +299,7 @@
     {
       "parameters": {
         "resource": "command",
-        "command": "cd /srv/3d-print-sales/repo && scripts/web01-compose.sh ps --format json"
+        "command": "cd /srv/3d-print-sales/repo && out=''; for i in $(seq 1 15); do out=$(scripts/web01-compose.sh ps --format json 2>&1); healthy=$(echo \"$out\" | grep -oE '\"Health\":\"healthy\"' | wc -l | tr -d ' '); if [ \"$healthy\" -ge 3 ]; then break; fi; sleep 2; done; echo \"$out\""
       },
       "id": "11111111-1111-1111-1111-111111111016",
       "name": "SSH: Compose ps",
@@ -376,7 +376,7 @@
     {
       "parameters": {
         "mode": "runOnceForEachItem",
-        "jsCode": "// Assemble the success response body.\nconst context = $('Validate Input').item.json.context;\nconst before = ($('SSH: Capture before SHA').item.json.stdout || '').trim();\nconst after = ($('SSH: Capture after SHA').item.json.stdout || '').trim();\nconst migrations = $('Detect Migrations').item.json;\nconst containers = $('Parse Compose ps').item.json.containers;\nconst healthOut = ($('SSH: GET /health').item.json.stdout || '').trim();\nconst frontendOut = ($('SSH: GET / (frontend)').item.json.stdout || '').trim();\n\nconst startedAt = context.started_at;\nconst finishedAt = new Date().toISOString();\nconst durationSeconds = Math.round((Date.parse(finishedAt) - Date.parse(startedAt)) / 1000);\n\nreturn {\n  json: {\n    ok: true,\n    branch: context.branch,\n    before_sha: before.slice(0, 40),\n    after_sha: after.slice(0, 40),\n    migrations_run: migrations.needs_migration === true,\n    migration_files: migrations.migration_files || [],\n    duration_seconds: durationSeconds,\n    containers,\n    health_endpoint: healthOut,\n    frontend_endpoint: frontendOut,\n    triggered_by: context.triggered_by,\n    started_at: startedAt,\n    finished_at: finishedAt,\n  }\n};"
+        "jsCode": "// Assemble the success response body.\nconst context = $('Validate Input').item.json.context;\nconst before = ($('SSH: Capture before SHA').item.json.stdout || '').trim();\nconst after = ($('SSH: Capture after SHA').item.json.stdout || '').trim();\nconst migrations = $('Detect Migrations').item.json;\nconst containers = $('Parse Compose ps').item.json.containers;\nconst healthOut = ($('SSH: GET /health').item.json.stdout || '').trim();\nconst frontendOut = ($('SSH: GET / (frontend)').item.json.stdout || '').trim();\n\n// Parse alembic output for revisions that were actually upgraded. Alembic\n// emits a line like:\n//   INFO  [alembic.runtime.migration] Running upgrade 20260510_12 -> 20260510_13, <doc>\n// per applied revision (usually on stderr). When no upgrade was needed,\n// no such line is emitted, even if `needs_migration` flagged the run.\nlet migrationsApplied = [];\ntry {\n  const runMigItem = $('SSH: Run Migrations').item;\n  if (runMigItem && runMigItem.json) {\n    const combined = ((runMigItem.json.stderr || '') + '\\n' + (runMigItem.json.stdout || ''));\n    const re = /Running upgrade \\S+\\s*->\\s*([^,\\s]+)/g;\n    let m;\n    while ((m = re.exec(combined)) !== null) {\n      migrationsApplied.push(m[1]);\n    }\n  }\n} catch (e) {\n  // Run Migrations node didn't execute (e.g. needs_migration was false). Leave list empty.\n}\n\nconst startedAt = context.started_at;\nconst finishedAt = new Date().toISOString();\nconst durationSeconds = Math.round((Date.parse(finishedAt) - Date.parse(startedAt)) / 1000);\n\nreturn {\n  json: {\n    ok: true,\n    branch: context.branch,\n    before_sha: before.slice(0, 40),\n    after_sha: after.slice(0, 40),\n    // True only when alembic actually upgraded at least one revision.\n    // Old field; kept for back-compat with notification consumers.\n    migrations_run: migrationsApplied.length > 0,\n    // Actual list of revisions upgraded, parsed from alembic output.\n    migrations_applied: migrationsApplied,\n    // Migration files detected in the diff (intent — may not match what was applied\n    // if alembic was a no-op because the DB was already at head).\n    migration_files: migrations.migration_files || [],\n    duration_seconds: durationSeconds,\n    containers,\n    health_endpoint: healthOut,\n    frontend_endpoint: frontendOut,\n    triggered_by: context.triggered_by,\n    started_at: startedAt,\n    finished_at: finishedAt,\n  }\n};"
       },
       "id": "11111111-1111-1111-1111-111111111020",
       "name": "Build Success Summary",


### PR DESCRIPTION
## Summary

Closes #386 (health-check race) and #387 (migration ordering) — two independent bugs in `ops/n8n/web01-deploy.json` hit in the same hour on 2026-05-11. The migration-ordering bug is the root cause of the production 500 on print-job update earlier today. No nodes added/removed, so existing n8n node IDs and credential references stay intact on re-import.

## #387 — migrations now run against the **new** image

`SSH: Run Migrations` previously ran:

```
docker compose exec -T backend alembic upgrade head
```

…inside the already-running backend container. That container is on the **old** image; the new migration file is not present in its `/app/alembic/versions/` (the image is a COPY-build, no bind mount). Alembic exits 0 with no upgrade log line, then `up --build` rebuilds the image and restarts the container — **without ever running migrations against the new image**.

This is exactly why PR #384's `20260510_13_backfill_je_reference_sequence` did not apply on the 2026-05-11 deploy; the JE allocator then issued `JE-2026-0001` and collided with the existing entry when an operator hit print-job update.

New command:

```
scripts/web01-compose.sh build backend \
  && scripts/web01-compose.sh run --rm --no-deps -T backend alembic upgrade head
```

- `build backend` produces the new image without starting the long-running backend.
- `run --rm --no-deps` spins up a **one-shot container from the new image** to apply migrations.
- If alembic fails, the existing backend keeps serving (failure mode: deploy doesn't ship, not prod half-migrated).
- `--no-deps` skips bringing up `db` as a dependency (it's already running in steady state); if you somehow ran this on a host where db is down, the migration would fail and the deploy would halt.

## #386 — Compose ps now polls until healthy

`SSH: Compose ps` previously took a single snapshot 15 seconds after `up --build`. On execution id=56 today, that snapshot fired while backend was still `starting` and frontend was briefly `missing`, falsely failing the deploy. id=57 (~37s later) saw all three `healthy`, proving the bring-up itself was fine.

New polling shell:

```
out=''
for i in $(seq 1 15); do
  out=$(scripts/web01-compose.sh ps --format json 2>&1)
  healthy=$(echo "$out" | grep -oE '"Health":"healthy"' | wc -l | tr -d ' ')
  if [ "$healthy" -ge 3 ]; then break; fi
  sleep 2
done
echo "$out"
```

Exits early as soon as 3+ containers report `Health: healthy`. Budget ~30s. The latest output is always echoed for the existing `Parse Compose ps` JS validator, which still throws on the final-snapshot state if it isn't all-healthy — so a true bring-up failure still fails the deploy with a real error.

`Wait for containers` initial delay dropped from 15s → 5s; the poll loop covers the rest, so a fast bring-up isn't artificially penalized.

## Bonus — `migrations_run` now means what it says

`Build Success Summary` was previously reporting `migrations_run: <bool>` based on **intent** (did the diff show a new migration file?), not **fact** (did alembic actually upgrade anything?). Misleading when alembic was silently a no-op (the entire #387 bug).

Now parses alembic stderr for `Running upgrade <from> -> <to>` lines:

- `migrations_applied: string[]` — actual revisions upgraded (e.g. `["20260510_13"]`); empty when alembic was a no-op.
- `migrations_run: bool` — kept for back-compat, but now true only when `migrations_applied.length > 0`.
- `migration_files: string[]` — intent (the diffed alembic file names), unchanged.

## Operator action required after merge

n8n does not pull this JSON from git; the workflow file here is the source of truth for the *definition*. After merging, the operator must:

1. **Workflows → Import from file** in the n8n UI, pointing at the updated `ops/n8n/web01-deploy.json`.
2. Confirm overwrite when prompted.
3. Re-activate the toggle (import resets it).
4. Trigger a sanity-check deploy and verify the success response now includes `migrations_applied: []` (when there are no new migrations) instead of just `migrations_run`.

The first deploy with a new migration will exercise the #387 fix; any deploy will exercise the #386 fix (the new poll loop is the path now even on the happy path).

## Test plan

- [x] `jq -e '.' ops/n8n/web01-deploy.json` — JSON still valid, 27 nodes intact
- [x] Reviewed all node connections (`.connections.*`): no edges changed; only `parameters.command`, `parameters.amount`, and one `parameters.jsCode` modified
- [ ] **Operator: re-import the workflow into n8n** (see "Operator action required after merge")
- [ ] **Operator: trigger a deploy with no new migrations** — expect `migrations_run: false`, `migrations_applied: []`, all containers healthy, response in ~30-50s
- [ ] **Operator: trigger a deploy with a new migration** (next PR that adds an alembic revision is the natural test) — expect `migrations_applied: ["<rev>"]` and `alembic current` on web01 matches `alembic heads` after the deploy

## Risk

Workflow JSON only — no application code change. CI here will pass trivially (this file is not exercised by backend/frontend tests). The real test is the next operator-triggered deploy. Rollback is to revert this commit and re-import the prior JSON.