### PR TITLE
feat(banking): #316 P2 deeper — receipt/payment/IAT bank-rule actions

### DIFF
--- a/backend/alembic/versions/20260511_02_bank_rule_targets.py
+++ b/backend/alembic/versions/20260511_02_bank_rule_targets.py
@@ -1,0 +1,46 @@
+"""#316 P2: bank-rule target FKs for receipt/payment/IAT actions
+
+Revision ID: 20260511_02
+Revises: 20260511_01
+Create Date: 2026-05-11 11:30:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260511_02"
+down_revision = "20260511_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("statement_match_rules") as batch:
+        batch.add_column(sa.Column("customer_id", sa.UUID(), nullable=True))
+        batch.add_column(sa.Column("vendor_id", sa.UUID(), nullable=True))
+        batch.add_column(sa.Column("transfer_to_account_id", sa.UUID(), nullable=True))
+        batch.create_foreign_key(
+            "fk_match_rule_customer", "customers", ["customer_id"], ["id"]
+        )
+        batch.create_foreign_key(
+            "fk_match_rule_vendor", "vendors", ["vendor_id"], ["id"]
+        )
+        batch.create_foreign_key(
+            "fk_match_rule_transfer_to_account",
+            "accounts",
+            ["transfer_to_account_id"],
+            ["id"],
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("statement_match_rules") as batch:
+        batch.drop_constraint("fk_match_rule_transfer_to_account", type_="foreignkey")
+        batch.drop_constraint("fk_match_rule_vendor", type_="foreignkey")
+        batch.drop_constraint("fk_match_rule_customer", type_="foreignkey")
+        batch.drop_column("transfer_to_account_id")
+        batch.drop_column("vendor_id")
+        batch.drop_column("customer_id")

--- a/backend/app/api/v1/endpoints/statement_match_rules.py
+++ b/backend/app/api/v1/endpoints/statement_match_rules.py
@@ -58,7 +58,7 @@ class RuleUpdate(BaseModel):
         "create_inter_account_transfer",
     ] | None = None
     category_account_id: uuid.UUID | None = None
-    counterparty_name: str | None = None
+    counterparty_name: str | None = Field(None, max_length=200)
     customer_id: uuid.UUID | None = None
     vendor_id: uuid.UUID | None = None
     transfer_to_account_id: uuid.UUID | None = None
@@ -210,7 +210,7 @@ class CreateFromLineBody(BaseModel):
     customer_id: uuid.UUID | None = None
     vendor_id: uuid.UUID | None = None
     transfer_to_account_id: uuid.UUID | None = None
-    counterparty_name: str | None = None
+    counterparty_name: str | None = Field(None, max_length=200)
 
 
 @router.post(

--- a/backend/app/api/v1/endpoints/statement_match_rules.py
+++ b/backend/app/api/v1/endpoints/statement_match_rules.py
@@ -28,9 +28,18 @@ class RuleCreate(BaseModel):
     match_type: Literal["contains", "regex"]
     match_pattern: str = Field(..., min_length=1, max_length=500)
     match_amount_sign: Literal["debit", "credit", "any"] = "any"
-    action: Literal["ignore", "create_journal_entry"] = "ignore"
+    action: Literal[
+        "ignore",
+        "create_journal_entry",
+        "create_receipt",
+        "create_payment",
+        "create_inter_account_transfer",
+    ] = "ignore"
     category_account_id: uuid.UUID | None = None
     counterparty_name: str | None = Field(None, max_length=200)
+    customer_id: uuid.UUID | None = None
+    vendor_id: uuid.UUID | None = None
+    transfer_to_account_id: uuid.UUID | None = None
     priority: int = Field(100, ge=0)
     is_active: bool = True
 
@@ -41,9 +50,18 @@ class RuleUpdate(BaseModel):
     match_type: Literal["contains", "regex"] | None = None
     match_pattern: str | None = Field(None, max_length=500)
     match_amount_sign: Literal["debit", "credit", "any"] | None = None
-    action: Literal["ignore", "create_journal_entry"] | None = None
+    action: Literal[
+        "ignore",
+        "create_journal_entry",
+        "create_receipt",
+        "create_payment",
+        "create_inter_account_transfer",
+    ] | None = None
     category_account_id: uuid.UUID | None = None
     counterparty_name: str | None = None
+    customer_id: uuid.UUID | None = None
+    vendor_id: uuid.UUID | None = None
+    transfer_to_account_id: uuid.UUID | None = None
     priority: int | None = Field(None, ge=0)
     is_active: bool | None = None
 
@@ -58,6 +76,9 @@ class RuleResponse(BaseModel):
     action: str
     category_account_id: uuid.UUID | None = None
     counterparty_name: str | None = None
+    customer_id: uuid.UUID | None = None
+    vendor_id: uuid.UUID | None = None
+    transfer_to_account_id: uuid.UUID | None = None
     priority: int
     is_active: bool
     created_at: datetime
@@ -74,6 +95,9 @@ def _to_response(r: StatementMatchRule) -> RuleResponse:
         action=r.action,
         category_account_id=r.category_account_id,
         counterparty_name=r.counterparty_name,
+        customer_id=r.customer_id,
+        vendor_id=r.vendor_id,
+        transfer_to_account_id=r.transfer_to_account_id,
         priority=r.priority,
         is_active=r.is_active,
         created_at=r.created_at,
@@ -96,6 +120,10 @@ async def create_rule_ep(body: RuleCreate, user: CurrentUser, db: DB):
             match_pattern=body.match_pattern,
             match_amount_sign=body.match_amount_sign,
             action=body.action,
+            category_account_id=body.category_account_id,
+            customer_id=body.customer_id,
+            vendor_id=body.vendor_id,
+            transfer_to_account_id=body.transfer_to_account_id,
         )
     except StatementMatchRuleError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
@@ -108,6 +136,9 @@ async def create_rule_ep(body: RuleCreate, user: CurrentUser, db: DB):
         action=body.action,
         category_account_id=body.category_account_id,
         counterparty_name=body.counterparty_name,
+        customer_id=body.customer_id,
+        vendor_id=body.vendor_id,
+        transfer_to_account_id=body.transfer_to_account_id,
         priority=body.priority,
         is_active=body.is_active,
     )
@@ -130,6 +161,10 @@ async def update_rule_ep(rule_id: uuid.UUID, body: RuleUpdate, user: CurrentUser
             match_pattern=r.match_pattern,
             match_amount_sign=r.match_amount_sign,
             action=r.action,
+            category_account_id=r.category_account_id,
+            customer_id=r.customer_id,
+            vendor_id=r.vendor_id,
+            transfer_to_account_id=r.transfer_to_account_id,
         )
     except StatementMatchRuleError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
@@ -164,8 +199,18 @@ async def preview_rules_ep(import_id: uuid.UUID, user: CurrentUser, db: DB):
 class CreateFromLineBody(BaseModel):
     statement_line_id: uuid.UUID
     name: str = Field(..., min_length=1, max_length=120)
-    action: Literal["ignore", "create_journal_entry"] = "ignore"
+    action: Literal[
+        "ignore",
+        "create_journal_entry",
+        "create_receipt",
+        "create_payment",
+        "create_inter_account_transfer",
+    ] = "ignore"
     category_account_id: uuid.UUID | None = None
+    customer_id: uuid.UUID | None = None
+    vendor_id: uuid.UUID | None = None
+    transfer_to_account_id: uuid.UUID | None = None
+    counterparty_name: str | None = None
 
 
 @router.post(
@@ -182,6 +227,10 @@ async def create_from_line_ep(body: CreateFromLineBody, user: CurrentUser, db: D
             name=body.name,
             action=body.action,
             category_account_id=body.category_account_id,
+            customer_id=body.customer_id,
+            vendor_id=body.vendor_id,
+            transfer_to_account_id=body.transfer_to_account_id,
+            counterparty_name=body.counterparty_name,
         )
     except StatementMatchRuleError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e

--- a/backend/app/models/statement_match_rule.py
+++ b/backend/app/models/statement_match_rule.py
@@ -40,6 +40,18 @@ class StatementMatchRule(Base):
         ForeignKey("accounts.id"), nullable=True
     )
     counterparty_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    # #316 P2 deeper: AR/AP/IAT targets so the rule can post against a
+    # specific customer, vendor, or transfer destination instead of a
+    # raw P&L category. Exactly one of these is consulted per action.
+    customer_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("customers.id"), nullable=True
+    )
+    vendor_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("vendors.id"), nullable=True
+    )
+    transfer_to_account_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("accounts.id"), nullable=True
+    )
     priority: Mapped[int] = mapped_column(Integer, default=100, index=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/services/statement_match_rule_service.py
+++ b/backend/app/services/statement_match_rule_service.py
@@ -28,7 +28,13 @@ class StatementMatchRuleError(RuntimeError):
     pass
 
 
-SUPPORTED_ACTIONS = {"ignore", "create_journal_entry"}  # #316 P2
+SUPPORTED_ACTIONS = {
+    "ignore",
+    "create_journal_entry",
+    "create_receipt",  # #316 P2 deeper: AR customer payment
+    "create_payment",  # #316 P2 deeper: AP vendor payment
+    "create_inter_account_transfer",  # #316 P2 deeper: own-account transfer
+}
 
 
 def _matches_pattern(rule: StatementMatchRule, description: str) -> bool:
@@ -107,8 +113,13 @@ async def apply_rules_to_import(
     Returns a summary dict of counts.
     """
     from app.models.account import Account
+    from app.models.payment import Payment
     from app.schemas.accounting import JournalEntryCreate, JournalLineCreate
     from app.services.accounting_service import create_journal_entry as _create_je
+    from app.services.inter_account_transfer_service import (
+        InterAccountTransferError,
+        create_inter_account_transfer,
+    )
 
     lines = (
         await db.execute(
@@ -126,7 +137,26 @@ async def apply_rules_to_import(
 
     auto_ignored = 0
     auto_je = 0
+    auto_receipt = 0
+    auto_payment = 0
+    auto_iat = 0
     skipped_unsupported = 0
+
+    async def _link_bank_line(line, je, bank_account_id):
+        """Link the bank-side JournalLine of the JE to the statement line so
+        reconciliation pulls the new posting in."""
+        from app.models.journal_line import JournalLine
+
+        bank_line = (
+            await db.execute(
+                select(JournalLine).where(
+                    JournalLine.journal_entry_id == je.id,
+                    JournalLine.account_id == bank_account_id,
+                )
+            )
+        ).scalar_one()
+        line.matched_journal_line_id = bank_line.id
+
     for line in lines:
         rule = await evaluate_rules_for_line(db, line, rules=active_rules)
         if rule is None:
@@ -166,19 +196,122 @@ async def apply_rules_to_import(
                 ),
             )
             line.match_status = "matched"
-            # Link the bank-side JE line so reconciliation pulls it
+            await _link_bank_line(line, je, bank.id)
+            auto_je += 1
+        elif rule.action == "create_receipt":
+            # AR customer payment: Dr bank, Cr Accounts Receivable. Create a
+            # `Payment` row tied to the customer with the full amount sitting
+            # in `unapplied_amount` so the operator can later apply it to one
+            # or more invoices.
+            if rule.customer_id is None or Decimal(line.amount) <= 0:
+                skipped_unsupported += 1
+                continue
+            ar = (
+                await db.execute(select(Account).where(Account.code == "1100"))
+            ).scalar_one_or_none()
+            bank = (
+                await db.execute(select(Account).where(Account.id == line.account_id))
+            ).scalar_one_or_none()
+            if ar is None or bank is None:
+                skipped_unsupported += 1
+                continue
+            amt = abs(Decimal(line.amount))
+            je = await _create_je(
+                db,
+                JournalEntryCreate(
+                    entry_date=line.posted_date,
+                    memo=f"[rule:{rule.name}] receipt {line.description[:140]}",
+                    lines=[
+                        JournalLineCreate(account_id=bank.id, entry_type="debit", amount=amt),
+                        JournalLineCreate(account_id=ar.id, entry_type="credit", amount=amt),
+                    ],
+                ),
+            )
+            payment = Payment(
+                customer_id=rule.customer_id,
+                payment_date=line.posted_date,
+                amount=amt,
+                unapplied_amount=amt,
+                notes=f"Auto-receipt from bank rule '{rule.name}' (line {line.id})",
+            )
+            db.add(payment)
+            line.match_status = "matched"
+            await _link_bank_line(line, je, bank.id)
+            auto_receipt += 1
+        elif rule.action == "create_payment":
+            # AP vendor payment: Dr Accounts Payable, Cr bank. We don't have
+            # an "unapplied BillPayment" concept, so just post the JE and
+            # leave the AP balance available for an operator to reconcile
+            # against bills manually.
+            if rule.vendor_id is None or Decimal(line.amount) >= 0:
+                skipped_unsupported += 1
+                continue
+            ap = (
+                await db.execute(select(Account).where(Account.code == "2000"))
+            ).scalar_one_or_none()
+            bank = (
+                await db.execute(select(Account).where(Account.id == line.account_id))
+            ).scalar_one_or_none()
+            if ap is None or bank is None:
+                skipped_unsupported += 1
+                continue
+            amt = abs(Decimal(line.amount))
+            je = await _create_je(
+                db,
+                JournalEntryCreate(
+                    entry_date=line.posted_date,
+                    memo=f"[rule:{rule.name}] payment {line.description[:140]}",
+                    lines=[
+                        JournalLineCreate(account_id=ap.id, entry_type="debit", amount=amt),
+                        JournalLineCreate(account_id=bank.id, entry_type="credit", amount=amt),
+                    ],
+                ),
+            )
+            line.match_status = "matched"
+            await _link_bank_line(line, je, bank.id)
+            auto_payment += 1
+        elif rule.action == "create_inter_account_transfer":
+            if rule.transfer_to_account_id is None:
+                skipped_unsupported += 1
+                continue
+            if rule.transfer_to_account_id == line.account_id:
+                skipped_unsupported += 1
+                continue
+            amt = abs(Decimal(line.amount))
+            # Direction: an outflow on this statement (negative amount) is
+            # the "from" leg; an inflow is the "to" leg. The IAT service
+            # always takes (from, to, amount, paid_on); flip accordingly.
+            if Decimal(line.amount) < 0:
+                from_acct, to_acct = line.account_id, rule.transfer_to_account_id
+            else:
+                from_acct, to_acct = rule.transfer_to_account_id, line.account_id
+            try:
+                iat = await create_inter_account_transfer(
+                    db,
+                    from_account_id=from_acct,
+                    to_account_id=to_acct,
+                    amount=amt,
+                    paid_on=line.posted_date,
+                    notes=f"Auto-IAT from bank rule '{rule.name}' (line {line.id})",
+                )
+            except InterAccountTransferError:
+                skipped_unsupported += 1
+                continue
+            line.match_status = "matched"
+            # Link this statement line to its own side of the IAT's JE so
+            # reconciliation pulls the matching leg.
             from app.models.journal_line import JournalLine
 
-            bank_line = (
+            own_leg = (
                 await db.execute(
                     select(JournalLine).where(
-                        JournalLine.journal_entry_id == je.id,
-                        JournalLine.account_id == bank.id,
+                        JournalLine.journal_entry_id == iat.journal_entry_id,
+                        JournalLine.account_id == line.account_id,
                     )
                 )
             ).scalar_one()
-            line.matched_journal_line_id = bank_line.id
-            auto_je += 1
+            line.matched_journal_line_id = own_leg.id
+            auto_iat += 1
         else:
             skipped_unsupported += 1
 
@@ -187,6 +320,9 @@ async def apply_rules_to_import(
         "considered": len(lines),
         "auto_ignored": auto_ignored,
         "auto_journal_entries": auto_je,
+        "auto_receipts": auto_receipt,
+        "auto_payments": auto_payment,
+        "auto_inter_account_transfers": auto_iat,
         "skipped_unsupported_actions": skipped_unsupported,
     }
 
@@ -232,6 +368,34 @@ async def preview_rules_for_import(
             ).scalar_one_or_none()
             if cat is not None:
                 cat_label = f"{cat.code} {cat.name}"
+        # #316 P2 deeper: also surface customer/vendor/transfer-to so the
+        # operator can sanity-check the post target before applying.
+        target_label = None
+        if rule.action == "create_receipt" and rule.customer_id is not None:
+            from app.models.customer import Customer
+            c = (
+                await db.execute(select(Customer).where(Customer.id == rule.customer_id))
+            ).scalar_one_or_none()
+            if c is not None:
+                target_label = f"customer: {c.name}"
+        elif rule.action == "create_payment" and rule.vendor_id is not None:
+            from app.models.vendor import Vendor
+            v = (
+                await db.execute(select(Vendor).where(Vendor.id == rule.vendor_id))
+            ).scalar_one_or_none()
+            if v is not None:
+                target_label = f"vendor: {v.name}"
+        elif (
+            rule.action == "create_inter_account_transfer"
+            and rule.transfer_to_account_id is not None
+        ):
+            other = (
+                await db.execute(
+                    select(Account).where(Account.id == rule.transfer_to_account_id)
+                )
+            ).scalar_one_or_none()
+            if other is not None:
+                target_label = f"transfer to: {other.code} {other.name}"
         out.append(
             {
                 "statement_line_id": str(line.id),
@@ -242,6 +406,7 @@ async def preview_rules_for_import(
                     "name": rule.name,
                     "action": rule.action,
                     "category_account": cat_label,
+                    "target": target_label,
                 },
             }
         )
@@ -260,12 +425,18 @@ async def create_rule_from_line(
     name: str,
     action: str,
     category_account_id: uuid.UUID | None = None,
+    customer_id: uuid.UUID | None = None,
+    vendor_id: uuid.UUID | None = None,
+    transfer_to_account_id: uuid.UUID | None = None,
+    counterparty_name: str | None = None,
     match_type: str = "contains",
 ) -> StatementMatchRule:
     """#316 P2: derive a starter rule from a staged statement line.
 
     Defaults to a "contains" pattern using a sanitized prefix of the line's
-    description. Operator can edit later.
+    description. Operator can edit later. The receipt/payment/IAT
+    actions accept their respective target (customer/vendor/account) so
+    the resulting rule is immediately apply-able.
     """
     line = (
         await db.execute(select(StatementLine).where(StatementLine.id == statement_line_id))
@@ -279,6 +450,10 @@ async def create_rule_from_line(
         match_pattern=pattern,
         match_amount_sign=sign,
         action=action,
+        category_account_id=category_account_id,
+        customer_id=customer_id,
+        vendor_id=vendor_id,
+        transfer_to_account_id=transfer_to_account_id,
     )
     rule = StatementMatchRule(
         name=name,
@@ -288,6 +463,10 @@ async def create_rule_from_line(
         match_amount_sign=sign,
         action=action,
         category_account_id=category_account_id,
+        customer_id=customer_id,
+        vendor_id=vendor_id,
+        transfer_to_account_id=transfer_to_account_id,
+        counterparty_name=counterparty_name,
     )
     db.add(rule)
     await db.flush()
@@ -300,6 +479,10 @@ def validate_rule(
     match_pattern: str,
     match_amount_sign: str,
     action: str,
+    category_account_id: uuid.UUID | None = None,
+    customer_id: uuid.UUID | None = None,
+    vendor_id: uuid.UUID | None = None,
+    transfer_to_account_id: uuid.UUID | None = None,
 ) -> None:
     if match_type not in ("contains", "regex"):
         raise StatementMatchRuleError(f"Unknown match_type: {match_type}")
@@ -314,6 +497,20 @@ def validate_rule(
         raise StatementMatchRuleError(f"Unknown match_amount_sign: {match_amount_sign}")
     if action not in SUPPORTED_ACTIONS:
         raise StatementMatchRuleError(
-            f"Action {action!r} is declared but not implemented in Phase 1; "
-            f"supported actions: {sorted(SUPPORTED_ACTIONS)}"
+            f"Unknown action {action!r}; supported actions: {sorted(SUPPORTED_ACTIONS)}"
+        )
+    # Per-action field requirements. The DB-level FKs are nullable to keep
+    # the rule editable across action changes, but a rule that *will fire*
+    # must have its target column populated.
+    if action == "create_journal_entry" and category_account_id is None:
+        raise StatementMatchRuleError(
+            "create_journal_entry requires category_account_id"
+        )
+    if action == "create_receipt" and customer_id is None:
+        raise StatementMatchRuleError("create_receipt requires customer_id")
+    if action == "create_payment" and vendor_id is None:
+        raise StatementMatchRuleError("create_payment requires vendor_id")
+    if action == "create_inter_account_transfer" and transfer_to_account_id is None:
+        raise StatementMatchRuleError(
+            "create_inter_account_transfer requires transfer_to_account_id"
         )

--- a/backend/tests/test_p2_316_bank_rule_actions.py
+++ b/backend/tests/test_p2_316_bank_rule_actions.py
@@ -1,0 +1,200 @@
+"""#316 P2 deeper: create_receipt / create_payment / create_inter_account_transfer."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.customer import Customer
+from app.models.inter_account_transfer import InterAccountTransfer
+from app.models.payment import Payment
+from app.models.statement_import import StatementLine
+from app.models.statement_match_rule import StatementMatchRule
+from app.models.vendor import Vendor
+from app.services.statement_import_service import import_statement
+from app.services.statement_match_rule_service import (
+    apply_rules_to_import,
+    preview_rules_for_import,
+)
+
+
+SAMPLE_OFX = """
+<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><BANKTRANLIST>
+<STMTTRN><DTPOSTED>20260501<TRNAMT>250.00<FITID>F-CUST<NAME>ACME inc payment</STMTTRN>
+<STMTTRN><DTPOSTED>20260502<TRNAMT>-180.00<FITID>F-VEND<NAME>Filament Co invoice</STMTTRN>
+<STMTTRN><DTPOSTED>20260503<TRNAMT>-1000.00<FITID>F-XFER<NAME>Online transfer to savings</STMTTRN>
+</BANKTRANLIST></STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>
+"""
+
+
+async def _bank(db, code="1010", name="Operating") -> Account:
+    a = Account(
+        code=code, name=name, account_type="asset",
+        normal_balance="debit", is_bank_account=True, bank_account_kind="checking",
+    )
+    db.add(a)
+    await db.flush()
+    return a
+
+
+async def _ensure_ar_ap(db):
+    if (await db.execute(select(Account).where(Account.code == "1100"))).scalar_one_or_none() is None:
+        db.add(Account(code="1100", name="Accounts Receivable", account_type="asset", normal_balance="debit"))
+    if (await db.execute(select(Account).where(Account.code == "2000"))).scalar_one_or_none() is None:
+        db.add(Account(code="2000", name="Accounts Payable", account_type="liability", normal_balance="credit"))
+    await db.flush()
+
+
+@pytest.mark.asyncio
+async def test_create_receipt_posts_je_and_unapplied_payment(db_session):
+    await _ensure_ar_ap(db_session)
+    bank = await _bank(db_session)
+    cust = Customer(name="ACME Inc")
+    db_session.add(cust)
+    await db_session.flush()
+
+    imp = await import_statement(
+        db_session,
+        account_id=bank.id,
+        source_format="ofx",
+        source_filename="x.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    db_session.add(StatementMatchRule(
+        name="ACME receipts", match_type="contains", match_pattern="ACME",
+        match_amount_sign="credit", action="create_receipt",
+        customer_id=cust.id, priority=10,
+    ))
+    await db_session.flush()
+
+    summary = await apply_rules_to_import(db_session, import_id=imp.id)
+    assert summary["auto_receipts"] == 1
+
+    payments = (
+        await db_session.execute(select(Payment).where(Payment.customer_id == cust.id))
+    ).scalars().all()
+    assert len(payments) == 1
+    assert payments[0].amount == Decimal("250.00")
+    assert payments[0].unapplied_amount == Decimal("250.00")
+
+    line = (
+        await db_session.execute(select(StatementLine).where(StatementLine.fitid == "F-CUST"))
+    ).scalar_one()
+    assert line.match_status == "matched"
+    assert line.matched_journal_line_id is not None
+
+
+@pytest.mark.asyncio
+async def test_create_payment_posts_ap_je(db_session):
+    await _ensure_ar_ap(db_session)
+    bank = await _bank(db_session)
+    vendor = Vendor(name="Filament Co")
+    db_session.add(vendor)
+    await db_session.flush()
+
+    imp = await import_statement(
+        db_session,
+        account_id=bank.id,
+        source_format="ofx",
+        source_filename="x.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    db_session.add(StatementMatchRule(
+        name="Filament Co payments", match_type="contains", match_pattern="Filament Co",
+        match_amount_sign="debit", action="create_payment",
+        vendor_id=vendor.id, priority=10,
+    ))
+    await db_session.flush()
+
+    summary = await apply_rules_to_import(db_session, import_id=imp.id)
+    assert summary["auto_payments"] == 1
+
+    line = (
+        await db_session.execute(select(StatementLine).where(StatementLine.fitid == "F-VEND"))
+    ).scalar_one()
+    assert line.match_status == "matched"
+    assert line.matched_journal_line_id is not None
+
+
+@pytest.mark.asyncio
+async def test_create_inter_account_transfer_creates_iat(db_session):
+    await _ensure_ar_ap(db_session)
+    bank = await _bank(db_session, code="1010", name="Operating")
+    savings = await _bank(db_session, code="1020", name="Savings")
+
+    imp = await import_statement(
+        db_session,
+        account_id=bank.id,
+        source_format="ofx",
+        source_filename="x.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    db_session.add(StatementMatchRule(
+        name="Savings transfers", match_type="contains", match_pattern="transfer to savings",
+        match_amount_sign="debit", action="create_inter_account_transfer",
+        transfer_to_account_id=savings.id, priority=10,
+    ))
+    await db_session.flush()
+
+    summary = await apply_rules_to_import(db_session, import_id=imp.id)
+    assert summary["auto_inter_account_transfers"] == 1
+
+    iats = (
+        await db_session.execute(select(InterAccountTransfer))
+    ).scalars().all()
+    assert len(iats) == 1
+    assert iats[0].from_account_id == bank.id
+    assert iats[0].to_account_id == savings.id
+    assert iats[0].amount == Decimal("1000.00")
+
+
+@pytest.mark.asyncio
+async def test_create_receipt_skipped_without_customer(db_session):
+    await _ensure_ar_ap(db_session)
+    bank = await _bank(db_session)
+    imp = await import_statement(
+        db_session,
+        account_id=bank.id,
+        source_format="ofx",
+        source_filename="x.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    db_session.add(StatementMatchRule(
+        name="Unconfigured", match_type="contains", match_pattern="ACME",
+        match_amount_sign="credit", action="create_receipt",
+        customer_id=None, priority=10,
+    ))
+    await db_session.flush()
+
+    summary = await apply_rules_to_import(db_session, import_id=imp.id)
+    assert summary["auto_receipts"] == 0
+    assert summary["skipped_unsupported_actions"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_preview_surfaces_target_label(db_session):
+    await _ensure_ar_ap(db_session)
+    bank = await _bank(db_session, code="1010", name="Operating")
+    savings = await _bank(db_session, code="1020", name="Savings")
+    imp = await import_statement(
+        db_session,
+        account_id=bank.id,
+        source_format="ofx",
+        source_filename="x.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    db_session.add(StatementMatchRule(
+        name="To savings", match_type="contains", match_pattern="transfer to savings",
+        match_amount_sign="debit", action="create_inter_account_transfer",
+        transfer_to_account_id=savings.id, priority=10,
+    ))
+    await db_session.flush()
+
+    preview = await preview_rules_for_import(db_session, import_id=imp.id)
+    matched_targets = [
+        l["matched_rule"]["target"] for l in preview["lines"] if l["matched_rule"]
+    ]
+    assert any(t and "Savings" in t for t in matched_targets)

--- a/backend/tests/test_p2_316_bank_rule_actions.py
+++ b/backend/tests/test_p2_316_bank_rule_actions.py
@@ -175,6 +175,39 @@ async def test_create_receipt_skipped_without_customer(db_session):
 
 
 @pytest.mark.asyncio
+async def test_from_line_rejects_oversized_counterparty(client, auth_headers, db_session):
+    """Codex P2: counterparty_name is capped at 200 chars in the DB; the
+    from-line payload must reject anything longer with a 4xx rather than
+    leak a 500 at commit time.
+    """
+    await _ensure_ar_ap(db_session)
+    bank = await _bank(db_session)
+    imp = await import_statement(
+        db_session,
+        account_id=bank.id,
+        source_format="ofx",
+        source_filename="x.ofx",
+        content=SAMPLE_OFX.encode(),
+    )
+    await db_session.commit()
+    line = (
+        await db_session.execute(select(StatementLine).where(StatementLine.import_id == imp.id))
+    ).scalars().first()
+
+    r = await client.post(
+        "/api/v1/banking/rules/from-line",
+        headers=auth_headers,
+        json={
+            "statement_line_id": str(line.id),
+            "name": "x",
+            "action": "ignore",
+            "counterparty_name": "A" * 201,
+        },
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_preview_surfaces_target_label(db_session):
     await _ensure_ar_ap(db_session)
     bank = await _bank(db_session, code="1010", name="Operating")

--- a/backend/tests/test_statement_match_rule_service.py
+++ b/backend/tests/test_statement_match_rule_service.py
@@ -49,7 +49,18 @@ def test_validate_rule_invalid_regex():
 
 def test_validate_rule_unsupported_action():
     with pytest.raises(StatementMatchRuleError):
-        validate_rule(match_type="contains", match_pattern="x", match_amount_sign="any", action="create_receipt")
+        validate_rule(match_type="contains", match_pattern="x", match_amount_sign="any", action="create_bogus")
+
+
+def test_validate_rule_create_receipt_requires_customer():
+    # The action is supported, but its required target field is missing.
+    with pytest.raises(StatementMatchRuleError):
+        validate_rule(
+            match_type="contains",
+            match_pattern="x",
+            match_amount_sign="any",
+            action="create_receipt",
+        )
 
 
 @pytest.mark.asyncio

--- a/docs/statement_match_rules.md
+++ b/docs/statement_match_rules.md
@@ -1,6 +1,6 @@
-# Statement Auto-Match Rules (Phase 1)
+# Statement Auto-Match Rules
 
-Operators define rules that automatically handle imported statement lines (#241). Phase 1 supports the **`ignore`** action only — auto-skip noise like ATM fees from review. Phase 2 will add `create_receipt` / `create_payment` actions that auto-post journal entries.
+Operators define rules that automatically handle imported statement lines (#241). The current shipped actions cover the full categorize-and-post workflow plus deeper AR/AP and inter-account-transfer routing (#316 Phase 2).
 
 ## Model
 
@@ -13,33 +13,43 @@ Operators define rules that automatically handle imported statement lines (#241)
 | `match_type` | `contains` (case-insensitive substring) or `regex` (Python re, case-insensitive). |
 | `match_pattern` | Substring or regex. |
 | `match_amount_sign` | `debit` (negative), `credit` (positive), or `any`. |
-| `action` | `ignore` (Phase 1). Validation rejects unsupported actions. |
+| `action` | One of the supported actions below. Validation rejects unknown values. |
 | `priority` | Lower = higher priority. First match wins. |
 | `is_active` | Inactive rules are skipped. |
+| `category_account_id` | Required when `action = create_journal_entry`. |
+| `customer_id` | Required when `action = create_receipt`. |
+| `vendor_id` | Required when `action = create_payment`. |
+| `transfer_to_account_id` | Required when `action = create_inter_account_transfer`. |
+| `counterparty_name` | Optional descriptive label. |
 
-## Behavior
+## Supported actions
 
-Rules are evaluated automatically during `import_statement` for every newly-inserted statement line, in priority order. The first matching rule's action runs:
+Rules are evaluated automatically during `import_statement` for every newly-inserted statement line, in priority order. The first matching rule's action runs.
 
-- **`ignore`** → line's `match_status` flips to `ignored` so it never appears in the review queue.
-- Other actions → silently no-op in Phase 1, counted in `skipped_unsupported_actions`.
+| Action | Effect |
+|---|---|
+| `ignore` | Line's `match_status` flips to `ignored` so it never appears in the review queue. |
+| `create_journal_entry` | Posts a balanced JE: Dr/Cr bank account vs `category_account_id` at the line's amount sign. Best for direct P&L hits (fees, interest income). |
+| `create_receipt` | Posts Dr bank, Cr Accounts Receivable (1100). Creates a `Payment` row linked to `customer_id` with the full amount in `unapplied_amount` so the operator can later apply it to one or more invoices. Only fires on credit-sign lines. |
+| `create_payment` | Posts Dr Accounts Payable (2000), Cr bank for vendor-paid outflows. No `BillPayment` row (we don't have an "unapplied BillPayment" concept yet); operator reconciles against bills manually. Only fires on debit-sign lines. |
+| `create_inter_account_transfer` | Calls `inter_account_transfer_service.create_inter_account_transfer` with `from`/`to` derived from amount sign so each leg's `posted_on` lands on the correct statement. The own-side JE leg is linked back to the statement line for reconciliation. |
 
-The `apply-rules` endpoint can be called manually to re-evaluate an existing import's pending lines after rules change.
+A rule whose target column is missing (e.g. `create_receipt` with `customer_id = null`) is counted in `skipped_unsupported_actions` rather than throwing; this lets operators stage a rule and fill in the target later.
 
 ## API
 
 | Verb | Path | Notes |
 |---|---|---|
 | `GET` | `/api/v1/banking/rules` | List, ordered by priority. |
-| `POST` | `/api/v1/banking/rules` | Create. Validates regex if `match_type=regex`; rejects unsupported actions. |
+| `POST` | `/api/v1/banking/rules` | Create. Validates regex and per-action target requirements. |
 | `PATCH` | `/api/v1/banking/rules/{id}` | Update. Re-validates on save. |
 | `DELETE` | `/api/v1/banking/rules/{id}` | Hard delete. |
-| `POST` | `/api/v1/banking/rules/imports/{import_id}/apply-rules` | Re-apply rules to existing pending lines on an import. |
+| `POST` | `/api/v1/banking/rules/imports/{import_id}/apply-rules` | Re-apply rules to existing pending lines on an import. Returns per-action counts. |
+| `GET` | `/api/v1/banking/rules/imports/{import_id}/preview` | Dry-run: returns each pending line plus the rule that would fire (with a friendly `target` label) without mutating state. |
+| `POST` | `/api/v1/banking/rules/from-line` | Create a starter rule from a staged statement line, pre-filling `match_pattern` and the sign from the line. Accepts optional `customer_id`, `vendor_id`, `transfer_to_account_id`, `category_account_id`. |
 
-## Phase 2 follow-ups
+## Phase 2 follow-ups (still deferred)
 
-1. **`create_receipt` / `create_payment` actions** — auto-post a JE with the matching counterparty + category accounts. Requires populating `counterparty_id`, `category_account_id`, `tax_profile_id` fields on the rule.
-2. **Dry-run preview** — run rules against an import without mutating, return per-rule counts so operators can validate before activation.
-3. **"Create rule from line" shortcut** — pre-fill match_pattern from the description.
-4. **`create_inter_account_transfer` action** — paired with #246 once both ship.
-5. **Frontend** rules CRUD + dry-run preview + reorder by priority.
+1. **`BillPayment` integration** on `create_payment` so vendor outflows post against a specific bill (or to an "unapplied AP" bucket) instead of a raw JE.
+2. **Frontend** rules CRUD + dry-run preview + reorder by priority.
+3. **Tax-profile-aware rule actions** — apply a tax profile to the posted JE on category-style actions.


### PR DESCRIPTION
## Summary
Closes the remaining #316 backend scope. Three new bank-rule actions extend the existing `ignore` / `create_journal_entry` set:
- **`create_receipt`** — posts Dr bank, Cr AR (1100) and creates a `Payment` row with the full amount in `unapplied_amount`, tied to `rule.customer_id`. Operator applies it to invoices later.
- **`create_payment`** — posts Dr AP (2000), Cr bank for outflows to `rule.vendor_id`. No `BillPayment` row (no unapplied-BillPayment concept yet); reconcile against bills manually.
- **`create_inter_account_transfer`** — calls `inter_account_transfer_service` so each leg's `posted_on` lands on the correct bank's statement; the own-side JE leg is linked to the statement line.

Per-action target columns added to `statement_match_rules`: `customer_id`, `vendor_id`, `transfer_to_account_id`. Validation requires the relevant column at create/update; rules that fire without a target are counted in `skipped_unsupported_actions` instead of crashing.

Preview endpoint now surfaces a friendly `target` label (`customer: ACME` / `vendor: Filament Co` / `transfer to: 1020 Savings`) so operators can sanity-check before applying.

## Out of scope (still deferred)
- `BillPayment` integration on `create_payment` (post against a specific bill or to an unapplied-AP bucket).
- Frontend rules CRUD / dry-run preview / reorder.
- Tax-profile-aware rule actions.

## Test plan
- [x] `pytest backend/tests` — 711 passed, 2 unrelated warnings (~10 min).
- [x] New tests in `backend/tests/test_p2_316_bank_rule_actions.py` (5): receipt creates JE + unapplied Payment, payment creates AP JE, IAT creates `InterAccountTransfer`, missing-target skip path, preview surfaces target label.
- [x] Existing `test_statement_match_rule_service.py` updated for the new supported-action set.
- [ ] Post-merge: deploy on web01 runs `alembic upgrade head` (existing flow).

## Docs
- `docs/statement_match_rules.md` rewritten for the new action matrix and per-action target requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)