### PR TITLE
fix(alembic): merge divergent heads 20260510_13 + 20260511_02

### DIFF
--- a/backend/alembic/versions/20260511_03_merge_heads.py
+++ b/backend/alembic/versions/20260511_03_merge_heads.py
@@ -1,0 +1,30 @@
+"""Merge divergent heads 20260510_13 + 20260511_02
+
+Two migrations were added in parallel branches both descending from
+20260510_12: PR #384 (`20260510_13_backfill_je_reference_sequence`) and
+the #318/#316 chain (`20260511_01_product_location_stock` →
+`20260511_02_bank_rule_targets`). This merge revision joins them so
+`alembic upgrade head` resolves to a single head again.
+
+No DDL — pure topology fix.
+
+Revision ID: 20260511_03
+Revises: 20260510_13, 20260511_02
+Create Date: 2026-05-11 12:30:00
+"""
+
+from __future__ import annotations
+
+
+revision = "20260511_03"
+down_revision = ("20260510_13", "20260511_02")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
The web01 deploy of PR #390 failed at `alembic upgrade head` with `Multiple head revisions are present for given argument 'head'`. PR #384's `20260510_13_backfill_je_reference_sequence` and the #318/#316 chain (`20260511_01` → `20260511_02`) both descend from `20260510_12`, leaving two heads.

This adds a pure topology-fix merge revision (`20260511_03`) with both as `down_revision`. No DDL.

## Test plan
- [x] Identified the conflict from the failing deploy log.
- [ ] Deploy on web01 — should resolve to a single head and run remaining migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)