### PR TITLE
feat(jobs): #328 final bullet — Job → Project rollup link

### DIFF
--- a/backend/alembic/versions/20260511_06_job_project_link.py
+++ b/backend/alembic/versions/20260511_06_job_project_link.py
@@ -1,0 +1,37 @@
+"""#328 P2 follow-up: Job → Project FK
+
+Closes the last remaining bullet on #328 (Job rollup into Project) — the
+P&L by project filter already accepts project_id on doc rows, but Job
+itself had no link until now.
+
+Revision ID: 20260511_06
+Revises: 20260511_05
+Create Date: 2026-05-11 15:30:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260511_06"
+down_revision = "20260511_05"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("jobs") as batch:
+        batch.add_column(sa.Column("project_id", sa.UUID(), nullable=True))
+        batch.create_foreign_key(
+            "fk_jobs_project", "projects", ["project_id"], ["id"]
+        )
+    op.create_index("ix_jobs_project_id", "jobs", ["project_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_project_id", table_name="jobs")
+    with op.batch_alter_table("jobs") as batch:
+        batch.drop_constraint("fk_jobs_project", type_="foreignkey")
+        batch.drop_column("project_id")

--- a/backend/app/models/job.py
+++ b/backend/app/models/job.py
@@ -61,6 +61,11 @@ class Job(Base):
     inventory_added: Mapped[bool] = mapped_column(Boolean, default=False)
 
     status: Mapped[str] = mapped_column(String(20), default="completed")
+    # #328 P2: optional rollup link so existing Job records map onto the
+    # Project hierarchy for cost-center reporting.
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("projects.id"), nullable=True, index=True
+    )
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -34,6 +34,7 @@ class JobCreate(BaseModel):
     target_margin_pct: Decimal = Field(Decimal(40), ge=0, le=99, examples=[40])
     product_id: uuid.UUID | None = None
     printer_id: uuid.UUID | None = None
+    project_id: uuid.UUID | None = None
     status: JobStatus = Field(JobStatus.completed, examples=["completed"])
 
 
@@ -54,6 +55,7 @@ class JobUpdate(BaseModel):
     target_margin_pct: Decimal | None = Field(None, ge=0, le=99)
     product_id: uuid.UUID | None = None
     printer_id: uuid.UUID | None = None
+    project_id: uuid.UUID | None = None
     status: JobStatus | None = None
 
 
@@ -126,6 +128,7 @@ class JobResponse(BaseModel):
     product_id: uuid.UUID | None = None
     printer_id: uuid.UUID | None = None
     printer: PrinterResponse | None = None
+    project_id: uuid.UUID | None = None
     inventory_added: bool = False
     status: str
     created_at: datetime.datetime | None = None

--- a/backend/tests/test_p2_328_job_project_link.py
+++ b/backend/tests/test_p2_328_job_project_link.py
@@ -1,0 +1,85 @@
+"""#328 P2 final bullet: Job → Project rollup link."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models.division import Project
+from app.models.job import Job
+from app.models.material import Material
+
+
+@pytest.mark.asyncio
+async def test_job_create_persists_project_id(client: AsyncClient, auth_headers, db_session):
+    mat = Material(
+        name="PLA", brand="X", spool_weight_g=Decimal("1000"),
+        spool_price=Decimal("20"), net_usable_g=Decimal("950"),
+        cost_per_g=Decimal("0.02"),
+    )
+    db_session.add(mat)
+    project = Project(name="Holiday Campaign")
+    db_session.add(project)
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/jobs",
+        json={
+            "date": "2026-05-11",
+            "product_name": "Widget",
+            "qty_per_plate": 1,
+            "num_plates": 1,
+            "material_id": str(mat.id),
+            "material_per_plate_g": "10",
+            "print_time_per_plate_hrs": "1",
+            "project_id": str(project.id),
+        },
+        headers=auth_headers,
+    )
+    assert r.status_code == 201
+    assert r.json()["project_id"] == str(project.id)
+
+    row = (
+        await db_session.execute(select(Job).where(Job.id == uuid.UUID(r.json()["id"])))
+    ).scalar_one()
+    assert row.project_id == project.id
+
+
+@pytest.mark.asyncio
+async def test_job_update_can_clear_project(client: AsyncClient, auth_headers, db_session):
+    mat = Material(
+        name="PLA", brand="X", spool_weight_g=Decimal("1000"),
+        spool_price=Decimal("20"), net_usable_g=Decimal("950"),
+        cost_per_g=Decimal("0.02"),
+    )
+    project = Project(name="P1")
+    db_session.add_all([mat, project])
+    await db_session.commit()
+
+    create = await client.post(
+        "/api/v1/jobs",
+        json={
+            "date": "2026-05-11",
+            "product_name": "Widget",
+            "qty_per_plate": 1,
+            "num_plates": 1,
+            "material_id": str(mat.id),
+            "material_per_plate_g": "10",
+            "print_time_per_plate_hrs": "1",
+            "project_id": str(project.id),
+        },
+        headers=auth_headers,
+    )
+    job_id = create.json()["id"]
+
+    cleared = await client.put(
+        f"/api/v1/jobs/{job_id}",
+        json={"project_id": None},
+        headers=auth_headers,
+    )
+    assert cleared.status_code == 200
+    assert cleared.json()["project_id"] is None

--- a/docs/divisions_and_projects.md
+++ b/docs/divisions_and_projects.md
@@ -1,11 +1,15 @@
-# Divisions + Projects (Phase 1)
+# Divisions + Projects
 
-Two reporting dimensions for segmentation. Phase 1 ships the master data + CRUD; cross-table FK additions on bills/invoices/sales/journal_entries deferred to Phase 2.
+Two reporting dimensions for segmentation: a fixed cost center (`Division`) and a cross-cutting tag (`Project`). Phase 1 shipped the master data + CRUD; Phase 2 (#328) wired FKs across docs, the P&L by division/project filter, and the Job → Project rollup.
 
 ## Models
 
 - **`Division`** — fixed cost center. A record has at most one. Use cases: Wholesale / Marketplace / Custom commissions.
 - **`Project`** — cross-cutting tag, ad-hoc, time-bounded. Use cases: a specific custom commission, a launch, a one-off promo.
+
+## Cross-table FKs
+
+Optional `division_id` + `project_id` (both nullable) live on: `invoices`, `bills`, `sales`, `journal_entries`, `quotes`, `expense_claims`. `Job` carries an optional `project_id` only (no division — division is a cost-center concept that doesn't fit jobs).
 
 ## API
 
@@ -16,9 +20,13 @@ Two reporting dimensions for segmentation. Phase 1 ships the master data + CRUD;
 | `GET` | `/api/v1/projects` | List active by default; `?include_archived=true` for full. |
 | `POST/PATCH/DELETE` | `/api/v1/projects[/{id}]` | Standard CRUD; status `active|archived`. |
 
-## Phase 2 follow-ups
+## Reporting filters
 
-- **Optional FKs** (`division_id`, `project_id`) on `bill`, `invoice`, `sale`, `journal_entry`, `expense_claim`, `quote`. Each nullable.
-- **Job link** to project (`Job.project_id` — one-way, optional).
-- **Report filtering** by division and by project on P&L, Balance Sheet (#249), Sales report, Cash Flow.
-- **Frontend** master-data CRUD + record-form pickers + report filter dropdowns.
+`GET /api/v1/reports/profit-and-loss` accepts `division_id` and `project_id` query params. The filter threads through `_posted_journal_balances` so only journal entries tagged with the selected dimension(s) are aggregated.
+
+## Phase 2 follow-ups (still deferred)
+
+- **Cash-basis P&L filter** — division/project filter today applies to the accrual report only.
+- **Per-division Balance Sheet** — same dimension threading on `/reports/balance-sheet`.
+- **Sales report and Cash Flow** dimension filters.
+- **Frontend** record-form pickers + report filter dropdowns.


### PR DESCRIPTION
## Summary
Closes the last open bullet on #328 (Job rollup into Project). PR #345 already landed division/project FKs on docs (`bill`, `invoice`, `sale`, `journal_entry`, `expense_claim`, `quote`) plus the P&L by division/project filter; this PR adds the same `project_id` FK to `Job` so existing print jobs roll up into the Project hierarchy.

- Migration `20260511_06` adds nullable `project_id` + index on `jobs`.
- Model + `JobCreate`/`JobUpdate`/`JobResponse` Pydantic schemas expose the field.
- 2 tests cover create-with-project and clear-on-update (`PUT` with `project_id: null`).
- `docs/divisions_and_projects.md` rewritten to reflect the now-shipped Phase 2 state.

## Out of scope (remaining deferrals)
- Cash-basis P&L filter, per-division balance sheet, sales report / cash flow dimension filters — call out in the doc as still deferred.
- Frontend record-form pickers + report dropdowns.

After this lands, #328 can be closed.

## Test plan
- [x] `pytest backend/tests/test_p2_328_job_project_link.py` — 2 passed.
- [ ] Post-merge: deploy on web01 runs `alembic upgrade head` (`20260511_06`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)