### PR TITLE
fix(products): SKU generator collision (2026-05-12 prod 500)

### DIFF
--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import uuid
 from decimal import Decimal
 
@@ -13,21 +14,54 @@ from app.models.product import Product
 from app.services.inventory_accounting_service import post_finished_goods_from_job
 
 
+_SKU_SUFFIX_RE = re.compile(r"-(\d+)$")
+_NON_ALNUM_RE = re.compile(r"[^A-Z0-9]+")
+
+
+def _material_sku_code(name: str | None) -> str:
+    """Derive a 4-character upper-alphanumeric code from a material name.
+
+    Whitespace, punctuation, and other non-alphanumeric characters are
+    stripped before truncation so a material called "SM Spool" doesn't
+    leak a space into the SKU prefix (which then broke `LIKE` matching
+    and collided once the count-based numbering walked into an existing
+    row — see the 2026-05-12 prod 500).
+    """
+    if not name:
+        return "UNKN"
+    cleaned = _NON_ALNUM_RE.sub("", name.upper())
+    return cleaned[:4] if cleaned else "UNKN"
+
+
 async def generate_sku(db: AsyncSession, material_id: uuid.UUID) -> str:
-    """Generate a unique SKU in format PRD-{MATERIAL}-{NNNN}."""
+    """Generate a unique SKU in format `PRD-{MATERIAL}-{NNNN}`.
+
+    Picks the next sequence by reading the MAX of existing suffixes
+    within the prefix (not `COUNT`), so gaps from deleted or
+    out-of-order inserts can't drive a collision. The caller still has
+    to handle the genuine concurrent-insert race — `db.commit()` will
+    raise `IntegrityError` on the unique SKU index — but in practice
+    product creation is operator-driven and serial.
+    """
     result = await db.execute(select(Material).where(Material.id == material_id))
     material = result.scalar_one_or_none()
-    material_code = material.name.upper()[:4] if material else "UNKN"
+    material_code = _material_sku_code(material.name if material else None)
 
-    # Find next sequence number for this material prefix
     prefix = f"PRD-{material_code}-"
-    result = await db.execute(
-        select(func.count()).select_from(Product).where(Product.sku.like(f"{prefix}%"))
-    )
-    count = result.scalar() or 0
-    seq = count + 1
+    existing = (
+        await db.execute(select(Product.sku).where(Product.sku.like(f"{prefix}%")))
+    ).scalars().all()
 
-    return f"{prefix}{seq:04d}"
+    max_seq = 0
+    for sku in existing:
+        m = _SKU_SUFFIX_RE.search(sku)
+        if m is not None:
+            try:
+                max_seq = max(max_seq, int(m.group(1)))
+            except ValueError:
+                continue
+
+    return f"{prefix}{max_seq + 1:04d}"
 
 
 async def add_inventory_from_job(

--- a/backend/tests/test_sku_generator.py
+++ b/backend/tests/test_sku_generator.py
@@ -1,0 +1,97 @@
+"""Regression tests for `generate_sku` (2026-05-12 prod 500).
+
+Old implementation used COUNT(*) on the prefix to pick the next number,
+which collided whenever the existing sequence had a gap. It also let
+non-alphanumeric characters in the material name leak into the SKU
+prefix, breaking the LIKE match and producing duplicates against
+historically-spaced rows.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.material import Material
+from app.models.product import Product
+from app.services.inventory_service import _material_sku_code, generate_sku
+
+
+def test_material_sku_code_strips_non_alphanumeric():
+    assert _material_sku_code("SM Spool") == "SMSP"
+    assert _material_sku_code("petg!@#") == "PETG"
+    assert _material_sku_code("   ") == "UNKN"
+    assert _material_sku_code(None) == "UNKN"
+
+
+def test_material_sku_code_truncates_to_four():
+    assert _material_sku_code("LongMaterialName") == "LONG"
+
+
+@pytest.mark.asyncio
+async def test_generate_sku_uses_max_not_count(db_session):
+    """Existing rows: 0001, 0002, 0005 (gap at 3/4). COUNT-based logic
+    would pick 0004 and collide eventually; MAX-based picks 0006."""
+    m = Material(
+        name="PLA", brand="X", spool_weight_g=Decimal("1000"),
+        spool_price=Decimal("20"), net_usable_g=Decimal("950"),
+        cost_per_g=Decimal("0.02"),
+    )
+    db_session.add(m)
+    await db_session.flush()
+    for suffix in ("0001", "0002", "0005"):
+        db_session.add(Product(
+            sku=f"PRD-PLA-{suffix}", name=f"P{suffix}", material_id=m.id,
+            unit_cost=Decimal("1"), unit_price=Decimal("2"),
+        ))
+    await db_session.flush()
+
+    next_sku = await generate_sku(db_session, m.id)
+    assert next_sku == "PRD-PLA-0006"
+
+
+@pytest.mark.asyncio
+async def test_generate_sku_ignores_historical_spaced_prefix(db_session):
+    """If old rows carry a space (legacy bug, e.g. PRD-SM M-0005), the
+    new generator's space-stripped prefix shouldn't see them, so it
+    starts a fresh sequence under the cleaned prefix."""
+    m = Material(
+        name="SM Spool", brand="X", spool_weight_g=Decimal("1000"),
+        spool_price=Decimal("20"), net_usable_g=Decimal("950"),
+        cost_per_g=Decimal("0.02"),
+    )
+    db_session.add(m)
+    await db_session.flush()
+    # Pre-seed legacy spaced SKUs.
+    for suffix in ("0001", "0002", "0005"):
+        db_session.add(Product(
+            sku=f"PRD-SM M-{suffix}", name=f"L{suffix}", material_id=m.id,
+            unit_cost=Decimal("1"), unit_price=Decimal("2"),
+        ))
+    await db_session.flush()
+
+    next_sku = await generate_sku(db_session, m.id)
+    # Cleaned prefix is PRD-SMSP-, no historical match -> starts at 0001.
+    assert next_sku == "PRD-SMSP-0001"
+
+
+@pytest.mark.asyncio
+async def test_generate_sku_handles_empty_material_name(db_session):
+    m = Material(
+        name="!!!", brand="X", spool_weight_g=Decimal("1000"),
+        spool_price=Decimal("20"), net_usable_g=Decimal("950"),
+        cost_per_g=Decimal("0.02"),
+    )
+    db_session.add(m)
+    await db_session.flush()
+    sku = await generate_sku(db_session, m.id)
+    assert sku == "PRD-UNKN-0001"
+
+
+@pytest.mark.asyncio
+async def test_generate_sku_unknown_material_returns_unkn_prefix(db_session):
+    import uuid
+    sku = await generate_sku(db_session, uuid.uuid4())
+    assert sku.startswith("PRD-UNKN-")


### PR DESCRIPTION
## Summary
Fix the 2026-05-12 production 500 on `POST /products`. The endpoint was returning `IntegrityError: duplicate key value violates unique constraint "ix_products_sku"` (the SKU `PRD-SM M-0005` already existed when the operator tried to create another product on the "SM Spool" material).

Two root causes:

1. **Whitespace leaked into the SKU prefix.** `material.name.upper()[:4]` kept spaces and other punctuation, so a material named `"SM Spool"` produced the prefix `PRD-SM M-` — which then didn't `LIKE`-match cleanly against rows inserted at other times.
2. **COUNT(*) + 1 is collision-prone.** Any gap in the existing sequence (deleted row, out-of-order insert, manual data load) caused `COUNT + 1` to walk back into an existing suffix and collide.

Fix:
- `_material_sku_code` strips non-alphanumeric and falls back to `UNKN` on empty input.
- `generate_sku` reads `MAX(suffix)` instead of `COUNT`, so gaps don't drive collisions.
- 6 regression tests in `backend/tests/test_sku_generator.py`.

## Out of scope
- Race-safe SKU allocation under genuine concurrent inserts. Product creation is operator-driven and serial in practice, so the existing `db.commit()` IntegrityError surface is acceptable. If concurrent product creates become a real problem we should register a `product_sku` scope in `reference_number_service` keyed by (material_id, year).
- Backfilling the historical `PRD-SM M-*` rows. The cleaned prefix produces a different namespace (`PRD-SMSP-*`) so legacy rows stay isolated; rename is operator-discretion.

## Test plan
- [x] `pytest backend/tests/test_sku_generator.py backend/tests/test_api_products.py` — 32 passed.
- [ ] Post-merge: deploy on web01 (no migration this time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)