### PR TITLE
feat(custom-fields): #326 P2 — multi_select + computed + per-line scopes

### DIFF
--- a/backend/alembic/versions/20260511_04_custom_fields_phase2.py
+++ b/backend/alembic/versions/20260511_04_custom_fields_phase2.py
@@ -1,0 +1,27 @@
+"""#326 P2: custom-fields formula column for computed fields
+
+Revision ID: 20260511_04
+Revises: 20260511_03
+Create Date: 2026-05-11 13:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260511_04"
+down_revision = "20260511_03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("custom_field_definitions") as batch:
+        batch.add_column(sa.Column("formula", sa.String(120), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("custom_field_definitions") as batch:
+        batch.drop_column("formula")

--- a/backend/app/api/v1/endpoints/custom_fields.py
+++ b/backend/app/api/v1/endpoints/custom_fields.py
@@ -25,10 +25,14 @@ class DefinitionCreate(BaseModel):
     scope: str = Field(..., min_length=1, max_length=40)
     key: str = Field(..., min_length=1, max_length=64)
     name: str = Field(..., min_length=1, max_length=120)
-    field_type: Literal["text", "long_text", "number", "date", "dropdown", "checkbox"]
+    field_type: Literal[
+        "text", "long_text", "number", "date", "dropdown", "checkbox",
+        "multi_select", "computed",
+    ]
     options: list[str] | None = None
     is_required: bool = False
     sort_order: int = 100
+    formula: str | None = Field(None, max_length=120)
 
 
 class DefinitionUpdate(BaseModel):
@@ -37,6 +41,7 @@ class DefinitionUpdate(BaseModel):
     is_required: bool | None = None
     sort_order: int | None = None
     is_active: bool | None = None
+    formula: str | None = Field(None, max_length=120)
 
 
 class DefinitionResponse(BaseModel):
@@ -49,6 +54,7 @@ class DefinitionResponse(BaseModel):
     is_required: bool
     sort_order: int
     is_active: bool
+    formula: str | None = None
 
 
 def _to_response(d: CustomFieldDefinition) -> DefinitionResponse:
@@ -62,6 +68,7 @@ def _to_response(d: CustomFieldDefinition) -> DefinitionResponse:
         is_required=d.is_required,
         sort_order=d.sort_order,
         is_active=d.is_active,
+        formula=d.formula,
     )
 
 
@@ -78,7 +85,8 @@ async def list_defs_ep(scope: str, user: CurrentUser, db: DB, include_inactive: 
 async def create_def(body: DefinitionCreate, user: CurrentUser, db: DB):
     try:
         validate_definition(
-            scope=body.scope, key=body.key, field_type=body.field_type, options=body.options,
+            scope=body.scope, key=body.key, field_type=body.field_type,
+            options=body.options, formula=body.formula,
         )
     except CustomFieldError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
@@ -103,6 +111,7 @@ async def create_def(body: DefinitionCreate, user: CurrentUser, db: DB):
         options=body.options,
         is_required=body.is_required,
         sort_order=body.sort_order,
+        formula=body.formula,
     )
     db.add(d)
     await db.commit()
@@ -117,10 +126,15 @@ async def update_def(def_id: uuid.UUID, body: DefinitionUpdate, user: CurrentUse
     payload = body.model_dump(exclude_unset=True)
     for k, v in payload.items():
         setattr(d, k, v)
-    # Re-validate dropdown options if they changed
-    if "options" in payload and d.field_type == "dropdown":
+    # Re-validate when options/formula change on a type that uses them.
+    if ("options" in payload and d.field_type in ("dropdown", "multi_select")) or (
+        "formula" in payload and d.field_type == "computed"
+    ):
         try:
-            validate_definition(scope=d.scope, key=d.key, field_type=d.field_type, options=d.options)
+            validate_definition(
+                scope=d.scope, key=d.key, field_type=d.field_type,
+                options=d.options, formula=d.formula,
+            )
         except CustomFieldError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
     await db.commit()

--- a/backend/app/models/custom_field.py
+++ b/backend/app/models/custom_field.py
@@ -33,10 +33,13 @@ class CustomFieldDefinition(Base):
     scope: Mapped[str] = mapped_column(String(40), index=True)
     key: Mapped[str] = mapped_column(String(64))  # slug used in API + filters
     name: Mapped[str] = mapped_column(String(120))  # display label
-    # text | long_text | number | date | dropdown | checkbox
+    # text | long_text | number | date | dropdown | checkbox | multi_select | computed
     field_type: Mapped[str] = mapped_column(String(20))
-    options: Mapped[list | None] = mapped_column(JSON, nullable=True)  # for dropdown
+    options: Mapped[list | None] = mapped_column(JSON, nullable=True)  # for dropdown / multi_select
     is_required: Mapped[bool] = mapped_column(Boolean, default=False)
+    # #326 P2: computed fields evaluate a registered formula at read time
+    # (no stored value). Format: `<formula_key>:<arg>` — e.g. `days_since:invoice_date`.
+    formula: Mapped[str | None] = mapped_column(String(120), nullable=True)
     sort_order: Mapped[int] = mapped_column(Integer, default=100)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/services/custom_field_service.py
+++ b/backend/app/services/custom_field_service.py
@@ -26,9 +26,27 @@ class CustomFieldError(RuntimeError):
 VALID_SCOPES = {
     "customer", "vendor", "product", "material", "supply",
     "job", "sale", "invoice", "quote", "bill",
+    # #326 P2: per-line scopes. record_id refers to the child line's id.
+    "sale_item", "invoice_line", "quote_line", "bill_line",
+    "purchase_order_line", "sales_order_line",
 }
 
-FIELD_TYPES = {"text", "long_text", "number", "date", "dropdown", "checkbox"}
+FIELD_TYPES = {
+    "text", "long_text", "number", "date", "dropdown", "checkbox",
+    # #326 P2:
+    "multi_select",  # list of strings drawn from `options`
+    "computed",      # evaluated at read time via the formula registry
+}
+
+# Computed-field formula registry. Each entry maps a formula key to a
+# resolver `(db, scope, record_id, arg) -> Any`. Keep the registry small
+# and pure — no business rules, just calculator-style derivations.
+COMPUTED_FORMULAS: dict[str, str] = {
+    # days_since:<scope-specific source date column>
+    # Currently supports any scope whose record exposes one of the well-known
+    # date columns: invoice_date, sale_date, date, issue_date, posted_date.
+    "days_since": "Whole days from <arg> column on the record to today.",
+}
 
 _KEY_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
@@ -39,6 +57,7 @@ def validate_definition(
     key: str,
     field_type: str,
     options: list | None,
+    formula: str | None = None,
 ) -> None:
     if scope not in VALID_SCOPES:
         raise CustomFieldError(f"Unsupported scope: {scope!r}")
@@ -48,9 +67,24 @@ def validate_definition(
         )
     if field_type not in FIELD_TYPES:
         raise CustomFieldError(f"Unknown field_type: {field_type!r}")
-    if field_type == "dropdown":
+    if field_type in ("dropdown", "multi_select"):
         if not options or not isinstance(options, list) or not all(isinstance(o, str) and o for o in options):
-            raise CustomFieldError("dropdown field_type requires non-empty options: list[str]")
+            raise CustomFieldError(
+                f"{field_type} field_type requires non-empty options: list[str]"
+            )
+    if field_type == "computed":
+        if not formula:
+            raise CustomFieldError("computed field_type requires a formula")
+        # Format: `<formula_key>:<arg>` (arg required for all current formulas).
+        head, _, arg = formula.partition(":")
+        if head not in COMPUTED_FORMULAS:
+            raise CustomFieldError(
+                f"Unknown formula {head!r}; supported: {sorted(COMPUTED_FORMULAS)}"
+            )
+        if not arg:
+            raise CustomFieldError(
+                f"formula {head!r} requires an argument; got {formula!r}"
+            )
 
 
 def coerce_value(field_type: str, raw: Any, options: list | None) -> str | None:
@@ -85,6 +119,34 @@ def coerce_value(field_type: str, raw: Any, options: list | None) -> str | None:
         if not options or str(raw) not in options:
             raise CustomFieldError(f"Value {raw!r} is not in the configured options")
         return str(raw)
+    if field_type == "multi_select":
+        # Accept list[str] or comma-separated string; store as JSON-array
+        # string so we round-trip cleanly and avoid ambiguity around
+        # commas inside option labels.
+        import json
+        if isinstance(raw, str):
+            items = [p.strip() for p in raw.split(",") if p.strip()]
+        elif isinstance(raw, (list, tuple, set)):
+            items = [str(x).strip() for x in raw if str(x).strip()]
+        else:
+            raise CustomFieldError(f"multi_select expects list or comma-string, got {type(raw).__name__}")
+        if not options:
+            raise CustomFieldError("multi_select requires options on the definition")
+        unknown = [i for i in items if i not in options]
+        if unknown:
+            raise CustomFieldError(
+                f"multi_select values not in options: {unknown}"
+            )
+        # Deduplicate while preserving order.
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for i in items:
+            if i not in seen:
+                seen.add(i)
+                deduped.append(i)
+        return json.dumps(deduped)
+    if field_type == "computed":
+        raise CustomFieldError("computed fields are read-only and cannot be set directly")
     raise CustomFieldError(f"Unhandled field_type: {field_type}")
 
 
@@ -100,6 +162,12 @@ def decode_value(field_type: str, stored: str | None) -> Any:
         return stored  # ISO string
     if field_type == "checkbox":
         return stored == "true"
+    if field_type == "multi_select":
+        import json
+        try:
+            return json.loads(stored)
+        except json.JSONDecodeError:
+            return []
     return stored
 
 
@@ -148,6 +216,9 @@ async def upsert_values(
     for d in defs:
         if not d.is_required:
             continue
+        if d.field_type == "computed":
+            # Computed values are always derived; required-check is N/A.
+            continue
         if d.key in values:
             if _is_empty(values[d.key]):
                 raise CustomFieldError(
@@ -163,6 +234,11 @@ async def upsert_values(
             # Unknown key — silently ignore so client API stays loose
             continue
         d = by_key[key]
+        if d.field_type == "computed":
+            # Computed fields are derived at read time; ignore writes silently
+            # rather than raising, so a generic upsert payload that includes
+            # the field doesn't fail on an otherwise-unrelated record save.
+            continue
         canonical = coerce_value(d.field_type, raw, d.options)
         existing = (
             await db.execute(
@@ -221,8 +297,111 @@ async def read_values(
             )
         )
     ).scalars().all()
-    return {
+    out: dict[str, Any] = {
         by_id[r.definition_id].key: decode_value(by_id[r.definition_id].field_type, r.value)
         for r in rows
         if r.definition_id in by_id
     }
+    # #326 P2: evaluate computed defs (no stored value, computed at read).
+    for d in defs:
+        if d.field_type != "computed":
+            continue
+        out[d.key] = await _evaluate_formula(db, scope=scope, record_id=record_id, formula=d.formula)
+    return out
+
+
+# ---------- #326 P2: computed-field evaluator ----------
+
+
+def _scope_model(scope: str):
+    """Lazy-import the ORM model class for a given scope. Lazy to avoid
+    bootstrap-order coupling and to keep the registry trivially editable."""
+    if scope == "customer":
+        from app.models.customer import Customer
+        return Customer
+    if scope == "vendor":
+        from app.models.vendor import Vendor
+        return Vendor
+    if scope == "product":
+        from app.models.product import Product
+        return Product
+    if scope == "material":
+        from app.models.material import Material
+        return Material
+    if scope == "supply":
+        from app.models.supply import Supply
+        return Supply
+    if scope == "job":
+        from app.models.job import Job
+        return Job
+    if scope == "sale":
+        from app.models.sale import Sale
+        return Sale
+    if scope == "invoice":
+        from app.models.invoice import Invoice
+        return Invoice
+    if scope == "quote":
+        from app.models.quote import Quote
+        return Quote
+    if scope == "bill":
+        from app.models.bill import Bill
+        return Bill
+    if scope == "sale_item":
+        from app.models.sale_item import SaleItem
+        return SaleItem
+    if scope == "invoice_line":
+        from app.models.invoice_line import InvoiceLine
+        return InvoiceLine
+    if scope == "quote_line":
+        from app.models.quote import QuoteLine
+        return QuoteLine
+    if scope == "bill_line":
+        from app.models.bill import BillLine
+        return BillLine
+    if scope == "purchase_order_line":
+        from app.models.purchase_order import PurchaseOrderLine
+        return PurchaseOrderLine
+    if scope == "sales_order_line":
+        from app.models.sales_order import SalesOrderLine
+        return SalesOrderLine
+    return None
+
+
+async def _evaluate_formula(
+    db: AsyncSession,
+    *,
+    scope: str,
+    record_id: uuid.UUID,
+    formula: str | None,
+) -> Any:
+    """Evaluate a computed-field formula on a specific record.
+
+    Returns None when the formula is malformed, the scope has no
+    registered ORM model, or the source column is missing on the row,
+    rather than raising — a computed field is a display affordance and
+    a transient evaluator error should never surface as an API failure
+    on an otherwise valid record read.
+    """
+    if not formula:
+        return None
+    head, _, arg = formula.partition(":")
+    if head not in COMPUTED_FORMULAS or not arg:
+        return None
+    Model = _scope_model(scope)
+    if Model is None or not hasattr(Model, arg):
+        return None
+    if head == "days_since":
+        from datetime import date
+
+        row = (
+            await db.execute(select(Model).where(Model.id == record_id))
+        ).scalar_one_or_none()
+        if row is None:
+            return None
+        source = getattr(row, arg, None)
+        if isinstance(source, datetime):
+            source = source.date()
+        if not isinstance(source, date):
+            return None
+        return (date.today() - source).days
+    return None

--- a/backend/tests/test_p2_326_custom_fields_phase2.py
+++ b/backend/tests/test_p2_326_custom_fields_phase2.py
@@ -1,0 +1,213 @@
+"""#326 P2: multi_select + computed (days_since) + per-line scopes."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.custom_field import CustomFieldDefinition, CustomFieldValue
+from app.models.customer import Customer
+from app.models.invoice import Invoice
+from app.models.invoice_line import InvoiceLine
+from app.services.custom_field_service import (
+    CustomFieldError,
+    coerce_value,
+    decode_value,
+    read_values,
+    upsert_values,
+    validate_definition,
+)
+
+
+def test_multi_select_validation_requires_options():
+    with pytest.raises(CustomFieldError):
+        validate_definition(scope="customer", key="tags", field_type="multi_select", options=None)
+
+
+def test_multi_select_coerce_and_decode_roundtrip():
+    options = ["vip", "trade", "reseller"]
+    stored = coerce_value("multi_select", ["vip", "reseller", "vip"], options)
+    # Dedups while preserving order.
+    decoded = decode_value("multi_select", stored)
+    assert decoded == ["vip", "reseller"]
+
+
+def test_multi_select_rejects_unknown_value():
+    with pytest.raises(CustomFieldError):
+        coerce_value("multi_select", ["vip", "bogus"], ["vip", "trade"])
+
+
+def test_multi_select_accepts_comma_string():
+    decoded = decode_value(
+        "multi_select",
+        coerce_value("multi_select", "vip, trade", ["vip", "trade"]),
+    )
+    assert decoded == ["vip", "trade"]
+
+
+def test_computed_requires_formula():
+    with pytest.raises(CustomFieldError):
+        validate_definition(scope="invoice", key="days_open", field_type="computed", options=None)
+
+
+def test_computed_rejects_unknown_formula_key():
+    with pytest.raises(CustomFieldError):
+        validate_definition(
+            scope="invoice", key="x", field_type="computed", options=None, formula="bogus:foo"
+        )
+
+
+def test_computed_rejects_missing_argument():
+    with pytest.raises(CustomFieldError):
+        validate_definition(
+            scope="invoice", key="x", field_type="computed", options=None, formula="days_since:"
+        )
+
+
+def test_computed_cannot_be_set_directly():
+    with pytest.raises(CustomFieldError):
+        coerce_value("computed", "5", None)
+
+
+def test_per_line_scope_is_valid():
+    # Should not raise — these scopes were added in #326 P2.
+    for s in ("sale_item", "invoice_line", "quote_line", "bill_line"):
+        validate_definition(scope=s, key="k", field_type="text", options=None)
+
+
+@pytest.mark.asyncio
+async def test_multi_select_round_trip_through_upsert(db_session):
+    d = CustomFieldDefinition(
+        scope="customer", key="segments", name="Segments",
+        field_type="multi_select", options=["vip", "trade", "reseller"],
+    )
+    db_session.add(d)
+    c = Customer(name="ACME")
+    db_session.add(c)
+    await db_session.flush()
+
+    out = await upsert_values(
+        db_session, scope="customer", record_id=c.id,
+        values={"segments": ["vip", "reseller"]},
+    )
+    assert out["segments"] == ["vip", "reseller"]
+
+    # Round-trip read.
+    out2 = await read_values(db_session, scope="customer", record_id=c.id)
+    assert out2["segments"] == ["vip", "reseller"]
+
+
+@pytest.mark.asyncio
+async def test_computed_days_since_invoice_date(db_session):
+    d = CustomFieldDefinition(
+        scope="invoice", key="days_open", name="Days Open",
+        field_type="computed", formula="days_since:issue_date",
+    )
+    db_session.add(d)
+    # Build a minimal invoice 7 days back.
+    cust = Customer(name="Customer 1")
+    db_session.add(cust)
+    await db_session.flush()
+    inv = Invoice(
+        invoice_number="INV-1",
+        customer_id=cust.id,
+        issue_date=dt.date.today() - dt.timedelta(days=7),
+        due_date=dt.date.today() + dt.timedelta(days=23),
+        status="sent",
+        subtotal=Decimal("0"),
+        tax_amount=Decimal("0"),
+        total_due=Decimal("0"),
+    )
+    db_session.add(inv)
+    await db_session.flush()
+
+    out = await read_values(db_session, scope="invoice", record_id=inv.id)
+    assert out["days_open"] == 7
+
+
+@pytest.mark.asyncio
+async def test_computed_silently_skipped_on_upsert(db_session):
+    """An upsert payload that includes a computed-field key must not raise;
+    it just gets ignored so generic record-save flows can pass through
+    `{key: raw}` blindly.
+    """
+    d = CustomFieldDefinition(
+        scope="invoice", key="days_open", name="Days Open",
+        field_type="computed", formula="days_since:issue_date",
+    )
+    db_session.add(d)
+    cust = Customer(name="Customer 2")
+    db_session.add(cust)
+    await db_session.flush()
+    inv = Invoice(
+        invoice_number="INV-2",
+        customer_id=cust.id,
+        issue_date=dt.date.today() - dt.timedelta(days=3),
+        due_date=dt.date.today() + dt.timedelta(days=27),
+        status="sent",
+        subtotal=Decimal("0"),
+        tax_amount=Decimal("0"),
+        total_due=Decimal("0"),
+    )
+    db_session.add(inv)
+    await db_session.flush()
+
+    out = await upsert_values(
+        db_session, scope="invoice", record_id=inv.id,
+        values={"days_open": 999},
+    )
+    # The computed value reflects the record, not the rejected write.
+    assert out["days_open"] == 3
+    # And no row should have been persisted for the computed def.
+    cnt = (
+        await db_session.execute(
+            select(CustomFieldValue).where(CustomFieldValue.definition_id == d.id)
+        )
+    ).scalars().all()
+    assert cnt == []
+
+
+@pytest.mark.asyncio
+async def test_per_line_custom_field_on_invoice_line(db_session):
+    """Custom fields on the invoice_line scope key by InvoiceLine.id."""
+    cust = Customer(name="LineCustomer")
+    db_session.add(cust)
+    await db_session.flush()
+    inv = Invoice(
+        invoice_number="INV-L1",
+        customer_id=cust.id,
+        issue_date=dt.date.today(),
+        due_date=dt.date.today() + dt.timedelta(days=30),
+        status="draft",
+        subtotal=Decimal("10"),
+        tax_amount=Decimal("0"),
+        total_due=Decimal("10"),
+    )
+    db_session.add(inv)
+    await db_session.flush()
+    line = InvoiceLine(
+        invoice_id=inv.id,
+        description="Widget",
+        quantity=1,
+        unit_price=Decimal("10"),
+        line_total=Decimal("10"),
+    )
+    db_session.add(line)
+    await db_session.flush()
+
+    d = CustomFieldDefinition(
+        scope="invoice_line", key="warranty_months", name="Warranty (months)",
+        field_type="number",
+    )
+    db_session.add(d)
+    await db_session.flush()
+
+    out = await upsert_values(
+        db_session, scope="invoice_line", record_id=line.id,
+        values={"warranty_months": "24"},
+    )
+    assert out["warranty_months"] == "24"

--- a/docs/custom_fields.md
+++ b/docs/custom_fields.md
@@ -1,15 +1,57 @@
-# Custom Fields (Phase 1)
+# Custom Fields
 
-User-defined per-scope fields stored in a side table — the existing record schemas (Customer, Product, etc.) are untouched. #253.
+User-defined per-scope fields stored in a side table — the existing record schemas (Customer, Product, etc.) are untouched. Originally #253; computed, multi-value, and per-line scopes added in #326 Phase 2.
 
 ## Model
 
-- **`CustomFieldDefinition`**: `scope` × `key` (unique), `name`, `field_type` (text / long_text / number / date / dropdown / checkbox), `options` (JSON, for dropdown), `is_required`, `sort_order`, `is_active`.
-- **`CustomFieldValue`**: `(definition_id, record_id)` unique. String-stored; coerced on read per type.
+- **`CustomFieldDefinition`**: `scope` × `key` (unique), `name`, `field_type` (text / long_text / number / date / dropdown / checkbox / multi_select / computed), `options` (JSON, used by dropdown and multi_select), `formula` (computed only), `is_required`, `sort_order`, `is_active`.
+- **`CustomFieldValue`**: `(definition_id, record_id)` unique. String-stored; coerced on read per type. Computed fields have no row — they're derived at read time.
 
-## Supported scopes (Phase 1)
+## Supported scopes
 
-`customer`, `vendor`, `product`, `material`, `supply`, `job`, `sale`, `invoice`, `quote`, `bill`.
+Document scopes: `customer`, `vendor`, `product`, `material`, `supply`, `job`, `sale`, `invoice`, `quote`, `bill`.
+
+Per-line scopes (#326 P2): `sale_item`, `invoice_line`, `quote_line`, `bill_line`, `purchase_order_line`, `sales_order_line`. `record_id` refers to the child line's id.
+
+## Field types
+
+| Type | Storage | API form | Notes |
+|---|---|---|---|
+| `text`, `long_text` | string | string | |
+| `dropdown` | string | string | Validated against `options`. |
+| `number` | normalized Decimal string | string | |
+| `date` | `YYYY-MM-DD` ISO | `YYYY-MM-DD` | |
+| `checkbox` | `"true"` / `"false"` | bool | |
+| `multi_select` | JSON-array string | `list[str]` (or comma-string on write) | Validated against `options`. Deduped, order preserved. |
+| `computed` | *(no row)* | derived value | `formula` selects a registered evaluator; no writes. |
+
+## Computed-field formulas
+
+| Formula | Argument | Returns |
+|---|---|---|
+| `days_since:<column>` | A date column on the scope's model. | Whole days from that date to today (`int`). |
+
+Computed fields are read-only — writes to them are silently dropped so generic record-save flows can pass through `{key: raw}` blindly without raising. Required-check is N/A for computed fields. If the evaluator can't resolve the source column (column missing, value null), the field returns `null` rather than 500-ing on the read.
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `GET` | `/api/v1/custom-fields/{scope}` | List definitions for a scope. |
+| `POST` | `/api/v1/custom-fields` | Create a definition. Validates `key` slug, dropdown/multi_select options, computed formula. |
+| `PATCH` | `/api/v1/custom-fields/{id}` | Update name / options / formula / required / sort_order / active. `field_type` and `scope` are immutable to avoid silent value-corruption. |
+| `DELETE` | `/api/v1/custom-fields/{id}` | Soft-deactivate (preserves stored values). |
+| `DELETE` | `/api/v1/custom-fields/{id}/hard?force=true` | Hard delete. Refuses by default if any values exist; `force=true` deletes values too. |
+| `GET` | `/api/v1/custom-fields/values/{scope}/search?key=…&value=…` | Find record IDs whose value for `{key}` matches. |
+| `GET` | `/api/v1/custom-fields/values/{scope}/{record_id}` | Read all values for a record (computed included). |
+| `POST` | `/api/v1/custom-fields/values/{scope}/{record_id}` | Upsert values: `{values: {key: raw}}`. Required-field check across active defs. Unknown keys silently ignored. Writes to computed-field keys are silently dropped. |
+
+## Phase 2 follow-ups (still deferred)
+
+- **List filtering** at the master-data list endpoint level (`?cf.{key}=value`) — the dedicated search endpoint covers the lookup, but inline `?cf.*` query-string filters on `/customers`, `/products`, etc. are still on the wishlist.
+- **Frontend**: definition CRUD under `/admin` + per-detail-page "Custom" section, including per-line column rendering.
+- **Additional computed formulas**: arithmetic between two columns, conditional, etc. Today the registry is just `days_since`.
+- **Field-level validation rules** (regex, min/max).
 
 ## API
 


### PR DESCRIPTION
## Summary
Closes the remaining #326 backend scope.

- **`multi_select` field type** — list-of-strings over `options`. Accepts list or comma-string on write, stored as JSON-array, dedups while preserving order, validates every value against `options`.
- **`computed` field type** — read-only formula-derived value. Definition stores a `formula` string like `days_since:issue_date`; the evaluator's registry (`COMPUTED_FORMULAS`) currently ships `days_since` and is trivially extensible. No `CustomFieldValue` row; resolution happens in `read_values`. Writes to computed keys are silently dropped so generic record-save flows pass through `{key: raw}` payloads blindly. Required-check is N/A for computed fields.
- **Per-line scopes** — `sale_item`, `invoice_line`, `quote_line`, `bill_line`, `purchase_order_line`, `sales_order_line`. `record_id` refers to the child line's id.
- Migration `20260511_04` adds the nullable `formula` column.

Already shipped in earlier passes: hard-delete (`DELETE /{id}/hard?force=`) and value-search endpoint.

## Out of scope (still deferred)
- Master-data list-endpoint inline filtering (`?cf.{key}=value` on `/customers`, `/products`, etc.) — the dedicated search endpoint covers the lookup.
- Frontend definition CRUD + per-line column rendering.
- Additional computed formulas beyond `days_since`.
- Field-level validation rules (regex, min/max).

## Test plan
- [x] `pytest backend/tests` — 725 passed (~9 min).
- [x] 13 new tests in `backend/tests/test_p2_326_custom_fields_phase2.py` cover: multi_select coerce/decode/dedup/comma-string/unknown-rejection/options-validation, computed validation (missing formula / unknown key / missing arg / write rejection), per-line scope validity, multi_select round-trip via upsert, computed days_since on Invoice.issue_date, silent-drop of computed on upsert, per-line custom field on InvoiceLine.
- [ ] Post-merge: deploy on web01 runs `alembic upgrade head` (`20260511_04`).

## Docs
- `docs/custom_fields.md` rewritten for the new field types, per-line scopes, formula registry, and updated API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)