### PR TITLE
feat(inventory): #318 P2 multi-location SoT — per-location decrement + soft-warn + in-transit

### DIFF
--- a/backend/alembic/versions/20260511_01_product_location_stock.py
+++ b/backend/alembic/versions/20260511_01_product_location_stock.py
@@ -29,7 +29,10 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
         sa.ForeignKeyConstraint(["product_id"], ["products.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["location_id"], ["inventory_locations.id"], ondelete="CASCADE"),
+        # RESTRICT on locations: deleting a stocked location must be an
+        # explicit operator action via the API path that also keeps
+        # Product.stock_qty in sync (#318 P2).
+        sa.ForeignKeyConstraint(["location_id"], ["inventory_locations.id"], ondelete="RESTRICT"),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("product_id", "location_id", name="uq_product_location_stock"),
     )

--- a/backend/alembic/versions/20260511_01_product_location_stock.py
+++ b/backend/alembic/versions/20260511_01_product_location_stock.py
@@ -1,0 +1,84 @@
+"""#318 P2: product_location_stock SoT + backfill from Product.stock_qty
+
+Revision ID: 20260511_01
+Revises: 20260510_12
+Create Date: 2026-05-11 09:00:00
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260511_01"
+down_revision = "20260510_12"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "product_location_stock",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("product_id", sa.UUID(), nullable=False),
+        sa.Column("location_id", sa.UUID(), nullable=False),
+        sa.Column("on_hand_qty", sa.Numeric(14, 4), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["product_id"], ["products.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["location_id"], ["inventory_locations.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("product_id", "location_id", name="uq_product_location_stock"),
+    )
+    op.create_index(
+        "ix_product_location_stock_product_id",
+        "product_location_stock",
+        ["product_id"],
+    )
+    op.create_index(
+        "ix_product_location_stock_location_id",
+        "product_location_stock",
+        ["location_id"],
+    )
+
+    # Backfill: park each product's existing stock_qty at the seeded Default
+    # location, so per-location reads work immediately for single-location
+    # operators. Skipped if no Default location exists yet (fresh installs
+    # before `ensure_default_location` has been called).
+    bind = op.get_bind()
+    default_loc = bind.execute(
+        sa.text("SELECT id FROM inventory_locations WHERE name = 'Default' LIMIT 1")
+    ).first()
+    if default_loc is None:
+        return
+
+    default_loc_id = default_loc[0]
+    products = bind.execute(
+        sa.text(
+            "SELECT id, stock_qty FROM products "
+            "WHERE stock_qty IS NOT NULL AND stock_qty <> 0"
+        )
+    ).fetchall()
+    for product_id, stock_qty in products:
+        bind.execute(
+            sa.text(
+                "INSERT INTO product_location_stock "
+                "(id, product_id, location_id, on_hand_qty) "
+                "VALUES (:id, :product_id, :location_id, :qty)"
+            ),
+            {
+                "id": str(uuid.uuid4()),
+                "product_id": str(product_id),
+                "location_id": str(default_loc_id),
+                "qty": stock_qty,
+            },
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_product_location_stock_location_id", table_name="product_location_stock")
+    op.drop_index("ix_product_location_stock_product_id", table_name="product_location_stock")
+    op.drop_table("product_location_stock")

--- a/backend/app/api/v1/endpoints/locations.py
+++ b/backend/app/api/v1/endpoints/locations.py
@@ -10,7 +10,13 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser
-from app.models.inventory_location import InventoryLocation, InventoryTransfer, InventoryTransferLine
+from app.models.inventory_location import (
+    InventoryLocation,
+    InventoryTransfer,
+    InventoryTransferLine,
+    ProductLocationStock,
+)
+from app.services import product_location_stock_service as pls
 from app.services.inventory_transfer_service import (
     InventoryTransferError,
     cancel_transfer,
@@ -355,3 +361,102 @@ async def set_default_fulfillment_location(
         row.value = new_val
     await db.commit()
     return DefaultFulfillmentLocationResponse(location_id=body.location_id)
+
+
+# ---------- #318 P2: per-location stock SoT + prevent-negative-stock toggle ----------
+
+
+class LocationStockRow(BaseModel):
+    product_id: uuid.UUID
+    on_hand_qty: Decimal
+    in_transit_to_qty: Decimal
+    projected_qty: Decimal
+
+
+@router.get(
+    "/locations/{location_id}/product-stock",
+    response_model=list[LocationStockRow],
+    summary="#318 P2: per-product on-hand at this location from the SoT",
+)
+async def location_product_stock(location_id: uuid.UUID, user: CurrentUser, db: DB):
+    """Returns the per-(product, location) source-of-truth on-hand,
+    plus the in-transit qty arriving from `in_transit` transfers. The
+    snapshot endpoint above derives from completed transfers only and
+    is retained for back-compat; this endpoint is the authoritative
+    read.
+    """
+    loc = (
+        await db.execute(select(InventoryLocation).where(InventoryLocation.id == location_id))
+    ).scalar_one_or_none()
+    if loc is None:
+        raise HTTPException(status_code=404, detail="Location not found")
+
+    rows = await pls.stock_by_product_at_location(db, location_id=location_id)
+    out: list[LocationStockRow] = []
+    for r in rows:
+        in_transit = await pls.in_transit_to(
+            db, product_id=r.product_id, location_id=location_id
+        )
+        out.append(
+            LocationStockRow(
+                product_id=r.product_id,
+                on_hand_qty=Decimal(r.on_hand_qty),
+                in_transit_to_qty=in_transit,
+                projected_qty=Decimal(r.on_hand_qty) + in_transit,
+            )
+        )
+    return out
+
+
+_PREVENT_NEG_KEY = "inventory.prevent_negative_stock"
+
+
+class PreventNegativeStockResponse(BaseModel):
+    enabled: bool
+
+
+class PreventNegativeStockUpdate(BaseModel):
+    enabled: bool
+
+
+@router.get(
+    "/prevent-negative-stock",
+    response_model=PreventNegativeStockResponse,
+    summary="#318 P2: read the prevent-negative-stock toggle",
+)
+async def get_prevent_negative_stock(user: CurrentUser, db: DB):
+    from app.models.setting import Setting
+
+    row = (
+        await db.execute(select(Setting).where(Setting.key == _PREVENT_NEG_KEY))
+    ).scalar_one_or_none()
+    enabled = bool(row and (row.value or "").strip().lower() == "true")
+    return PreventNegativeStockResponse(enabled=enabled)
+
+
+@router.put(
+    "/prevent-negative-stock",
+    response_model=PreventNegativeStockResponse,
+    summary="#318 P2: set the prevent-negative-stock toggle (hard-block sales when on)",
+)
+async def set_prevent_negative_stock(
+    body: PreventNegativeStockUpdate, user: CurrentUser, db: DB
+):
+    from app.models.setting import Setting
+
+    row = (
+        await db.execute(select(Setting).where(Setting.key == _PREVENT_NEG_KEY))
+    ).scalar_one_or_none()
+    new_val = "true" if body.enabled else "false"
+    if row is None:
+        db.add(
+            Setting(
+                key=_PREVENT_NEG_KEY,
+                value=new_val,
+                notes="When true, sales that would drive per-location on-hand below zero are blocked; when false they are warned but allowed.",
+            )
+        )
+    else:
+        row.value = new_val
+    await db.commit()
+    return PreventNegativeStockResponse(enabled=body.enabled)

--- a/backend/app/api/v1/endpoints/locations.py
+++ b/backend/app/api/v1/endpoints/locations.py
@@ -101,6 +101,22 @@ async def delete_location(location_id: uuid.UUID, user: CurrentUser, db: DB):
     ).first()
     if referenced:
         raise HTTPException(status_code=400, detail="Location is referenced by transfers; deactivate it instead")
+    # #318 P2: also block when this location is the SoT for any product
+    # on-hand. The FK is ondelete=CASCADE so a raw delete would silently
+    # drop the rows and leave Product.stock_qty out of sync.
+    stocked = (
+        await db.execute(
+            select(ProductLocationStock.id).where(
+                ProductLocationStock.location_id == location_id,
+                ProductLocationStock.on_hand_qty != 0,
+            ).limit(1)
+        )
+    ).first()
+    if stocked:
+        raise HTTPException(
+            status_code=400,
+            detail="Location holds product stock; transfer it out or deactivate the location instead",
+        )
     await db.delete(loc)
     await db.commit()
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -16,6 +16,7 @@ from app.models.inventory_location import (  # noqa: F401
     InventoryLocation,
     InventoryTransfer,
     InventoryTransferLine,
+    ProductLocationStock,
 )
 from app.models.product_bom_item import ProductBOMItem  # noqa: F401
 from app.models.production_order import (  # noqa: F401

--- a/backend/app/models/inventory_location.py
+++ b/backend/app/models/inventory_location.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -98,3 +99,42 @@ class InventoryTransferLine(Base):
     )
 
     transfer = relationship("InventoryTransfer", back_populates="lines")
+
+
+class ProductLocationStock(Base):
+    """Per-(product, location) on-hand quantity — source of truth for
+    multi-location inventory (#318 Phase 2).
+
+    `Product.stock_qty` is kept in sync as the aggregate across locations
+    for backward compatibility, but allocation decisions (which location
+    fulfills a sale, which is depleted by a transfer ship, which has free
+    stock to project a receive into) read this table.
+
+    `on_hand_qty` excludes in-transit holds: when a transfer ships, the
+    source's on-hand drops immediately; the destination's on-hand only
+    rises when the transfer is received. Projected-available at a
+    destination must add `inventory_transfers` rows in `in_transit` status
+    targeting that location.
+    """
+
+    __tablename__ = "product_location_stock"
+    __table_args__ = (
+        UniqueConstraint("product_id", "location_id", name="uq_product_location_stock"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    product_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("products.id", ondelete="CASCADE"), index=True
+    )
+    location_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("inventory_locations.id", ondelete="CASCADE"), index=True
+    )
+    on_hand_qty: Mapped[Decimal] = mapped_column(Numeric(14, 4), default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/backend/app/models/inventory_location.py
+++ b/backend/app/models/inventory_location.py
@@ -126,8 +126,13 @@ class ProductLocationStock(Base):
     product_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("products.id", ondelete="CASCADE"), index=True
     )
+    # Locations use RESTRICT: deleting a location should never silently
+    # discard per-location on-hand and leave the Product.stock_qty
+    # aggregate stale. The HTTP delete endpoint refuses to drop a
+    # location holding stock, and this FK is the same guarantee at the DB
+    # level.
     location_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("inventory_locations.id", ondelete="CASCADE"), index=True
+        ForeignKey("inventory_locations.id", ondelete="RESTRICT"), index=True
     )
     on_hand_qty: Mapped[Decimal] = mapped_column(Numeric(14, 4), default=0)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/services/inventory_transfer_service.py
+++ b/backend/app/services/inventory_transfer_service.py
@@ -1,19 +1,19 @@
-"""Inventory transfer lifecycle (#245 Phase 1).
+"""Inventory transfer lifecycle (#245 Phase 1 → #318 Phase 2).
 
-Phase 1 covers location CRUD + the transfer state machine. It does not
-yet wire decrement of source-side qty or increment of destination-side qty
-into existing inventory tracking — material/supply/product on-hand stays
-in the existing single-bucket model. The transfer document is persisted
-and reportable, which is the operationally important step; making the
-decrements per-location is Phase 2 (and requires the per-row backfill of
-material_receipt.location_id and inventory_transaction.location_id that's
-out of scope for this PR).
+Phase 1 added the state machine without touching per-location stock.
+Phase 2 wires product lines through ``product_location_stock_service``:
+shipping decrements source on-hand, receiving increments destination
+on-hand, and cancelling while in-transit restores the source.
+
+Material and supply lines still flow through the document only; their
+per-location SoT is a separate follow-up.
 """
 
 from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
+from decimal import Decimal
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,6 +23,7 @@ from app.models.inventory_location import (
     InventoryTransfer,
     InventoryTransferLine,
 )
+from app.services import product_location_stock_service as pls
 from app.services.reference_number_service import next_number
 
 
@@ -94,10 +95,36 @@ async def create_transfer(
     return transfer
 
 
+async def _product_lines(db: AsyncSession, transfer_id: uuid.UUID) -> list[InventoryTransferLine]:
+    return (
+        (
+            await db.execute(
+                select(InventoryTransferLine).where(
+                    InventoryTransferLine.transfer_id == transfer_id,
+                    InventoryTransferLine.kind == "product",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
 async def ship_transfer(db: AsyncSession, transfer_id: uuid.UUID) -> InventoryTransfer:
     transfer = await _require_transfer(db, transfer_id)
     if transfer.status != STATUS_PENDING:
         raise InventoryTransferError(f"Cannot ship transfer in status {transfer.status}")
+
+    for line in await _product_lines(db, transfer.id):
+        if not line.product_id:
+            continue
+        await pls.adjust(
+            db,
+            product_id=line.product_id,
+            location_id=transfer.from_location_id,
+            delta=-Decimal(line.quantity),
+        )
+
     transfer.status = STATUS_IN_TRANSIT
     transfer.shipped_at = datetime.now(timezone.utc)
     await db.flush()
@@ -108,6 +135,17 @@ async def receive_transfer(db: AsyncSession, transfer_id: uuid.UUID) -> Inventor
     transfer = await _require_transfer(db, transfer_id)
     if transfer.status != STATUS_IN_TRANSIT:
         raise InventoryTransferError(f"Cannot receive transfer in status {transfer.status}")
+
+    for line in await _product_lines(db, transfer.id):
+        if not line.product_id:
+            continue
+        await pls.adjust(
+            db,
+            product_id=line.product_id,
+            location_id=transfer.to_location_id,
+            delta=Decimal(line.quantity),
+        )
+
     transfer.status = STATUS_COMPLETED
     transfer.received_at = datetime.now(timezone.utc)
     await db.flush()
@@ -118,6 +156,19 @@ async def cancel_transfer(db: AsyncSession, transfer_id: uuid.UUID) -> Inventory
     transfer = await _require_transfer(db, transfer_id)
     if transfer.status not in (STATUS_PENDING, STATUS_IN_TRANSIT):
         raise InventoryTransferError(f"Cannot cancel transfer in status {transfer.status}")
+
+    if transfer.status == STATUS_IN_TRANSIT:
+        # Release the source-side hold that ship_transfer applied.
+        for line in await _product_lines(db, transfer.id):
+            if not line.product_id:
+                continue
+            await pls.adjust(
+                db,
+                product_id=line.product_id,
+                location_id=transfer.from_location_id,
+                delta=Decimal(line.quantity),
+            )
+
     transfer.status = STATUS_CANCELLED
     transfer.cancelled_at = datetime.now(timezone.utc)
     await db.flush()

--- a/backend/app/services/product_location_stock_service.py
+++ b/backend/app/services/product_location_stock_service.py
@@ -1,0 +1,286 @@
+"""Per-(product, location) on-hand quantity service (#318 Phase 2).
+
+`ProductLocationStock` is the source of truth for "which location holds
+how many of which product." `Product.stock_qty` is kept in sync as the
+aggregate sum for backward compatibility with existing read paths.
+
+Allocation rules
+----------------
+- Transfer **ship**: source on-hand drops immediately (items are now in
+  transit and count as zero on-hand at the source).
+- Transfer **receive**: destination on-hand rises.
+- Transfer **cancel** while ``in_transit``: source on-hand is restored.
+- Transfer **cancel** while ``pending``: no-op (no decrement yet).
+- Sale fulfillment: the resolved location's on-hand drops.
+- Refund / cancel of a sale: the original fulfillment location's on-hand
+  is restored.
+
+Negative-stock policy
+---------------------
+Soft-warn is the default — fulfillment is allowed and the caller can
+surface the warning. Operators can flip ``inventory.prevent_negative_stock``
+to ``"true"`` to make the same condition a hard block. Both branches are
+evaluated against *projected* on-hand (the new value after the proposed
+decrement).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from decimal import Decimal
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.inventory_location import (
+    InventoryLocation,
+    InventoryTransfer,
+    InventoryTransferLine,
+    ProductLocationStock,
+)
+from app.models.product import Product
+from app.models.setting import Setting
+
+
+PREVENT_NEGATIVE_STOCK_KEY = "inventory.prevent_negative_stock"
+DEFAULT_FULFILLMENT_KEY = "inventory.default_fulfillment_location_id"
+
+
+class NegativeStockBlockedError(Exception):
+    """Raised when a decrement would drive on-hand negative and the
+    `inventory.prevent_negative_stock` setting is enabled."""
+
+
+@dataclass
+class StockWarning:
+    product_id: uuid.UUID
+    location_id: uuid.UUID
+    requested_qty: Decimal
+    projected_on_hand: Decimal
+
+
+# ---------- helpers ----------
+
+
+async def _get_setting(db: AsyncSession, key: str) -> str | None:
+    row = (await db.execute(select(Setting).where(Setting.key == key))).scalar_one_or_none()
+    return row.value if row else None
+
+
+async def _hard_block_enabled(db: AsyncSession) -> bool:
+    val = await _get_setting(db, PREVENT_NEGATIVE_STOCK_KEY)
+    return (val or "").strip().lower() == "true"
+
+
+async def _ensure_default_location(db: AsyncSession) -> InventoryLocation:
+    row = (
+        await db.execute(select(InventoryLocation).where(InventoryLocation.name == "Default"))
+    ).scalar_one_or_none()
+    if row:
+        return row
+    row = InventoryLocation(name="Default", kind="internal")
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def resolve_fulfillment_location_id(
+    db: AsyncSession, *, sale_fulfillment_location_id: uuid.UUID | None
+) -> uuid.UUID:
+    """Pick the location to fulfill a sale from.
+
+    Order: explicit sale.fulfillment_location_id → setting default → the
+    auto-seeded ``Default`` location. Always returns a usable id so
+    callers never need to special-case None.
+    """
+    if sale_fulfillment_location_id:
+        return sale_fulfillment_location_id
+
+    setting_val = await _get_setting(db, DEFAULT_FULFILLMENT_KEY)
+    if setting_val:
+        try:
+            return uuid.UUID(setting_val)
+        except ValueError:
+            pass
+
+    return (await _ensure_default_location(db)).id
+
+
+# ---------- read ----------
+
+
+async def get_row(
+    db: AsyncSession, *, product_id: uuid.UUID, location_id: uuid.UUID
+) -> ProductLocationStock | None:
+    return (
+        await db.execute(
+            select(ProductLocationStock).where(
+                ProductLocationStock.product_id == product_id,
+                ProductLocationStock.location_id == location_id,
+            )
+        )
+    ).scalar_one_or_none()
+
+
+async def get_on_hand(
+    db: AsyncSession, *, product_id: uuid.UUID, location_id: uuid.UUID
+) -> Decimal:
+    row = await get_row(db, product_id=product_id, location_id=location_id)
+    return Decimal(row.on_hand_qty) if row else Decimal(0)
+
+
+async def in_transit_to(
+    db: AsyncSession, *, product_id: uuid.UUID, location_id: uuid.UUID
+) -> Decimal:
+    """Sum of `in_transit` transfer-line quantities arriving at this
+    location for this product. Used to project a destination's "incoming"
+    qty without including it in current on-hand.
+    """
+    total = (
+        await db.execute(
+            select(func.coalesce(func.sum(InventoryTransferLine.quantity), 0))
+            .join(InventoryTransfer, InventoryTransfer.id == InventoryTransferLine.transfer_id)
+            .where(
+                InventoryTransfer.to_location_id == location_id,
+                InventoryTransfer.status == "in_transit",
+                InventoryTransferLine.kind == "product",
+                InventoryTransferLine.product_id == product_id,
+            )
+        )
+    ).scalar() or 0
+    return Decimal(total)
+
+
+async def stock_by_product_at_location(
+    db: AsyncSession, *, location_id: uuid.UUID
+) -> list[ProductLocationStock]:
+    return (
+        (
+            await db.execute(
+                select(ProductLocationStock).where(ProductLocationStock.location_id == location_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+# ---------- write ----------
+
+
+async def _refresh_product_aggregate(db: AsyncSession, product_id: uuid.UUID) -> None:
+    """Recompute `Product.stock_qty` as the sum of on-hand across
+    locations so existing single-bucket readers keep working.
+    """
+    total = (
+        await db.execute(
+            select(func.coalesce(func.sum(ProductLocationStock.on_hand_qty), 0)).where(
+                ProductLocationStock.product_id == product_id
+            )
+        )
+    ).scalar() or 0
+    product = (
+        await db.execute(select(Product).where(Product.id == product_id))
+    ).scalar_one_or_none()
+    if product is None:
+        return
+    # `Product.stock_qty` is Integer; in-flight Decimal totals from
+    # numeric columns round down to whole units, matching the existing
+    # int-only semantics on the read side.
+    product.stock_qty = int(Decimal(total))
+    await db.flush()
+
+
+async def _ensure_product_seeded(db: AsyncSession, product_id: uuid.UUID) -> None:
+    """Lazy backfill of legacy single-bucket inventory.
+
+    If a product has ``stock_qty > 0`` in the legacy column but no
+    ``ProductLocationStock`` rows yet, park that on-hand at the Default
+    location so the SoT can take over. Idempotent — once any row exists
+    for the product, we stop. The Alembic migration does the same thing
+    eagerly for existing installs; this guards test paths and any rows
+    that were inserted while the migration was running.
+    """
+    has_row = (
+        await db.execute(
+            select(ProductLocationStock.id).where(
+                ProductLocationStock.product_id == product_id
+            ).limit(1)
+        )
+    ).scalar_one_or_none()
+    if has_row is not None:
+        return
+
+    product = (
+        await db.execute(select(Product).where(Product.id == product_id))
+    ).scalar_one_or_none()
+    if product is None or not product.stock_qty:
+        return
+
+    default_loc = await _ensure_default_location(db)
+    db.add(
+        ProductLocationStock(
+            product_id=product_id,
+            location_id=default_loc.id,
+            on_hand_qty=Decimal(product.stock_qty),
+        )
+    )
+    await db.flush()
+
+
+async def adjust(
+    db: AsyncSession,
+    *,
+    product_id: uuid.UUID,
+    location_id: uuid.UUID,
+    delta: Decimal,
+    enforce_non_negative: bool | None = None,
+) -> tuple[ProductLocationStock, StockWarning | None]:
+    """Apply ``delta`` (positive = receipt, negative = consumption) to
+    the (product, location) row, creating it if missing.
+
+    Returns the row plus an optional ``StockWarning`` when a negative
+    decrement drives projected on-hand below zero. Callers may surface
+    the warning to the operator. When ``enforce_non_negative`` is True
+    (or when the global ``inventory.prevent_negative_stock`` setting is
+    enabled) the same condition raises ``NegativeStockBlockedError``
+    instead.
+    """
+    await _ensure_product_seeded(db, product_id)
+
+    row = await get_row(db, product_id=product_id, location_id=location_id)
+    if row is None:
+        row = ProductLocationStock(
+            product_id=product_id,
+            location_id=location_id,
+            on_hand_qty=Decimal(0),
+        )
+        db.add(row)
+        await db.flush()
+
+    current = Decimal(row.on_hand_qty)
+    projected = current + Decimal(delta)
+
+    warning: StockWarning | None = None
+    if projected < 0:
+        block = enforce_non_negative
+        if block is None:
+            block = await _hard_block_enabled(db)
+        if block:
+            raise NegativeStockBlockedError(
+                f"Product {product_id} at location {location_id} would go to "
+                f"{projected} (have {current}, requested {-delta}); "
+                f"{PREVENT_NEGATIVE_STOCK_KEY} is enabled."
+            )
+        warning = StockWarning(
+            product_id=product_id,
+            location_id=location_id,
+            requested_qty=Decimal(-delta) if delta < 0 else Decimal(delta),
+            projected_on_hand=projected,
+        )
+
+    row.on_hand_qty = projected
+    await db.flush()
+    await _refresh_product_aggregate(db, product_id)
+    return row, warning

--- a/backend/app/services/sales_service.py
+++ b/backend/app/services/sales_service.py
@@ -13,6 +13,7 @@ from app.models.sale_item import SaleItem
 from app.models.sales_channel import SalesChannel
 from app.models.product import Product
 from app.models.inventory_transaction import InventoryTransaction
+from app.services import product_location_stock_service as pls
 from app.services.inventory_accounting_service import post_cogs_for_sale
 
 
@@ -239,8 +240,22 @@ async def deduct_inventory_for_sale(
     sale_id: uuid.UUID,
     items: list[SaleItem],
     user_id: uuid.UUID | None = None,
-) -> None:
-    """Deduct product stock for each sale item with a product_id."""
+) -> list[pls.StockWarning]:
+    """Deduct product stock for each sale item with a product_id.
+
+    Routes the decrement through the per-(product, location) source of
+    truth (#318 P2). The location is resolved from the sale's
+    ``fulfillment_location_id`` (falling back to the global default
+    setting, then the ``Default`` location). Returns the list of stock
+    warnings emitted by the per-location adjuster so the route can
+    surface them to operators.
+    """
+    sale = (await db.execute(select(Sale).where(Sale.id == sale_id))).scalar_one_or_none()
+    location_id = await pls.resolve_fulfillment_location_id(
+        db, sale_fulfillment_location_id=sale.fulfillment_location_id if sale else None
+    )
+
+    warnings: list[pls.StockWarning] = []
     for item in items:
         if not item.product_id:
             continue
@@ -254,15 +269,28 @@ async def deduct_inventory_for_sale(
             type="sale",
             quantity=-item.quantity,
             unit_cost=item.unit_cost,
-            notes=f"Sale {sale_id}",
+            notes=f"Sale {sale_id} @ location {location_id}",
             created_by=user_id,
         )
         db.add(txn)
-        product.stock_qty = max(0, product.stock_qty - item.quantity)
 
-    sale = (await db.execute(select(Sale).where(Sale.id == sale_id))).scalar_one_or_none()
+        try:
+            _, warning = await pls.adjust(
+                db,
+                product_id=item.product_id,
+                location_id=location_id,
+                delta=Decimal(-item.quantity),
+            )
+        except pls.NegativeStockBlockedError as exc:
+            # Reuse the existing checkout-blocking exception type so route
+            # handlers don't need a separate catch.
+            raise InsufficientStockError(str(exc)) from exc
+        if warning:
+            warnings.append(warning)
+
     if sale:
         await post_cogs_for_sale(db, sale, items)
+    return warnings
 
 
 async def restore_inventory_for_refund(
@@ -270,7 +298,17 @@ async def restore_inventory_for_refund(
     sale: Sale,
     user_id: uuid.UUID | None = None,
 ) -> None:
-    """Restore product stock when a sale is refunded."""
+    """Restore product stock when a sale is refunded.
+
+    Returns inventory to the same location the sale was fulfilled from
+    (#318 P2). If the sale had no explicit fulfillment location, we use
+    the same resolver as the original decrement so the refund lands
+    where the deduction was applied.
+    """
+    location_id = await pls.resolve_fulfillment_location_id(
+        db, sale_fulfillment_location_id=sale.fulfillment_location_id
+    )
+
     for item in sale.items:
         if not item.product_id:
             continue
@@ -284,8 +322,13 @@ async def restore_inventory_for_refund(
             type="return",
             quantity=item.quantity,
             unit_cost=item.unit_cost,
-            notes=f"Refund for sale {sale.sale_number}",
+            notes=f"Refund for sale {sale.sale_number} @ location {location_id}",
             created_by=user_id,
         )
         db.add(txn)
-        product.stock_qty += item.quantity
+        await pls.adjust(
+            db,
+            product_id=item.product_id,
+            location_id=location_id,
+            delta=Decimal(item.quantity),
+        )

--- a/backend/app/services/sales_service.py
+++ b/backend/app/services/sales_service.py
@@ -254,6 +254,11 @@ async def deduct_inventory_for_sale(
     location_id = await pls.resolve_fulfillment_location_id(
         db, sale_fulfillment_location_id=sale.fulfillment_location_id if sale else None
     )
+    # Pin the resolved location to the sale so refunds restore inventory to
+    # exactly the location it was deducted from, even if the operator later
+    # changes the default-fulfillment-location setting.
+    if sale and sale.fulfillment_location_id is None:
+        sale.fulfillment_location_id = location_id
 
     warnings: list[pls.StockWarning] = []
     for item in items:

--- a/backend/tests/test_p2_318_stock_sot.py
+++ b/backend/tests/test_p2_318_stock_sot.py
@@ -282,6 +282,73 @@ async def test_product_stock_endpoint_reports_in_transit(client: AsyncClient, au
 
 
 @pytest.mark.asyncio
+async def test_refund_uses_pinned_location_even_after_default_changes(db_session):
+    """Codex P1: refund must restore to the location originally deducted
+    from, even if the default-fulfillment-location setting changes after
+    the sale.
+    """
+    import datetime as dt
+    a, b = await _two_locs(db_session)
+    p = await _product(db_session, stock=0)
+    await pls.adjust(db_session, product_id=p.id, location_id=a.id, delta=Decimal(10))
+    db_session.add(Setting(key=pls.DEFAULT_FULFILLMENT_KEY, value=str(a.id)))
+    await db_session.flush()
+
+    sale = Sale(sale_number="S-PIN-1", date=dt.date.today(), status="pending")
+    db_session.add(sale)
+    await db_session.flush()
+    item = SaleItem(
+        sale_id=sale.id,
+        product_id=p.id,
+        description="Widget",
+        quantity=3,
+        unit_price=Decimal("10"),
+        line_total=Decimal("30"),
+        unit_cost=Decimal("3"),
+    )
+    db_session.add(item)
+    await db_session.flush()
+
+    await deduct_inventory_for_sale(db_session, sale.id, [item])
+    # The deduction should have pinned the resolved location onto the sale.
+    await db_session.refresh(sale)
+    assert sale.fulfillment_location_id == a.id
+
+    # Operator flips the default to a different location.
+    setting = (
+        await db_session.execute(select(Setting).where(Setting.key == pls.DEFAULT_FULFILLMENT_KEY))
+    ).scalar_one()
+    setting.value = str(b.id)
+    await db_session.flush()
+
+    class _SaleLike:
+        def __init__(self, sale, items):
+            self.id = sale.id
+            self.sale_number = sale.sale_number
+            self.fulfillment_location_id = sale.fulfillment_location_id
+            self.items = items
+
+    await restore_inventory_for_refund(db_session, _SaleLike(sale, [item]))
+    assert await pls.get_on_hand(db_session, product_id=p.id, location_id=a.id) == Decimal(10)
+    assert await pls.get_on_hand(db_session, product_id=p.id, location_id=b.id) == Decimal(0)
+
+
+@pytest.mark.asyncio
+async def test_delete_stocked_location_blocked(client: AsyncClient, auth_headers, db_session):
+    """Codex P1: deleting a location holding SoT stock must be refused,
+    not silently cascade and orphan Product.stock_qty.
+    """
+    a, _ = await _two_locs(db_session)
+    p = await _product(db_session, stock=0)
+    await pls.adjust(db_session, product_id=p.id, location_id=a.id, delta=Decimal(5))
+    await db_session.commit()
+
+    r = await client.delete(f"/api/v1/inventory/locations/{a.id}", headers=auth_headers)
+    assert r.status_code == 400
+    assert "stock" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
 async def test_prevent_negative_stock_toggle_round_trip(client: AsyncClient, auth_headers, db_session):
     r0 = await client.get("/api/v1/inventory/prevent-negative-stock", headers=auth_headers)
     assert r0.status_code == 200

--- a/backend/tests/test_p2_318_stock_sot.py
+++ b/backend/tests/test_p2_318_stock_sot.py
@@ -1,0 +1,299 @@
+"""#318 P2: ProductLocationStock SoT + per-location decrement + soft-warn + in-transit."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models.inventory_location import InventoryLocation
+from app.models.material import Material
+from app.models.product import Product
+from app.models.sale import Sale
+from app.models.sale_item import SaleItem
+from app.models.setting import Setting
+from app.services import product_location_stock_service as pls
+from app.services.inventory_transfer_service import (
+    cancel_transfer,
+    create_transfer,
+    receive_transfer,
+    ship_transfer,
+)
+from app.services.sales_service import (
+    create_sale_with_items,
+    deduct_inventory_for_sale,
+    restore_inventory_for_refund,
+)
+
+
+async def _two_locs(db):
+    a = InventoryLocation(name="Workshop")
+    b = InventoryLocation(name="Showroom")
+    db.add_all([a, b])
+    await db.flush()
+    return a, b
+
+
+async def _product(db, stock=10) -> Product:
+    m = Material(
+        name="PLA",
+        brand="Generic",
+        spool_weight_g=Decimal("1000"),
+        spool_price=Decimal("20"),
+        net_usable_g=Decimal("950"),
+        cost_per_g=Decimal("0.02"),
+    )
+    db.add(m)
+    await db.flush()
+    p = Product(
+        sku="PROD-1",
+        name="Widget",
+        material_id=m.id,
+        unit_cost=Decimal("3"),
+        unit_price=Decimal("10"),
+        stock_qty=stock,
+    )
+    db.add(p)
+    await db.flush()
+    return p
+
+
+class _Item:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+    def model_dump(self):
+        return dict(self.__dict__)
+
+
+@pytest.mark.asyncio
+async def test_adjust_creates_and_updates_row_and_aggregate(db_session):
+    a, _ = await _two_locs(db_session)
+    p = await _product(db_session, stock=0)
+
+    row, warn = await pls.adjust(db_session, product_id=p.id, location_id=a.id, delta=Decimal(5))
+    assert warn is None
+    assert row.on_hand_qty == Decimal(5)
+    await db_session.refresh(p)
+    assert p.stock_qty == 5
+
+    row2, _ = await pls.adjust(db_session, product_id=p.id, location_id=a.id, delta=Decimal(-2))
+    assert row2.on_hand_qty == Decimal(3)
+    await db_session.refresh(p)
+    assert p.stock_qty == 3
+
+
+@pytest.mark.asyncio
+async def test_soft_warn_on_negative(db_session):
+    a, _ = await _two_locs(db_session)
+    p = await _product(db_session, stock=0)
+
+    _, warn = await pls.adjust(db_session, product_id=p.id, location_id=a.id, delta=Decimal(-3))
+    assert warn is not None
+    assert warn.projected_on_hand == Decimal(-3)
+
+
+@pytest.mark.asyncio
+async def test_hard_block_when_setting_enabled(db_session):
+    a, _ = await _two_locs(db_session)
+    p = await _product(db_session, stock=0)
+    db_session.add(Setting(key=pls.PREVENT_NEGATIVE_STOCK_KEY, value="true"))
+    await db_session.flush()
+
+    with pytest.raises(pls.NegativeStockBlockedError):
+        await pls.adjust(db_session, product_id=p.id, location_id=a.id, delta=Decimal(-1))
+
+
+@pytest.mark.asyncio
+async def test_transfer_ship_decrements_source_receive_increments_dest(db_session):
+    a, b = await _two_locs(db_session)
+    p = await _product(db_session, stock=0)
+    # Seed 10 at source.
+    await pls.adjust(db_session, product_id=p.id, location_id=a.id, delta=Decimal(10))
+
+    transfer = await create_transfer(
+        db_session,
+        from_location_id=a.id,
+        to_location_id=b.id,
+        lines=[{"kind": "product", "product_id": p.id, "quantity": Decimal(4)}],
+    )
+
+    await ship_transfer(db_session, transfer.id)
+    assert await pls.get_on_hand(db_session, product_id=p.id, location_id=a.id) == Decimal(6)
+    assert await pls.get_on_hand(db_session, product_id=p.id, location_id=b.id) == Decimal(0)
+    # In-transit is visible at destination.
+    assert await pls.in_transit_to(db_session, product_id=p.id, location_id=b.id) == Decimal(4)
+
+    await receive_transfer(db_session, transfer.id)
+    assert await pls.get_on_hand(db_session, product_id=p.id, location_id=b.id) == Decimal(4)
+    assert await pls.in_transit_to(db_session, product_id=p.id, location_id=b.id) == Decimal(0)
+
+
+@pytest.mark.asyncio
+async def test_cancel_in_transit_restores_source(db_session):
+    a, b = await _two_locs(db_session)
+    p = await _product(db_session, stock=0)
+    await pls.adjust(db_session, product_id=p.id, location_id=a.id, delta=Decimal(10))
+
+    transfer = await create_transfer(
+        db_session,
+        from_location_id=a.id,
+        to_location_id=b.id,
+        lines=[{"kind": "product", "product_id": p.id, "quantity": Decimal(4)}],
+    )
+    await ship_transfer(db_session, transfer.id)
+    await cancel_transfer(db_session, transfer.id)
+    assert await pls.get_on_hand(db_session, product_id=p.id, location_id=a.id) == Decimal(10)
+
+
+@pytest.mark.asyncio
+async def test_sale_decrements_resolved_fulfillment_location(db_session):
+    a, b = await _two_locs(db_session)
+    p = await _product(db_session, stock=0)
+    await pls.adjust(db_session, product_id=p.id, location_id=a.id, delta=Decimal(10))
+    await pls.adjust(db_session, product_id=p.id, location_id=b.id, delta=Decimal(10))
+    await db_session.commit()
+
+    sale = await create_sale_with_items(
+        db_session,
+        user_id=None,
+        date=dt.date.today(),
+        customer_id=None,
+        customer_name=None,
+        channel_id=None,
+        tax_profile_id=None,
+        tax_treatment="seller_collected",
+        shipping_charged=Decimal(0),
+        shipping_cost=Decimal(0),
+        tax_collected=Decimal(0),
+        payment_method=None,
+        tracking_number=None,
+        shipping_recipient_name=None,
+        shipping_company=None,
+        shipping_address_line1=None,
+        shipping_address_line2=None,
+        shipping_city=None,
+        shipping_state=None,
+        shipping_postal_code=None,
+        shipping_country=None,
+        notes=None,
+        status="pending",
+        items=[_Item(product_id=p.id, job_id=None, description="Widget", quantity=3, unit_price=Decimal("10"), unit_cost=Decimal("3"))],
+    )
+    sale.fulfillment_location_id = b.id
+    await db_session.flush()
+
+    # Hook: the create-with-items path already deducted via the resolver
+    # using sale.fulfillment_location_id == None (so default→Default).
+    # Re-run via explicit deduct_inventory_for_sale to verify the
+    # explicit-location branch.
+    items = (await db_session.execute(select(SaleItem).where(SaleItem.sale_id == sale.id))).scalars().all()
+    # Manually restore so we can re-test deduct against b.
+    for item in items:
+        await pls.adjust(db_session, product_id=item.product_id, location_id=a.id, delta=Decimal(item.quantity))
+    await deduct_inventory_for_sale(db_session, sale.id, items, user_id=None)
+
+    assert await pls.get_on_hand(db_session, product_id=p.id, location_id=b.id) == Decimal(7)
+
+
+@pytest.mark.asyncio
+async def test_sale_refund_restores_to_fulfillment_location(db_session):
+    a, b = await _two_locs(db_session)
+    p = await _product(db_session, stock=0)
+    await pls.adjust(db_session, product_id=p.id, location_id=b.id, delta=Decimal(10))
+    await db_session.flush()
+
+    sale = Sale(
+        sale_number="S-1",
+        date=dt.date.today(),
+        status="pending",
+        fulfillment_location_id=b.id,
+    )
+    db_session.add(sale)
+    await db_session.flush()
+    item = SaleItem(
+        sale_id=sale.id,
+        product_id=p.id,
+        description="Widget",
+        quantity=4,
+        unit_price=Decimal("10"),
+        line_total=Decimal("40"),
+        unit_cost=Decimal("3"),
+    )
+    db_session.add(item)
+    await db_session.flush()
+
+    await deduct_inventory_for_sale(db_session, sale.id, [item])
+    assert await pls.get_on_hand(db_session, product_id=p.id, location_id=b.id) == Decimal(6)
+
+    # Reload with items relationship.
+    full = (
+        await db_session.execute(
+            select(Sale).where(Sale.id == sale.id)
+        )
+    ).scalar_one()
+    # SaleItem relationship lazy load is tricky in async; fetch manually.
+    full_items = (
+        await db_session.execute(
+            select(SaleItem).where(SaleItem.sale_id == sale.id)
+        )
+    ).scalars().all()
+
+    # Restore_inventory uses sale.items; emulate by attaching.
+    class _SaleLike:
+        def __init__(self, sale, items):
+            self.id = sale.id
+            self.sale_number = sale.sale_number
+            self.fulfillment_location_id = sale.fulfillment_location_id
+            self.items = items
+
+    await restore_inventory_for_refund(db_session, _SaleLike(full, full_items))
+    assert await pls.get_on_hand(db_session, product_id=p.id, location_id=b.id) == Decimal(10)
+
+
+@pytest.mark.asyncio
+async def test_product_stock_endpoint_reports_in_transit(client: AsyncClient, auth_headers, db_session):
+    a, b = await _two_locs(db_session)
+    p = await _product(db_session, stock=0)
+    await pls.adjust(db_session, product_id=p.id, location_id=a.id, delta=Decimal(10))
+    transfer = await create_transfer(
+        db_session,
+        from_location_id=a.id,
+        to_location_id=b.id,
+        lines=[{"kind": "product", "product_id": p.id, "quantity": Decimal(3)}],
+    )
+    await ship_transfer(db_session, transfer.id)
+    await db_session.commit()
+
+    r = await client.get(f"/api/v1/inventory/locations/{b.id}/product-stock", headers=auth_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 0 or all(Decimal(row["on_hand_qty"]) == Decimal(0) for row in body)
+
+    r2 = await client.get(f"/api/v1/inventory/locations/{a.id}/product-stock", headers=auth_headers)
+    assert r2.status_code == 200
+    row = [row for row in r2.json() if row["product_id"] == str(p.id)][0]
+    assert Decimal(row["on_hand_qty"]) == Decimal(7)
+    # Source has no in-transit-to itself.
+    assert Decimal(row["in_transit_to_qty"]) == Decimal(0)
+
+
+@pytest.mark.asyncio
+async def test_prevent_negative_stock_toggle_round_trip(client: AsyncClient, auth_headers, db_session):
+    r0 = await client.get("/api/v1/inventory/prevent-negative-stock", headers=auth_headers)
+    assert r0.status_code == 200
+    assert r0.json()["enabled"] is False
+
+    r1 = await client.put(
+        "/api/v1/inventory/prevent-negative-stock",
+        json={"enabled": True},
+        headers=auth_headers,
+    )
+    assert r1.status_code == 200
+    assert r1.json()["enabled"] is True
+
+    r2 = await client.get("/api/v1/inventory/prevent-negative-stock", headers=auth_headers)
+    assert r2.json()["enabled"] is True

--- a/docs/inventory_locations.md
+++ b/docs/inventory_locations.md
@@ -1,28 +1,67 @@
-# Inventory Locations + Transfers (Phase 1)
+# Inventory Locations + Transfers
 
-Operators can model physical/logical inventory buckets (workshop, packaging, consignment, marketplace FBA) and record transfers between them. #245.
+Operators model physical/logical inventory buckets (workshop, packaging, consignment, marketplace FBA) and record transfers between them. Originally #245 (Phase 1); per-location stock + fulfillment routing extended in #318 (Phase 2).
 
-## Phase 1 scope (this PR)
+## Phase 1 — locations + transfer document
 
-- **`InventoryLocation` model + Default seed.** Migration creates the table and seeds a `Default` location so single-location operators see no behavior change.
+- **`InventoryLocation` model + Default seed.** A `Default` location is auto-seeded so single-location operators see no behavior change.
 - **`InventoryTransfer` + `InventoryTransferLine` models.** Lines accept material/supply/product kinds with quantity.
 - **Transfer lifecycle**: `pending → in_transit (ship) → completed (receive)`. Cancellation allowed from `pending` or `in_transit`.
 - **Allocator scope**: `inventory_transfer` registered with format `IT-{year}-{value:04d}` in #243's allocator.
 - **No GL impact** — transfers are operational, not financial.
 - **CRUD endpoints**: `/api/v1/inventory/locations`, `/api/v1/inventory/transfers`, plus `ship`, `receive`, `cancel`.
 
-## Phase 2 follow-ups (deferred)
+## Phase 2 — per-location stock SoT + sale fulfillment routing
 
-Each could be its own issue when prioritized:
+### `ProductLocationStock` — source of truth
 
-1. **Per-location qty decrement.** Phase 1 records the transfer document but does not yet decrement source-side qty or increment destination-side qty in the existing inventory tracking. Material/supply/product on-hand stays in the global single-bucket model. Requires backfilling `material_receipt.location_id` and `inventory_transaction.location_id` on existing rows, plus rewiring consumption/sale paths to source from a chosen location.
-2. **Sale-side fulfillment-from-location.** `Sale.fulfillment_location_id` (with channel-level default via `SalesChannel.default_fulfillment_location_id` and a global `default_fulfillment_location_id` setting). Auto-pick on marketplace orders.
-3. **Soft-warn on negative stock** with a `prevent_negative_stock` settings toggle (default off).
-4. **Frontend**: `/inventory/transfers` route + locations CRUD UI under `/admin`. Per-location qty column on inventory list pages.
-5. **In-transit hold computation** — the available qty at a source location subtracts in-transit holds.
-6. **Multi-location reorder points / min-stock thresholds.**
-7. **Per-location physical addresses** (for shipping to/from).
+- New table `product_location_stock` keys `(product_id, location_id)` and holds the `on_hand_qty` for that pair.
+- `Product.stock_qty` is kept in sync as the aggregate sum across locations so existing single-bucket reads keep working.
+- Migration `20260511_01_product_location_stock.py` backfills each product's existing `stock_qty` to the seeded `Default` location.
+
+### Movement rules
+
+| Event | Source on-hand | Destination on-hand |
+| --- | --- | --- |
+| Transfer **ship** | decrements immediately | unchanged (in-transit only) |
+| Transfer **receive** | unchanged | increments |
+| Transfer **cancel** while `in_transit` | restored | unchanged |
+| Transfer **cancel** while `pending` | unchanged | unchanged |
+| Sale fulfillment | decrements resolved fulfillment location | — |
+| Refund / cancel | restored to original fulfillment location | — |
+
+`in_transit_to_qty` is computed live from `inventory_transfer_lines` joined to transfers in `in_transit` status; it is never stored as a separate hold.
+
+### Fulfillment location resolution
+
+`product_location_stock_service.resolve_fulfillment_location_id` returns, in order:
+
+1. `Sale.fulfillment_location_id` if set.
+2. Setting `inventory.default_fulfillment_location_id` (managed via `PUT /api/v1/inventory/default-fulfillment-location`).
+3. The auto-seeded `Default` location (created on demand).
+
+### Negative-stock policy
+
+- **Soft-warn (default).** Decrements that drive projected on-hand below zero return a `StockWarning` record from `pls.adjust`; callers may surface it. Sales still complete.
+- **Hard-block.** Setting `inventory.prevent_negative_stock = "true"` (managed via `PUT /api/v1/inventory/prevent-negative-stock`) turns the same condition into `NegativeStockBlockedError`. Sales routes raise that as the existing `InsufficientStockError`, so the route layer needs no change.
+
+### Endpoints
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/v1/inventory/locations/{id}/product-stock` | Per-product on-hand + in-transit-to + projected at this location (SoT). |
+| GET | `/api/v1/inventory/locations/{id}/stock-snapshot` | Back-compat snapshot derived from completed transfers (Phase 1). |
+| GET / PUT | `/api/v1/inventory/default-fulfillment-location` | Read/set the fallback fulfillment location. |
+| GET / PUT | `/api/v1/inventory/prevent-negative-stock` | Read/set the hard-block toggle. |
+
+## Phase 2 follow-ups (still deferred)
+
+- **Materials / supplies per-location SoT.** Transfer documents already carry material/supply lines, but only product lines feed `ProductLocationStock`. Material consumption stays single-bucket until this lands.
+- **Frontend.** Multi-location surfaces (`/inventory/transfers` UI, per-location qty column on inventory list pages, fulfillment-location picker on sale form) — backend is ready; UI is a follow-up.
+- **Multi-location reorder points / min-stock thresholds.**
+- **Per-location physical addresses** (for shipping to/from).
+- **Channel-level default fulfillment location** (`SalesChannel.default_fulfillment_location_id`) — currently the only fallback is the global setting.
 
 ## Allocator note
 
-The `inventory_transfer` scope is now registered in `app.services.reference_number_service.FORMATS`. New scopes should follow the same pattern — one line in `FORMATS` and the parser will accept it everywhere.
+The `inventory_transfer` scope is registered in `app.services.reference_number_service.FORMATS`. New scopes follow the same pattern — one line in `FORMATS` and the parser accepts it everywhere.

--- a/docs/issue_priority.md
+++ b/docs/issue_priority.md
@@ -2,7 +2,7 @@
 
 > **Source of truth for which issue to pick up next.** Updated as issues land, dependencies shift, or scope changes. Cross-session readers (and future Claude sessions) should start here when asked "what's next."
 >
-> **Last reviewed:** 2026-05-10 — Manager.io gap walk substantively complete. 5 trackers open; no Tier 1 / Tier 2 items remain. Total 629 backend tests passing. 60+ PRs landed since 2026-05-09.
+> **Last reviewed:** 2026-05-11 — #318 multi-location Phase 2 deeper SoT shipping (ProductLocationStock + per-location sale decrement + soft-warn + in-transit hold). 4 P2 trackers remain. 638 backend tests passing.
 
 ---
 


### PR DESCRIPTION
## Summary
Closes the #318 backend Phase 2 scope:
- New `ProductLocationStock` table is the per-(product, location) source of truth. `Product.stock_qty` remains in sync as the aggregate sum across locations.
- Transfer **ship** decrements source on-hand; **receive** increments destination; **cancel** while in-transit restores source.
- Sale fulfillment decrements the resolved location; refunds restore there. Resolution order: `Sale.fulfillment_location_id` → setting → auto-seeded `Default`.
- Negative-stock policy: soft-warn by default; flip `inventory.prevent_negative_stock=true` for hard-block (raised as the existing `InsufficientStockError`).
- New endpoints: `GET /inventory/locations/{id}/product-stock` (SoT read with in-transit), `GET/PUT /inventory/prevent-negative-stock`.
- Migration backfills the Default location from legacy `Product.stock_qty`; the service does the same lazily for any in-flight rows.

## Out of scope (still deferred under #318)
- Materials / supplies per-location SoT (only product lines feed the SoT — material consumption stays single-bucket).
- Frontend (`/inventory/transfers` UI, fulfillment-location picker on sale form, per-location qty column).
- Channel-level default fulfillment location.

## Test plan
- [x] `pytest backend/tests` — 638 passed, 2 unrelated warnings (~9 min).
- [x] New tests in `backend/tests/test_p2_318_stock_sot.py` (9): adjust + aggregate, soft-warn, hard-block, transfer ship/receive/cancel-in-transit, sale decrement, refund restore, in-transit endpoint, settings round-trip.
- [x] Existing `test_api_pos.py` and `test_api_sales.py` exercise the legacy-backfill path.
- [ ] Post-merge: deploy on web01 runs `alembic upgrade head` (covered by PR #356 deploy hardening).

## Docs
- `docs/inventory_locations.md` — Phase 2 section added (SoT, movement rules, resolution, negative-stock policy, endpoints, remaining follow-ups).
- `docs/issue_priority.md` — "Last reviewed" bumped to 2026-05-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)