### PR TITLE
fix(products): raise GET /products limit cap 100 → 500

### DIFF
--- a/backend/app/api/v1/endpoints/products.py
+++ b/backend/app/api/v1/endpoints/products.py
@@ -51,7 +51,7 @@ async def list_products(
     ),
     sort_dir: str = Query("asc", description="Sort direction", pattern="^(asc|desc)$"),
     skip: int = Query(0, ge=0, description="Number of records to skip"),
-    limit: int = Query(50, ge=1, le=100, description="Max records to return"),
+    limit: int = Query(50, ge=1, le=500, description="Max records to return"),
 ):
     base = select(Product)
     if is_active is not None:


### PR DESCRIPTION
## Summary
Inventory Studio page-load 422 on 2026-05-12: the frontend's `InventoryPage` requests `GET /products?is_active=true&limit=200`, but the endpoint capped `limit` at 100, so the request failed validation as soon as the operator wanted to see more than 100 products on one page.

Raise the cap to 500 — matches what `/supplies` already allows and what the frontend assumes.

## Test plan
- [x] Backend logs confirmed the 422 was caused by `limit=200 > le=100`.
- [ ] Post-merge: deploy on web01 + reload Inventory page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)