### PR TITLE
feat(jobs): #399 multi-part prints — per-plate qty + printer assignment

### DIFF
--- a/backend/alembic/versions/20260512_01_job_plates.py
+++ b/backend/alembic/versions/20260512_01_job_plates.py
@@ -1,0 +1,123 @@
+"""#399: per-plate qty + printer for multi-part prints
+
+Introduces a `plates` child table on Job so multi-part prints can record
+per-plate parts_count, material_g, print_time_hrs, and printer_id.
+Adds `total_material_g` and `total_print_time_hrs` columns to `jobs` so
+inventory accounting and reports read a single authoritative number
+instead of computing `material_per_plate_g * num_plates`. The legacy
+uniform fields become nullable but stay populated for backwards-compat
+on uniform jobs.
+
+Backfill: for every existing job, insert N identical plate rows
+(N = num_plates), then populate total_material_g and total_print_time_hrs.
+
+Revision ID: 20260512_01
+Revises: 20260511_06
+Create Date: 2026-05-12 10:00:00
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260512_01"
+down_revision = "20260511_06"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "plates",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("job_id", sa.UUID(), nullable=False),
+        sa.Column("plate_number", sa.Integer(), nullable=False),
+        sa.Column("printer_id", sa.UUID(), nullable=True),
+        sa.Column("parts_count", sa.Integer(), nullable=False),
+        sa.Column("material_g", sa.Numeric(10, 2), nullable=False),
+        sa.Column("print_time_hrs", sa.Numeric(10, 2), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.ForeignKeyConstraint(["job_id"], ["jobs.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["printer_id"], ["printers.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("job_id", "plate_number", name="uq_plates_job_plate_number"),
+    )
+    op.create_index("ix_plates_job_id", "plates", ["job_id"])
+    op.create_index("ix_plates_printer_id", "plates", ["printer_id"])
+
+    with op.batch_alter_table("jobs") as batch:
+        batch.add_column(sa.Column("total_material_g", sa.Numeric(10, 2), nullable=False, server_default="0"))
+        batch.add_column(sa.Column("total_print_time_hrs", sa.Numeric(10, 2), nullable=False, server_default="0"))
+
+    bind = op.get_bind()
+
+    # Backfill plates from existing uniform jobs.
+    jobs = bind.execute(
+        sa.text(
+            "SELECT id, qty_per_plate, num_plates, material_per_plate_g, "
+            "print_time_per_plate_hrs, printer_id FROM jobs"
+        )
+    ).fetchall()
+
+    for row in jobs:
+        job_id = row[0]
+        qpp = row[1]
+        npl = row[2]
+        mpp = row[3]
+        tpp = row[4]
+        printer_id = row[5]
+        if qpp is None or npl is None or mpp is None or tpp is None:
+            continue
+        for i in range(int(npl)):
+            bind.execute(
+                sa.text(
+                    "INSERT INTO plates (id, job_id, plate_number, printer_id, parts_count, "
+                    "material_g, print_time_hrs) VALUES "
+                    "(:id, :job_id, :plate_number, :printer_id, :parts_count, :material_g, :print_time_hrs)"
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "job_id": str(job_id),
+                    "plate_number": i + 1,
+                    "printer_id": str(printer_id) if printer_id else None,
+                    "parts_count": int(qpp),
+                    "material_g": float(mpp),
+                    "print_time_hrs": float(tpp),
+                },
+            )
+        bind.execute(
+            sa.text(
+                "UPDATE jobs SET total_material_g = :tmg, total_print_time_hrs = :tph "
+                "WHERE id = :id"
+            ),
+            {
+                "tmg": float(mpp) * int(npl),
+                "tph": float(tpp) * int(npl),
+                "id": str(job_id),
+            },
+        )
+
+    # Make uniform-input fields nullable now that plates are authoritative.
+    with op.batch_alter_table("jobs") as batch:
+        batch.alter_column("qty_per_plate", existing_type=sa.Integer(), nullable=True)
+        batch.alter_column("num_plates", existing_type=sa.Integer(), nullable=True)
+        batch.alter_column("material_per_plate_g", existing_type=sa.Numeric(10, 2), nullable=True)
+        batch.alter_column("print_time_per_plate_hrs", existing_type=sa.Numeric(10, 2), nullable=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("jobs") as batch:
+        batch.alter_column("print_time_per_plate_hrs", existing_type=sa.Numeric(10, 2), nullable=False)
+        batch.alter_column("material_per_plate_g", existing_type=sa.Numeric(10, 2), nullable=False)
+        batch.alter_column("num_plates", existing_type=sa.Integer(), nullable=False)
+        batch.alter_column("qty_per_plate", existing_type=sa.Integer(), nullable=False)
+        batch.drop_column("total_print_time_hrs")
+        batch.drop_column("total_material_g")
+    op.drop_index("ix_plates_printer_id", table_name="plates")
+    op.drop_index("ix_plates_job_id", table_name="plates")
+    op.drop_table("plates")

--- a/backend/app/api/v1/endpoints/jobs.py
+++ b/backend/app/api/v1/endpoints/jobs.py
@@ -23,31 +23,36 @@ from app.schemas.job import (
 from app.services.cost_calculator import CostCalculator
 from app.services.inventory_service import add_inventory_from_job
 from app.services.job_service import build_duplicate_job_create, generate_job_number
+from app.services.plate_service import (
+    aggregate_plate_totals,
+    build_plates_from_input,
+    build_uniform_plates,
+    is_uniform,
+)
 
 router = APIRouter(prefix="/jobs", tags=["Jobs"])
 
 
-@router.get(
-    "",
-    response_model=PaginatedJobs,
-    summary="List jobs",
-    description="Returns paginated print jobs with filtering by status, material, customer, date range, and product name search.",
-)
+def _job_load_options():
+    return [selectinload(Job.printer), selectinload(Job.plates)]
+
+
+@router.get("", response_model=PaginatedJobs, summary="List jobs")
 async def list_jobs(
     db: DB,
-    status: JobStatus | None = Query(None, description="Filter by job status"),
-    material_id: uuid.UUID | None = Query(None, description="Filter by material ID"),
-    customer_id: uuid.UUID | None = Query(None, description="Filter by customer ID"),
-    printer_id: uuid.UUID | None = Query(None, description="Filter by printer ID"),
-    date_from: datetime.date | None = Query(None, description="Start date (inclusive)"),
-    date_to: datetime.date | None = Query(None, description="End date (inclusive)"),
-    search: str | None = Query(None, description="Search by product name or job number"),
-    sort_by: str = Query("date", description="Sort field", pattern="^(date|job_number|total_revenue|net_profit|created_at)$"),
-    sort_dir: str = Query("desc", description="Sort direction", pattern="^(asc|desc)$"),
-    skip: int = Query(0, ge=0, description="Number of records to skip"),
-    limit: int = Query(50, ge=1, le=100, description="Max records to return"),
+    status: JobStatus | None = Query(None),
+    material_id: uuid.UUID | None = Query(None),
+    customer_id: uuid.UUID | None = Query(None),
+    printer_id: uuid.UUID | None = Query(None),
+    date_from: datetime.date | None = Query(None),
+    date_to: datetime.date | None = Query(None),
+    search: str | None = Query(None),
+    sort_by: str = Query("date", pattern="^(date|job_number|total_revenue|net_profit|created_at)$"),
+    sort_dir: str = Query("desc", pattern="^(asc|desc)$"),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
 ):
-    base = select(Job).options(selectinload(Job.printer)).where(Job.is_deleted == False)
+    base = select(Job).options(*_job_load_options()).where(Job.is_deleted == False)
 
     if status:
         base = base.where(Job.status == status.value)
@@ -63,45 +68,28 @@ async def list_jobs(
         base = base.where(Job.date <= date_to)
     if search:
         pattern = f"%{search}%"
-        base = base.where(
-            Job.product_name.ilike(pattern) | Job.job_number.ilike(pattern)
-        )
+        base = base.where(Job.product_name.ilike(pattern) | Job.job_number.ilike(pattern))
 
-    # Total count
     count_stmt = select(func.count()).select_from(base.subquery())
     total = (await db.execute(count_stmt)).scalar() or 0
 
-    # Sorting
     sort_column = getattr(Job, sort_by, Job.date)
     order = sort_column.desc() if sort_dir == "desc" else sort_column.asc()
 
     result = await db.execute(base.order_by(order).offset(skip).limit(limit))
-    items = result.scalars().all()
-
+    items = result.scalars().unique().all()
     return PaginatedJobs(items=items, total=total, skip=skip, limit=limit)
 
 
-@router.get(
-    "/next-number",
-    summary="Get next job number",
-    description="Preview the next available job number for the provided job date using YYYY.MM.DD.NNN sequencing.",
-)
-async def get_next_job_number(
-    db: DB,
-    date: datetime.date = Query(..., description="Job date to generate the next sequence for"),
-):
+@router.get("/next-number", summary="Get next job number")
+async def get_next_job_number(db: DB, date: datetime.date = Query(...)):
     return {"job_number": await generate_job_number(db, date)}
 
 
-@router.get(
-    "/{job_id}",
-    response_model=JobResponse,
-    summary="Get job by ID",
-    description="Retrieve a single job with its full cost breakdown, pricing, and profit analysis.",
-)
+@router.get("/{job_id}", response_model=JobResponse, summary="Get job by ID")
 async def get_job(job_id: uuid.UUID, db: DB):
     result = await db.execute(
-        select(Job).options(selectinload(Job.printer)).where(Job.id == job_id, Job.is_deleted == False)
+        select(Job).options(*_job_load_options()).where(Job.id == job_id, Job.is_deleted == False)
     )
     job = result.scalar_one_or_none()
     if not job:
@@ -109,52 +97,74 @@ async def get_job(job_id: uuid.UUID, db: DB):
     return job
 
 
-@router.post(
-    "",
-    response_model=JobResponse,
-    status_code=201,
-    summary="Create a job",
-    description="Create a new print job. All cost fields (electricity, material, labor, etc.) are automatically calculated from the input parameters and current business settings/rates.",
-)
+async def _validate_printers(db: DB, printer_ids: list[uuid.UUID]) -> None:
+    unique = [p for p in {pid for pid in printer_ids if pid is not None}]
+    if not unique:
+        return
+    found = (await db.execute(select(Printer.id).where(Printer.id.in_(unique)))).scalars().all()
+    if set(found) != set(unique):
+        raise HTTPException(status_code=404, detail="Printer not found")
+
+
+def _materialize_plates(body) -> tuple[list, bool]:
+    """Return (plate_orm_list, is_mixed) from a JobCreate-ish body."""
+    if body.plates:
+        return build_plates_from_input(body.plates), True
+    plates = build_uniform_plates(
+        qty_per_plate=body.qty_per_plate,
+        num_plates=body.num_plates,
+        material_per_plate_g=Decimal(body.material_per_plate_g),
+        print_time_per_plate_hrs=Decimal(body.print_time_per_plate_hrs),
+        printer_id=body.printer_id,
+    )
+    return plates, False
+
+
+@router.post("", response_model=JobResponse, status_code=201, summary="Create a job")
 async def create_job(body: JobCreate, user: CurrentUser, db: DB):
     job_number = body.job_number or await generate_job_number(db, body.date)
 
-    assigned_printer = None
-    if body.printer_id:
-        printer_exists = await db.execute(select(Printer).where(Printer.id == body.printer_id))
-        assigned_printer = printer_exists.scalar_one_or_none()
-        if not assigned_printer:
-            raise HTTPException(status_code=404, detail="Printer not found")
+    printer_ids = [body.printer_id] + [p.printer_id for p in (body.plates or [])]
+    await _validate_printers(db, printer_ids)
 
-    # Check for duplicate job number
     existing = await db.execute(select(Job.id).where(Job.job_number == job_number))
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=409, detail=f"Job number '{job_number}' already exists")
 
+    plate_rows, is_mixed = _materialize_plates(body)
+    total_pieces, total_material_g, total_print_time_hrs = aggregate_plate_totals(plate_rows)
+
     calc = CostCalculator(db)
     costs = await calc.calculate(
         material_id=body.material_id,
-        qty_per_plate=body.qty_per_plate,
-        num_plates=body.num_plates,
-        material_per_plate_g=body.material_per_plate_g,
-        print_time_per_plate_hrs=body.print_time_per_plate_hrs,
         labor_mins=body.labor_mins,
         design_time_hrs=body.design_time_hrs or Decimal(0),
         shipping_cost=body.shipping_cost,
         target_margin_pct=body.target_margin_pct,
+        total_pieces=total_pieces,
+        total_material_g=total_material_g,
+        total_print_time_hrs=total_print_time_hrs,
     )
-    # Exclude shipping_cost from body since it's included in calculated costs
-    body_data = body.model_dump(exclude={"shipping_cost"})
+
+    body_data = body.model_dump(exclude={"shipping_cost", "plates"})
     body_data["job_number"] = job_number
+    if is_mixed:
+        body_data["qty_per_plate"] = None
+        body_data["num_plates"] = None
+        body_data["material_per_plate_g"] = None
+        body_data["print_time_per_plate_hrs"] = None
+
     job = Job(
         **body_data,
-        total_pieces=body.qty_per_plate * body.num_plates,
+        total_pieces=total_pieces,
+        total_material_g=total_material_g,
+        total_print_time_hrs=total_print_time_hrs,
         **costs,
     )
+    job.plates = plate_rows
     db.add(job)
     await db.flush()
 
-    # Auto-add to inventory if job is completed and linked to a product
     if job.product_id and job.status == "completed":
         await add_inventory_from_job(
             db=db,
@@ -167,25 +177,21 @@ async def create_job(body: JobCreate, user: CurrentUser, db: DB):
         job.inventory_added = True
 
     await db.commit()
-    result = await db.execute(select(Job).options(selectinload(Job.printer)).execution_options(populate_existing=True).where(Job.id == job.id))
+    result = await db.execute(
+        select(Job).options(*_job_load_options()).execution_options(populate_existing=True).where(Job.id == job.id)
+    )
     return result.scalar_one()
 
 
-@router.put(
-    "/{job_id}",
-    response_model=JobResponse,
-    summary="Update a job",
-    description="Update one or more fields of a job. Costs are automatically recalculated when print parameters change.",
-)
+@router.put("/{job_id}", response_model=JobResponse, summary="Update a job")
 async def update_job(job_id: uuid.UUID, body: JobUpdate, user: CurrentUser, db: DB):
     result = await db.execute(
-        select(Job).options(selectinload(Job.printer)).where(Job.id == job_id, Job.is_deleted == False)
+        select(Job).options(*_job_load_options()).where(Job.id == job_id, Job.is_deleted == False)
     )
     job = result.scalar_one_or_none()
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    # Check unique job_number if it's being changed
     if body.job_number and body.job_number != job.job_number:
         existing = await db.execute(
             select(Job.id).where(Job.job_number == body.job_number, Job.id != job_id)
@@ -193,33 +199,77 @@ async def update_job(job_id: uuid.UUID, body: JobUpdate, user: CurrentUser, db: 
         if existing.scalar_one_or_none():
             raise HTTPException(status_code=409, detail=f"Job number '{body.job_number}' already exists")
 
-    if body.printer_id:
-        printer_exists = await db.execute(select(Printer.id).where(Printer.id == body.printer_id))
-        if not printer_exists.scalar_one_or_none():
-            raise HTTPException(status_code=404, detail="Printer not found")
+    update_data = body.model_dump(exclude_unset=True)
+    new_plates_payload = update_data.pop("plates", None)
+
+    printer_ids: list[uuid.UUID | None] = []
+    if "printer_id" in update_data and update_data["printer_id"] is not None:
+        printer_ids.append(update_data["printer_id"])
+    if new_plates_payload is not None:
+        printer_ids.extend([p.printer_id for p in body.plates or []])
+    await _validate_printers(db, [pid for pid in printer_ids if pid is not None])
 
     old_status = job.status
-    for field, value in body.model_dump(exclude_unset=True).items():
+    for field, value in update_data.items():
         setattr(job, field, value)
 
-    job.total_pieces = job.qty_per_plate * job.num_plates
+    # Determine new plate set
+    async def _replace_plates(fresh):
+        if job.plates:
+            for old in list(job.plates):
+                await db.delete(old)
+            job.plates = []
+            await db.flush()
+        job.plates = fresh
+
+    if new_plates_payload is not None:
+        # Caller supplied a fresh plate array — replace
+        await _replace_plates(build_plates_from_input(body.plates or []))
+        # Mixed mode: null out uniform conveniences unless they happen to be uniform
+        uniform, qpp, npl, mpp, tpp = is_uniform(job.plates)
+        if uniform:
+            job.qty_per_plate = qpp
+            job.num_plates = npl
+            job.material_per_plate_g = mpp
+            job.print_time_per_plate_hrs = tpp
+        else:
+            job.qty_per_plate = None
+            job.num_plates = None
+            job.material_per_plate_g = None
+            job.print_time_per_plate_hrs = None
+    else:
+        # Uniform input updated — only regenerate plate rows if any uniform field changed
+        uniform_keys = {"qty_per_plate", "num_plates", "material_per_plate_g", "print_time_per_plate_hrs", "printer_id"}
+        if uniform_keys & set(update_data.keys()) and job.qty_per_plate is not None and job.num_plates is not None:
+            await _replace_plates(
+                build_uniform_plates(
+                    qty_per_plate=int(job.qty_per_plate),
+                    num_plates=int(job.num_plates),
+                    material_per_plate_g=Decimal(job.material_per_plate_g or 0),
+                    print_time_per_plate_hrs=Decimal(job.print_time_per_plate_hrs or 0),
+                    printer_id=job.printer_id,
+                )
+            )
+
+    total_pieces, total_material_g, total_print_time_hrs = aggregate_plate_totals(job.plates)
+    job.total_pieces = total_pieces
+    job.total_material_g = total_material_g
+    job.total_print_time_hrs = total_print_time_hrs
 
     calc = CostCalculator(db)
     costs = await calc.calculate(
         material_id=job.material_id,
-        qty_per_plate=job.qty_per_plate,
-        num_plates=job.num_plates,
-        material_per_plate_g=job.material_per_plate_g,
-        print_time_per_plate_hrs=job.print_time_per_plate_hrs,
         labor_mins=job.labor_mins,
         design_time_hrs=job.design_time_hrs or Decimal(0),
         shipping_cost=job.shipping_cost,
         target_margin_pct=job.target_margin_pct,
+        total_pieces=total_pieces,
+        total_material_g=total_material_g,
+        total_print_time_hrs=total_print_time_hrs,
     )
     for k, v in costs.items():
         setattr(job, k, v)
 
-    # Auto-add to inventory when status changes to completed
     if (
         job.product_id
         and job.status == "completed"
@@ -237,64 +287,85 @@ async def update_job(job_id: uuid.UUID, body: JobUpdate, user: CurrentUser, db: 
         job.inventory_added = True
 
     await db.commit()
-    result = await db.execute(select(Job).options(selectinload(Job.printer)).execution_options(populate_existing=True).where(Job.id == job.id))
+    result = await db.execute(
+        select(Job).options(*_job_load_options()).execution_options(populate_existing=True).where(Job.id == job.id)
+    )
     return result.scalar_one()
 
 
-@router.post(
-    "/{job_id}/duplicate",
-    response_model=JobResponse,
-    status_code=201,
-    summary="Duplicate a job",
-    description="Create a new draft job by copying the editable inputs from an existing job and generating a new job number.",
-)
+@router.post("/{job_id}/duplicate", response_model=JobResponse, status_code=201, summary="Duplicate a job")
 async def duplicate_job(job_id: uuid.UUID, user: CurrentUser, db: DB):
     result = await db.execute(
-        select(Job).options(selectinload(Job.printer)).where(Job.id == job_id, Job.is_deleted == False)
+        select(Job).options(*_job_load_options()).where(Job.id == job_id, Job.is_deleted == False)
     )
     source_job = result.scalar_one_or_none()
     if not source_job:
         raise HTTPException(status_code=404, detail="Job not found")
 
     new_job_number = await generate_job_number(db)
-    duplicate_body = build_duplicate_job_create(source_job, job_number=new_job_number)
+
+    # Clone plate rows from source
+    cloned_plates = [
+        # Build fresh ORM objects (cannot reuse source rows — they belong to source job)
+        type(p)(
+            plate_number=p.plate_number,
+            printer_id=p.printer_id,
+            parts_count=p.parts_count,
+            material_g=p.material_g,
+            print_time_hrs=p.print_time_hrs,
+        )
+        for p in source_job.plates
+    ]
+
+    total_pieces, total_material_g, total_print_time_hrs = aggregate_plate_totals(cloned_plates)
 
     calc = CostCalculator(db)
     costs = await calc.calculate(
-        material_id=duplicate_body.material_id,
-        qty_per_plate=duplicate_body.qty_per_plate,
-        num_plates=duplicate_body.num_plates,
-        material_per_plate_g=duplicate_body.material_per_plate_g,
-        print_time_per_plate_hrs=duplicate_body.print_time_per_plate_hrs,
-        labor_mins=duplicate_body.labor_mins,
-        design_time_hrs=duplicate_body.design_time_hrs or Decimal(0),
-        shipping_cost=duplicate_body.shipping_cost,
-        target_margin_pct=duplicate_body.target_margin_pct,
+        material_id=source_job.material_id,
+        labor_mins=source_job.labor_mins,
+        design_time_hrs=source_job.design_time_hrs or Decimal(0),
+        shipping_cost=source_job.shipping_cost,
+        target_margin_pct=source_job.target_margin_pct,
+        total_pieces=total_pieces,
+        total_material_g=total_material_g,
+        total_print_time_hrs=total_print_time_hrs,
     )
 
-    body_data = duplicate_body.model_dump(exclude={"shipping_cost"})
     job = Job(
-        **body_data,
-        total_pieces=duplicate_body.qty_per_plate * duplicate_body.num_plates,
+        job_number=new_job_number,
+        date=datetime.date.today(),
+        customer_id=source_job.customer_id,
+        customer_name=source_job.customer_name,
+        product_name=source_job.product_name,
+        qty_per_plate=source_job.qty_per_plate,
+        num_plates=source_job.num_plates,
+        material_id=source_job.material_id,
+        material_per_plate_g=source_job.material_per_plate_g,
+        print_time_per_plate_hrs=source_job.print_time_per_plate_hrs,
+        total_pieces=total_pieces,
+        total_material_g=total_material_g,
+        total_print_time_hrs=total_print_time_hrs,
+        labor_mins=source_job.labor_mins,
+        design_time_hrs=source_job.design_time_hrs,
+        target_margin_pct=source_job.target_margin_pct,
+        product_id=source_job.product_id,
+        printer_id=source_job.printer_id,
+        status="draft",
         inventory_added=False,
         **costs,
     )
+    job.plates = cloned_plates
     db.add(job)
     await db.commit()
-    result = await db.execute(select(Job).options(selectinload(Job.printer)).execution_options(populate_existing=True).where(Job.id == job.id))
+    result = await db.execute(
+        select(Job).options(*_job_load_options()).execution_options(populate_existing=True).where(Job.id == job.id)
+    )
     return result.scalar_one()
 
 
-@router.delete(
-    "/{job_id}",
-    status_code=204,
-    summary="Delete a job",
-    description="Soft-deletes a job by marking it as deleted. The record is preserved for historical reporting.",
-)
+@router.delete("/{job_id}", status_code=204, summary="Delete a job")
 async def delete_job(job_id: uuid.UUID, user: CurrentUser, db: DB):
-    result = await db.execute(
-        select(Job).where(Job.id == job_id, Job.is_deleted == False)
-    )
+    result = await db.execute(select(Job).where(Job.id == job_id, Job.is_deleted == False))
     job = result.scalar_one_or_none()
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -302,26 +373,23 @@ async def delete_job(job_id: uuid.UUID, user: CurrentUser, db: DB):
     await db.commit()
 
 
-@router.post(
-    "/calculate",
-    response_model=CalculateResponse,
-    summary="Preview cost calculation",
-    description="Run the cost calculation engine without saving a job. Use this for the live cost preview in the job form or the standalone calculator.",
-)
+@router.post("/calculate", response_model=CalculateResponse, summary="Preview cost calculation")
 async def calculate_preview(body: CalculateRequest, db: DB):
     calc = CostCalculator(db)
+    total_pieces = body.qty_per_plate * body.num_plates
+    total_material_g = Decimal(body.material_per_plate_g) * body.num_plates
+    total_print_time_hrs = Decimal(body.print_time_per_plate_hrs) * body.num_plates
     costs = await calc.calculate(
         material_id=body.material_id,
-        qty_per_plate=body.qty_per_plate,
-        num_plates=body.num_plates,
-        material_per_plate_g=body.material_per_plate_g,
-        print_time_per_plate_hrs=body.print_time_per_plate_hrs,
         labor_mins=body.labor_mins,
         design_time_hrs=body.design_time_hrs or Decimal(0),
         shipping_cost=body.shipping_cost,
         target_margin_pct=body.target_margin_pct,
+        total_pieces=total_pieces,
+        total_material_g=total_material_g,
+        total_print_time_hrs=total_print_time_hrs,
     )
     return CalculateResponse(
-        total_pieces=body.qty_per_plate * body.num_plates,
+        total_pieces=total_pieces,
         **{k: float(v) if isinstance(v, Decimal) else v for k, v in costs.items()},
     )

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -132,6 +132,9 @@ async def convert_quote_to_job(quote_id: uuid.UUID, body: QuoteConvertToJob, use
     if existing_job.scalar_one_or_none():
         raise HTTPException(status_code=409, detail=f"Job number '{body.job_number}' already exists")
 
+    from app.services.plate_service import build_uniform_plates
+    total_material_g = Decimal(quote.material_per_plate_g) * quote.num_plates
+    total_print_time_hrs = Decimal(quote.print_time_per_plate_hrs) * quote.num_plates
     job = Job(
         job_number=body.job_number,
         date=body.job_date or datetime.date.today(),
@@ -144,6 +147,8 @@ async def convert_quote_to_job(quote_id: uuid.UUID, body: QuoteConvertToJob, use
         total_pieces=quote.total_pieces,
         material_per_plate_g=quote.material_per_plate_g,
         print_time_per_plate_hrs=quote.print_time_per_plate_hrs,
+        total_material_g=total_material_g,
+        total_print_time_hrs=total_print_time_hrs,
         labor_mins=quote.labor_mins,
         design_time_hrs=quote.design_time_hrs,
         electricity_cost=quote.electricity_cost,
@@ -165,6 +170,13 @@ async def convert_quote_to_job(quote_id: uuid.UUID, body: QuoteConvertToJob, use
         net_profit=quote.net_profit,
         profit_per_piece=quote.profit_per_piece,
         status=body.status,
+    )
+    job.plates = build_uniform_plates(
+        qty_per_plate=int(quote.qty_per_plate),
+        num_plates=int(quote.num_plates),
+        material_per_plate_g=Decimal(quote.material_per_plate_g),
+        print_time_per_plate_hrs=Decimal(quote.print_time_per_plate_hrs),
+        printer_id=None,
     )
     db.add(job)
     await db.flush()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -41,3 +41,4 @@ from app.models.withholding_profile import WithholdingProfile  # noqa: F401
 from app.models.billable_expense import BillableExpense  # noqa: F401
 from app.models.job_discovery import JobDiscoverySource, JobDiscoveryCandidate  # noqa: F401
 from app.models.bank_import_mapping import BankImportMapping  # noqa: F401
+from app.models.plate import Plate  # noqa: F401

--- a/backend/app/models/job.py
+++ b/backend/app/models/job.py
@@ -21,12 +21,14 @@ class Job(Base):
     )
     customer_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
     product_name: Mapped[str] = mapped_column(String(200))
-    qty_per_plate: Mapped[int] = mapped_column(Integer)
-    num_plates: Mapped[int] = mapped_column(Integer)
+    qty_per_plate: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    num_plates: Mapped[int | None] = mapped_column(Integer, nullable=True)
     material_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("materials.id"))
     total_pieces: Mapped[int] = mapped_column(Integer)
-    material_per_plate_g: Mapped[Decimal] = mapped_column(Numeric(10, 2))
-    print_time_per_plate_hrs: Mapped[Decimal] = mapped_column(Numeric(10, 2))
+    material_per_plate_g: Mapped[Decimal | None] = mapped_column(Numeric(10, 2), nullable=True)
+    print_time_per_plate_hrs: Mapped[Decimal | None] = mapped_column(Numeric(10, 2), nullable=True)
+    total_material_g: Mapped[Decimal] = mapped_column(Numeric(10, 2), default=0)
+    total_print_time_hrs: Mapped[Decimal] = mapped_column(Numeric(10, 2), default=0)
     labor_mins: Mapped[Decimal] = mapped_column(Numeric(10, 2), default=0)
     design_time_hrs: Mapped[Decimal | None] = mapped_column(
         Numeric(10, 2), nullable=True, default=0
@@ -80,3 +82,9 @@ class Job(Base):
     material = relationship("Material")
     product = relationship("Product")
     printer = relationship("Printer")
+    plates = relationship(
+        "Plate",
+        back_populates="job",
+        cascade="all, delete-orphan",
+        order_by="Plate.plate_number",
+    )

--- a/backend/app/models/plate.py
+++ b/backend/app/models/plate.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Numeric, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class Plate(Base):
+    __tablename__ = "plates"
+    __table_args__ = (
+        UniqueConstraint("job_id", "plate_number", name="uq_plates_job_plate_number"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    job_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("jobs.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    plate_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    printer_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("printers.id"), nullable=True, index=True
+    )
+    parts_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    material_g: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+    print_time_hrs: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    job = relationship("Job", back_populates="plates")
+    printer = relationship("Printer")

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -5,8 +5,9 @@ import uuid
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
+from app.schemas.plate import PlateIn, PlateResponse
 from app.schemas.printer import PrinterResponse
 
 
@@ -17,17 +18,20 @@ class JobStatus(str, Enum):
     cancelled = "cancelled"
 
 
+_UNIFORM_FIELDS = ("qty_per_plate", "num_plates", "material_per_plate_g", "print_time_per_plate_hrs")
+
+
 class JobCreate(BaseModel):
     job_number: str | None = Field(None, min_length=1, max_length=50, examples=["2026.03.04.001"])
     date: datetime.date = Field(..., examples=["2026-03-04"])
     customer_id: uuid.UUID | None = None
     customer_name: str | None = Field(None, max_length=200, examples=["Sample Customer"])
     product_name: str = Field(..., min_length=1, max_length=200, examples=["Phone Stand"])
-    qty_per_plate: int = Field(..., gt=0, examples=[1])
-    num_plates: int = Field(..., gt=0, examples=[1])
+    qty_per_plate: int | None = Field(None, gt=0, examples=[1])
+    num_plates: int | None = Field(None, gt=0, examples=[1])
     material_id: uuid.UUID
-    material_per_plate_g: Decimal = Field(..., gt=0, examples=[45.0])
-    print_time_per_plate_hrs: Decimal = Field(..., gt=0, examples=[2.5])
+    material_per_plate_g: Decimal | None = Field(None, gt=0, examples=[45.0])
+    print_time_per_plate_hrs: Decimal | None = Field(None, gt=0, examples=[2.5])
     labor_mins: Decimal = Field(Decimal(0), ge=0, examples=[15])
     design_time_hrs: Decimal | None = Field(Decimal(0), ge=0, examples=[0.5])
     shipping_cost: Decimal = Field(Decimal(0), ge=0, examples=[0])
@@ -36,6 +40,18 @@ class JobCreate(BaseModel):
     printer_id: uuid.UUID | None = None
     project_id: uuid.UUID | None = None
     status: JobStatus = Field(JobStatus.completed, examples=["completed"])
+    plates: list[PlateIn] | None = Field(None, description="Per-plate breakdown for multi-part prints. If provided, supersedes uniform fields.")
+
+    @model_validator(mode="after")
+    def _validate_mode(self) -> "JobCreate":
+        if self.plates:
+            if not self.plates:
+                raise ValueError("plates must contain at least one entry")
+        else:
+            missing = [f for f in _UNIFORM_FIELDS if getattr(self, f) is None]
+            if missing:
+                raise ValueError(f"Either 'plates' or all uniform fields must be provided. Missing: {missing}")
+        return self
 
 
 class JobUpdate(BaseModel):
@@ -57,6 +73,7 @@ class JobUpdate(BaseModel):
     printer_id: uuid.UUID | None = None
     project_id: uuid.UUID | None = None
     status: JobStatus | None = None
+    plates: list[PlateIn] | None = None
 
 
 class CalculateRequest(BaseModel):
@@ -99,12 +116,14 @@ class JobResponse(BaseModel):
     customer_id: uuid.UUID | None = None
     customer_name: str | None = None
     product_name: str
-    qty_per_plate: int
-    num_plates: int
+    qty_per_plate: int | None = None
+    num_plates: int | None = None
     material_id: uuid.UUID
     total_pieces: int
-    material_per_plate_g: Decimal
-    print_time_per_plate_hrs: Decimal
+    material_per_plate_g: Decimal | None = None
+    print_time_per_plate_hrs: Decimal | None = None
+    total_material_g: Decimal
+    total_print_time_hrs: Decimal
     labor_mins: Decimal
     design_time_hrs: Decimal | None = None
     electricity_cost: Decimal
@@ -131,6 +150,7 @@ class JobResponse(BaseModel):
     project_id: uuid.UUID | None = None
     inventory_added: bool = False
     status: str
+    plates: list[PlateResponse] = []
     created_at: datetime.datetime | None = None
     updated_at: datetime.datetime | None = None
 

--- a/backend/app/schemas/plate.py
+++ b/backend/app/schemas/plate.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+class PlateIn(BaseModel):
+    plate_number: int | None = Field(None, gt=0, examples=[1])
+    printer_id: uuid.UUID | None = None
+    parts_count: int = Field(..., gt=0, examples=[4])
+    material_g: Decimal = Field(..., gt=0, examples=[45.0])
+    print_time_hrs: Decimal = Field(..., gt=0, examples=[2.5])
+
+
+class PlateResponse(BaseModel):
+    id: uuid.UUID
+    plate_number: int
+    printer_id: uuid.UUID | None = None
+    parts_count: int
+    material_g: Decimal
+    print_time_hrs: Decimal
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/cost_calculator.py
+++ b/backend/app/services/cost_calculator.py
@@ -31,15 +31,33 @@ class CostCalculator:
     async def calculate(
         self,
         material_id: uuid.UUID,
-        qty_per_plate: int,
-        num_plates: int,
-        material_per_plate_g: Decimal,
-        print_time_per_plate_hrs: Decimal,
         labor_mins: Decimal,
         design_time_hrs: Decimal,
         shipping_cost: Decimal,
         target_margin_pct: Decimal,
+        *,
+        total_pieces: int | None = None,
+        total_material_g: Decimal | None = None,
+        total_print_time_hrs: Decimal | None = None,
+        qty_per_plate: int | None = None,
+        num_plates: int | None = None,
+        material_per_plate_g: Decimal | None = None,
+        print_time_per_plate_hrs: Decimal | None = None,
     ) -> dict:
+        # Accept either pre-computed totals or legacy uniform inputs.
+        if total_pieces is None:
+            if qty_per_plate is None or num_plates is None:
+                raise HTTPException(status_code=400, detail="total_pieces or qty_per_plate+num_plates required")
+            total_pieces = qty_per_plate * num_plates
+        if total_material_g is None:
+            if material_per_plate_g is None or num_plates is None:
+                raise HTTPException(status_code=400, detail="total_material_g or material_per_plate_g+num_plates required")
+            total_material_g = Decimal(material_per_plate_g) * num_plates
+        if total_print_time_hrs is None:
+            if print_time_per_plate_hrs is None or num_plates is None:
+                raise HTTPException(status_code=400, detail="total_print_time_hrs or print_time_per_plate_hrs+num_plates required")
+            total_print_time_hrs = Decimal(print_time_per_plate_hrs) * num_plates
+
         # Validate material exists
         result = await self.db.execute(select(Material).where(Material.id == material_id))
         material = result.scalar_one_or_none()
@@ -62,15 +80,14 @@ class CostCalculator:
         machine_rate = await self._get_rate("Machine rate")
         overhead_pct = await self._get_rate("Overhead %")
 
-        total_pieces = qty_per_plate * num_plates
         if total_pieces <= 0:
             raise HTTPException(status_code=400, detail="Total pieces must be greater than 0")
 
-        total_print_hrs = print_time_per_plate_hrs * num_plates
+        total_print_hrs = Decimal(total_print_time_hrs)
 
         # Cost calculations
         electricity_cost = (printer_watts / Decimal(1000)) * total_print_hrs * electricity_rate
-        material_cost = material_per_plate_g * num_plates * cost_per_g
+        material_cost = Decimal(total_material_g) * cost_per_g
         labor_cost = (labor_mins / Decimal(60)) * labor_rate
         design_cost = design_time_hrs * labor_rate
         machine_cost = total_print_hrs * machine_rate

--- a/backend/app/services/inventory_accounting_service.py
+++ b/backend/app/services/inventory_accounting_service.py
@@ -37,7 +37,7 @@ async def consume_material_receipts_for_job(db: AsyncSession, job: Job) -> None:
     if not job.material_id:
         return
 
-    total_material_g = Decimal(job.material_per_plate_g) * job.num_plates
+    total_material_g = Decimal(job.total_material_g or 0)
     if total_material_g <= 0:
         return
 

--- a/backend/app/services/job_discovery_service.py
+++ b/backend/app/services/job_discovery_service.py
@@ -179,17 +179,32 @@ async def promote_candidate(
     if job_number is None:
         job_number = f"DJ-{datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d%H%M%S%f')[:18]}"
 
+    from decimal import Decimal as _D
+    from app.services.plate_service import build_uniform_plates
+    qpp = int(job_payload["qty_per_plate"])
+    npl = int(job_payload["num_plates"])
+    mpp = _D(str(job_payload["material_per_plate_g"]))
+    tpp = _D(str(job_payload["print_time_per_plate_hrs"]))
     job = Job(
         job_number=job_number,
         date=datetime.date.today(),
         product_name=job_payload["product_name"],
-        qty_per_plate=int(job_payload["qty_per_plate"]),
-        num_plates=int(job_payload["num_plates"]),
+        qty_per_plate=qpp,
+        num_plates=npl,
         material_id=job_payload["material_id"],
-        total_pieces=int(job_payload["qty_per_plate"]) * int(job_payload["num_plates"]),
-        material_per_plate_g=job_payload["material_per_plate_g"],
-        print_time_per_plate_hrs=job_payload["print_time_per_plate_hrs"],
+        total_pieces=qpp * npl,
+        material_per_plate_g=mpp,
+        print_time_per_plate_hrs=tpp,
+        total_material_g=mpp * npl,
+        total_print_time_hrs=tpp * npl,
         status="draft",
+    )
+    job.plates = build_uniform_plates(
+        qty_per_plate=qpp,
+        num_plates=npl,
+        material_per_plate_g=mpp,
+        print_time_per_plate_hrs=tpp,
+        printer_id=None,
     )
     db.add(job)
     await db.flush()

--- a/backend/app/services/plate_service.py
+++ b/backend/app/services/plate_service.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import Iterable
+
+from app.models.plate import Plate
+from app.schemas.plate import PlateIn
+
+
+def build_uniform_plates(
+    *,
+    qty_per_plate: int,
+    num_plates: int,
+    material_per_plate_g: Decimal,
+    print_time_per_plate_hrs: Decimal,
+    printer_id: uuid.UUID | None,
+) -> list[Plate]:
+    """Expand the legacy uniform inputs into N identical Plate rows."""
+    return [
+        Plate(
+            plate_number=i + 1,
+            printer_id=printer_id,
+            parts_count=qty_per_plate,
+            material_g=material_per_plate_g,
+            print_time_hrs=print_time_per_plate_hrs,
+        )
+        for i in range(num_plates)
+    ]
+
+
+def build_plates_from_input(plates_in: Iterable[PlateIn]) -> list[Plate]:
+    """Materialize PlateIn payloads into Plate rows, assigning sequential plate_numbers when omitted."""
+    result: list[Plate] = []
+    auto = 1
+    seen: set[int] = set()
+    for entry in plates_in:
+        number = entry.plate_number if entry.plate_number is not None else auto
+        while number in seen:
+            number += 1
+        seen.add(number)
+        auto = max(auto, number) + 1
+        result.append(
+            Plate(
+                plate_number=number,
+                printer_id=entry.printer_id,
+                parts_count=entry.parts_count,
+                material_g=Decimal(entry.material_g),
+                print_time_hrs=Decimal(entry.print_time_hrs),
+            )
+        )
+    return result
+
+
+def aggregate_plate_totals(plates: Iterable[Plate]) -> tuple[int, Decimal, Decimal]:
+    """Return (total_pieces, total_material_g, total_print_time_hrs) for a plate collection."""
+    total_pieces = 0
+    total_material_g = Decimal(0)
+    total_print_hrs = Decimal(0)
+    for p in plates:
+        total_pieces += int(p.parts_count)
+        total_material_g += Decimal(p.material_g)
+        total_print_hrs += Decimal(p.print_time_hrs)
+    return total_pieces, total_material_g, total_print_hrs
+
+
+def is_uniform(plates: list[Plate]) -> tuple[bool, int | None, int | None, Decimal | None, Decimal | None]:
+    """Detect whether a plate set is uniform; return (is_uniform, qty_per_plate, num_plates, material_per_plate_g, print_time_per_plate_hrs)."""
+    if not plates:
+        return False, None, None, None, None
+    first = plates[0]
+    for p in plates[1:]:
+        if (
+            int(p.parts_count) != int(first.parts_count)
+            or Decimal(p.material_g) != Decimal(first.material_g)
+            or Decimal(p.print_time_hrs) != Decimal(first.print_time_hrs)
+        ):
+            return False, None, None, None, None
+    return (
+        True,
+        int(first.parts_count),
+        len(plates),
+        Decimal(first.material_g),
+        Decimal(first.print_time_hrs),
+    )

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -78,7 +78,7 @@ async def generate_inventory_report(db: AsyncSession, date_from: date | None, da
     mat_stmt = (
         select(
             Material.name,
-            func.coalesce(func.sum(Job.material_per_plate_g * Job.num_plates), 0).label("total_g"),
+            func.coalesce(func.sum(Job.total_material_g), 0).label("total_g"),
             func.coalesce(func.sum(Job.material_cost), 0).label("total_cost"),
         )
         .join(Job, Job.material_id == Material.id)

--- a/backend/tests/test_api_jobs.py
+++ b/backend/tests/test_api_jobs.py
@@ -515,3 +515,174 @@ async def test_calculate_preview(client, seed_settings, seed_rates, seed_materia
     assert data["total_pieces"] == 1
     assert data["total_cost"] > 0
     assert data["net_profit"] > 0
+
+
+@pytest.mark.asyncio
+async def test_create_job_with_mixed_plates(client, seed_settings, seed_rates, seed_material, auth_headers):
+    resp = await client.post(
+        "/api/v1/jobs",
+        json={
+            "job_number": "MIX-001",
+            "date": "2026-03-30",
+            "product_name": "Multi-part assembly",
+            "material_id": str(seed_material.id),
+            "labor_mins": 15,
+            "design_time_hrs": 0.5,
+            "shipping_cost": 0,
+            "target_margin_pct": 40,
+            "plates": [
+                {"parts_count": 4, "material_g": 50, "print_time_hrs": 2.0},
+                {"parts_count": 2, "material_g": 30, "print_time_hrs": 1.5},
+                {"parts_count": 6, "material_g": 80, "print_time_hrs": 3.0},
+            ],
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    # Sums, not products
+    assert data["total_pieces"] == 12
+    assert float(data["total_material_g"]) == pytest.approx(160.0)
+    assert float(data["total_print_time_hrs"]) == pytest.approx(6.5)
+    # Uniform conveniences nulled for mixed jobs
+    assert data["qty_per_plate"] is None
+    assert data["num_plates"] is None
+    # Plate rows returned in order
+    assert len(data["plates"]) == 3
+    assert [p["parts_count"] for p in data["plates"]] == [4, 2, 6]
+
+
+@pytest.mark.asyncio
+async def test_create_job_uniform_still_generates_plate_rows(client, seed_settings, seed_rates, seed_material, auth_headers):
+    resp = await client.post(
+        "/api/v1/jobs",
+        json={
+            "job_number": "UNI-001",
+            "date": "2026-03-30",
+            "product_name": "Uniform job",
+            "qty_per_plate": 5,
+            "num_plates": 3,
+            "material_id": str(seed_material.id),
+            "material_per_plate_g": 40,
+            "print_time_per_plate_hrs": 2.0,
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["total_pieces"] == 15
+    assert float(data["total_material_g"]) == pytest.approx(120.0)
+    assert float(data["total_print_time_hrs"]) == pytest.approx(6.0)
+    assert len(data["plates"]) == 3
+    assert all(p["parts_count"] == 5 for p in data["plates"])
+
+
+@pytest.mark.asyncio
+async def test_create_job_requires_plates_or_uniform(client, seed_settings, seed_rates, seed_material, auth_headers):
+    resp = await client.post(
+        "/api/v1/jobs",
+        json={
+            "job_number": "BAD-001",
+            "date": "2026-03-30",
+            "product_name": "Missing inputs",
+            "material_id": str(seed_material.id),
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_job_replace_plates(client, seed_settings, seed_rates, seed_material, auth_headers):
+    create = await client.post(
+        "/api/v1/jobs",
+        json={
+            "job_number": "MIX-UPD",
+            "date": "2026-03-30",
+            "product_name": "Updatable",
+            "material_id": str(seed_material.id),
+            "plates": [
+                {"parts_count": 2, "material_g": 20, "print_time_hrs": 1.0},
+                {"parts_count": 2, "material_g": 20, "print_time_hrs": 1.0},
+            ],
+        },
+        headers=auth_headers,
+    )
+    assert create.status_code == 201
+    job_id = create.json()["id"]
+
+    upd = await client.put(
+        f"/api/v1/jobs/{job_id}",
+        json={
+            "plates": [
+                {"parts_count": 7, "material_g": 100, "print_time_hrs": 4.0},
+            ]
+        },
+        headers=auth_headers,
+    )
+    assert upd.status_code == 200, upd.text
+    data = upd.json()
+    assert data["total_pieces"] == 7
+    assert float(data["total_material_g"]) == pytest.approx(100.0)
+    assert len(data["plates"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_mixed_plate_job_inventory_deduction(client, seed_settings, seed_rates, seed_material, auth_headers, db_session):
+    """End-to-end: create a mixed-plate completed job linked to a product and verify material receipts are debited by the exact plate sum."""
+    from decimal import Decimal
+    from datetime import date
+    from app.models.material_receipt import MaterialReceipt
+    from app.models.product import Product
+    from app.services.material_receipt_service import create_material_receipt
+    from app.services.accounting_service import seed_chart_of_accounts
+    from app.schemas.material_receipt import MaterialReceiptCreate
+
+    await seed_chart_of_accounts(db_session)
+    await create_material_receipt(
+        db_session,
+        material=seed_material,
+        payload=MaterialReceiptCreate(
+            vendor_name="Vendor B",
+            purchase_date=date(2026, 3, 30),
+            quantity_purchased_g=Decimal("1000"),
+            unit_cost_per_g=Decimal("0.020000"),
+            landed_cost_total=Decimal("0.00"),
+            valuation_method="lot",
+        ),
+    )
+    product = Product(
+        sku="MIX-DED-001",
+        name="Mixed Plate Product",
+        material_id=seed_material.id,
+        unit_cost=Decimal("4.00"),
+        unit_price=Decimal("12.00"),
+        stock_qty=0,
+        reorder_point=2,
+        is_active=True,
+    )
+    db_session.add(product)
+    await db_session.commit()
+    await db_session.refresh(product)
+
+    resp = await client.post(
+        "/api/v1/jobs",
+        json={
+            "job_number": "MIX-DED-001",
+            "date": "2026-03-30",
+            "product_name": product.name,
+            "product_id": str(product.id),
+            "material_id": str(seed_material.id),
+            "status": "completed",
+            "plates": [
+                {"parts_count": 3, "material_g": 50, "print_time_hrs": 2.0},
+                {"parts_count": 2, "material_g": 75, "print_time_hrs": 2.5},
+            ],
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+    receipt = (await db_session.execute(select(MaterialReceipt).where(MaterialReceipt.material_id == seed_material.id))).scalar_one()
+    # 1000 - (50 + 75) = 875
+    assert float(receipt.quantity_remaining_g) == pytest.approx(875.0, rel=1e-5)

--- a/backend/tests/test_inventory_accounting.py
+++ b/backend/tests/test_inventory_accounting.py
@@ -67,6 +67,8 @@ async def test_post_finished_goods_from_job_creates_inventory_journal_and_consum
         num_plates=3,
         material_per_plate_g=Decimal("100"),
         print_time_per_plate_hrs=Decimal("1.0"),
+        total_material_g=Decimal("300"),
+        total_print_time_hrs=Decimal("3.0"),
         labor_mins=10,
         design_time_hrs=Decimal("0"),
         shipping_cost=Decimal("0"),

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -140,11 +140,22 @@ export default function JobDetailPage() {
         </div>
         <div className="bg-card border border-border rounded-lg p-4 flex items-center gap-3">
           <Package className="w-5 h-5 text-muted-foreground" />
-          <div><p className="text-xs text-muted-foreground">Total Pieces</p><p className="font-medium">{job.total_pieces} ({job.qty_per_plate} x {job.num_plates} plates)</p></div>
+          <div>
+            <p className="text-xs text-muted-foreground">Total Pieces</p>
+            <p className="font-medium">
+              {job.total_pieces}
+              {job.qty_per_plate !== null && job.num_plates !== null
+                ? ` (${job.qty_per_plate} x ${job.num_plates} plates)`
+                : ` (${job.plates?.length || 0} plates, mixed)`}
+            </p>
+          </div>
         </div>
         <div className="bg-card border border-border rounded-lg p-4 flex items-center gap-3">
           <Printer className="w-5 h-5 text-muted-foreground" />
-          <div><p className="text-xs text-muted-foreground">Print Time</p><p className="font-medium">{Number(job.print_time_per_plate_hrs).toFixed(1)}h x {job.num_plates} plates</p></div>
+          <div>
+            <p className="text-xs text-muted-foreground">Print Time</p>
+            <p className="font-medium">{Number(job.total_print_time_hrs).toFixed(1)}h total</p>
+          </div>
         </div>
         <div className="bg-card border border-border rounded-lg p-4 flex items-center gap-3">
           <Printer className="w-5 h-5 text-muted-foreground" />
@@ -157,6 +168,38 @@ export default function JobDetailPage() {
           </div>
         </div>
       </div>
+
+      {job.plates && job.plates.length > 0 && (
+        <div className="bg-card border border-border rounded-lg p-6">
+          <h3 className="text-base font-semibold mb-4">Plates ({job.plates.length})</h3>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-xs text-muted-foreground border-b border-border">
+                <tr>
+                  <th className="text-left py-2 pr-3">#</th>
+                  <th className="text-right py-2 px-3">Parts</th>
+                  <th className="text-right py-2 px-3">Material (g)</th>
+                  <th className="text-right py-2 px-3">Time (hrs)</th>
+                  <th className="text-left py-2 pl-3">Printer</th>
+                </tr>
+              </thead>
+              <tbody>
+                {job.plates.map((p) => (
+                  <tr key={p.id} className="border-b border-border/50">
+                    <td className="py-2 pr-3">{p.plate_number}</td>
+                    <td className="text-right py-2 px-3">{p.parts_count}</td>
+                    <td className="text-right py-2 px-3">{Number(p.material_g).toFixed(2)}</td>
+                    <td className="text-right py-2 px-3">{Number(p.print_time_hrs).toFixed(2)}</td>
+                    <td className="py-2 pl-3 text-muted-foreground">
+                      {p.printer_id ? (job.printer?.id === p.printer_id ? job.printer.name : '(other)') : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Cost Breakdown */}

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -11,7 +11,14 @@ import { Label } from '@/components/ui/Label';
 import PageHeader from '@/components/layout/PageHeader';
 import { formatCurrency } from '@/lib/utils';
 import { getApiErrorMessage } from '@/lib/apiError';
-import type { Material, Job, CalculateResponse, PaginatedProducts, PaginatedPrinters, Product } from '@/types';
+import type { Material, Job, CalculateResponse, PaginatedProducts, PaginatedPrinters, Product, PlateInput } from '@/types';
+
+type PlateFormRow = {
+  parts_count: number;
+  material_g: number;
+  print_time_hrs: number;
+  printer_id: string;
+};
 
 interface FieldProps {
   label: string;
@@ -97,6 +104,10 @@ export default function JobFormPage() {
     status: 'completed',
   });
 
+  const [plateMode, setPlateMode] = useState<'uniform' | 'mixed'>('uniform');
+  const [plates, setPlates] = useState<PlateFormRow[]>([
+    { parts_count: 1, material_g: 0, print_time_hrs: 0, printer_id: '' },
+  ]);
   const [preview, setPreview] = useState<CalculateResponse | null>(null);
   const [saving, setSaving] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -109,16 +120,17 @@ export default function JobFormPage() {
   useEffect(() => {
     if (existingJob) {
       setJobNumberTouched(true);
+      const isMixed = existingJob.qty_per_plate === null || existingJob.num_plates === null;
       setForm({
         job_number: existingJob.job_number,
         date: existingJob.date,
         customer_name: existingJob.customer_name || '',
         product_name: existingJob.product_name,
-        qty_per_plate: existingJob.qty_per_plate,
-        num_plates: existingJob.num_plates,
+        qty_per_plate: existingJob.qty_per_plate ?? 1,
+        num_plates: existingJob.num_plates ?? 1,
         material_id: existingJob.material_id,
-        material_per_plate_g: existingJob.material_per_plate_g,
-        print_time_per_plate_hrs: existingJob.print_time_per_plate_hrs,
+        material_per_plate_g: existingJob.material_per_plate_g ?? 0,
+        print_time_per_plate_hrs: existingJob.print_time_per_plate_hrs ?? 0,
         labor_mins: existingJob.labor_mins,
         design_time_hrs: existingJob.design_time_hrs || 0,
         shipping_cost: existingJob.shipping_cost,
@@ -127,6 +139,15 @@ export default function JobFormPage() {
         printer_id: existingJob.printer_id || '',
         status: existingJob.status,
       });
+      setPlateMode(isMixed ? 'mixed' : 'uniform');
+      if (existingJob.plates && existingJob.plates.length > 0) {
+        setPlates(existingJob.plates.map((p) => ({
+          parts_count: p.parts_count,
+          material_g: Number(p.material_g),
+          print_time_hrs: Number(p.print_time_hrs),
+          printer_id: p.printer_id || '',
+        })));
+      }
     }
   }, [existingJob]);
 
@@ -150,18 +171,41 @@ export default function JobFormPage() {
 
   // Live cost preview
   useEffect(() => {
-    if (!form.material_id || form.material_per_plate_g <= 0 || form.print_time_per_plate_hrs <= 0) {
+    if (!form.material_id) {
       setPreview(null);
       return;
+    }
+    let qty_per_plate = form.qty_per_plate;
+    let num_plates = form.num_plates;
+    let material_per_plate_g = form.material_per_plate_g;
+    let print_time_per_plate_hrs = form.print_time_per_plate_hrs;
+    if (plateMode === 'mixed') {
+      const totalParts = plates.reduce((s, p) => s + (Number(p.parts_count) || 0), 0);
+      const totalMaterial = plates.reduce((s, p) => s + (Number(p.material_g) || 0), 0);
+      const totalTime = plates.reduce((s, p) => s + (Number(p.print_time_hrs) || 0), 0);
+      if (totalParts <= 0 || totalMaterial <= 0 || totalTime <= 0) {
+        setPreview(null);
+        return;
+      }
+      // Use a 1-plate equivalent — the math in cost_calculator only depends on totals.
+      qty_per_plate = totalParts;
+      num_plates = 1;
+      material_per_plate_g = totalMaterial;
+      print_time_per_plate_hrs = totalTime;
+    } else {
+      if (material_per_plate_g <= 0 || print_time_per_plate_hrs <= 0) {
+        setPreview(null);
+        return;
+      }
     }
     const timer = setTimeout(async () => {
       try {
         const { data } = await api.post('/jobs/calculate', {
-          qty_per_plate: form.qty_per_plate,
-          num_plates: form.num_plates,
+          qty_per_plate,
+          num_plates,
           material_id: form.material_id,
-          material_per_plate_g: form.material_per_plate_g,
-          print_time_per_plate_hrs: form.print_time_per_plate_hrs,
+          material_per_plate_g,
+          print_time_per_plate_hrs,
           labor_mins: form.labor_mins,
           design_time_hrs: form.design_time_hrs,
           shipping_cost: form.shipping_cost,
@@ -173,7 +217,7 @@ export default function JobFormPage() {
       }
     }, 300);
     return () => clearTimeout(timer);
-  }, [form.material_id, form.qty_per_plate, form.num_plates, form.material_per_plate_g, form.print_time_per_plate_hrs, form.labor_mins, form.design_time_hrs, form.shipping_cost, form.target_margin_pct]);
+  }, [plateMode, plates, form.material_id, form.qty_per_plate, form.num_plates, form.material_per_plate_g, form.print_time_per_plate_hrs, form.labor_mins, form.design_time_hrs, form.shipping_cost, form.target_margin_pct]);
 
   const update = (field: string, value: string | number) => {
     setForm((f) => ({ ...f, [field]: value }));
@@ -240,12 +284,32 @@ export default function JobFormPage() {
     if (isEdit && !form.job_number) errs.job_number = 'Required';
     if (!form.product_name) errs.product_name = 'Required';
     if (!form.material_id) errs.material_id = 'Select a material';
-    if (form.qty_per_plate < 1) errs.qty_per_plate = 'Must be at least 1';
-    if (form.num_plates < 1) errs.num_plates = 'Must be at least 1';
-    if (form.material_per_plate_g <= 0) errs.material_per_plate_g = 'Must be greater than 0';
-    if (form.print_time_per_plate_hrs <= 0) errs.print_time_per_plate_hrs = 'Must be greater than 0';
+    if (plateMode === 'uniform') {
+      if (form.qty_per_plate < 1) errs.qty_per_plate = 'Must be at least 1';
+      if (form.num_plates < 1) errs.num_plates = 'Must be at least 1';
+      if (form.material_per_plate_g <= 0) errs.material_per_plate_g = 'Must be greater than 0';
+      if (form.print_time_per_plate_hrs <= 0) errs.print_time_per_plate_hrs = 'Must be greater than 0';
+    } else {
+      if (plates.length === 0) errs.plates = 'Add at least one plate';
+      plates.forEach((p, i) => {
+        if (p.parts_count < 1) errs[`plate_${i}_parts_count`] = 'Min 1';
+        if (p.material_g <= 0) errs[`plate_${i}_material_g`] = 'Required';
+        if (p.print_time_hrs <= 0) errs[`plate_${i}_print_time_hrs`] = 'Required';
+      });
+    }
     setErrors(errs);
     return Object.keys(errs).length === 0;
+  };
+
+  const addPlate = () => {
+    setPlates((rows) => [...rows, { parts_count: 1, material_g: 0, print_time_hrs: 0, printer_id: '' }]);
+  };
+  const removePlate = (index: number) => {
+    setPlates((rows) => rows.filter((_, i) => i !== index));
+  };
+  const updatePlate = (index: number, field: keyof PlateFormRow, value: string | number) => {
+    setPlates((rows) => rows.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
+    setErrors((e) => ({ ...e, [`plate_${index}_${field}`]: '' }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -253,13 +317,38 @@ export default function JobFormPage() {
     if (!validate()) return;
     setSaving(true);
     try {
-      const payload = {
-        ...form,
+      const basePayload: Record<string, unknown> = {
+        job_number: form.job_number,
+        date: form.date,
         customer_name: form.customer_name || null,
+        product_name: form.product_name,
+        material_id: form.material_id,
+        labor_mins: form.labor_mins,
         design_time_hrs: form.design_time_hrs || 0,
+        shipping_cost: form.shipping_cost,
+        target_margin_pct: form.target_margin_pct,
         product_id: form.product_id || null,
         printer_id: form.printer_id || null,
+        status: form.status,
       };
+      let payload: Record<string, unknown>;
+      if (plateMode === 'mixed') {
+        const platePayload: PlateInput[] = plates.map((p) => ({
+          parts_count: Number(p.parts_count),
+          material_g: Number(p.material_g),
+          print_time_hrs: Number(p.print_time_hrs),
+          printer_id: p.printer_id || null,
+        }));
+        payload = { ...basePayload, plates: platePayload };
+      } else {
+        payload = {
+          ...basePayload,
+          qty_per_plate: form.qty_per_plate,
+          num_plates: form.num_plates,
+          material_per_plate_g: form.material_per_plate_g,
+          print_time_per_plate_hrs: form.print_time_per_plate_hrs,
+        };
+      }
       if (isEdit) {
         await api.put(`/jobs/${id}`, payload);
         toast.success('Job updated');
@@ -431,8 +520,26 @@ export default function JobFormPage() {
 
           {/* Print Details */}
           <div className="bg-card border border-border rounded-lg p-6">
-            <h3 className="text-base font-semibold mb-4">Print Details</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-base font-semibold">Print Details</h3>
+              <div className="inline-flex rounded-md border border-input overflow-hidden text-xs">
+                <button
+                  type="button"
+                  onClick={() => setPlateMode('uniform')}
+                  className={`px-3 py-1 ${plateMode === 'uniform' ? 'bg-primary text-primary-foreground' : 'bg-background'}`}
+                >
+                  Uniform plates
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPlateMode('mixed')}
+                  className={`px-3 py-1 border-l border-input ${plateMode === 'mixed' ? 'bg-primary text-primary-foreground' : 'bg-background'}`}
+                >
+                  Mixed plates
+                </button>
+              </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
               <div className="space-y-1.5">
                 <Label htmlFor="job-material">Material</Label>
                 <select
@@ -448,11 +555,91 @@ export default function JobFormPage() {
                 </select>
                 {errors.material_id && <p className="text-destructive text-xs">{errors.material_id}</p>}
               </div>
-              <Field label="Qty per Plate" field="qty_per_plate" type="number" value={form.qty_per_plate} error={errors.qty_per_plate} onChange={update} min={1} />
-              <Field label="Number of Plates" field="num_plates" type="number" value={form.num_plates} error={errors.num_plates} onChange={update} min={1} />
-              <Field label="Material per Plate (g)" field="material_per_plate_g" type="number" value={form.material_per_plate_g} error={errors.material_per_plate_g} onChange={update} min={0} step="0.01" />
-              <Field label="Print Time per Plate (hrs)" field="print_time_per_plate_hrs" type="number" value={form.print_time_per_plate_hrs} error={errors.print_time_per_plate_hrs} onChange={update} min={0} step="0.01" />
             </div>
+            {plateMode === 'uniform' ? (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <Field label="Qty per Plate" field="qty_per_plate" type="number" value={form.qty_per_plate} error={errors.qty_per_plate} onChange={update} min={1} />
+                <Field label="Number of Plates" field="num_plates" type="number" value={form.num_plates} error={errors.num_plates} onChange={update} min={1} />
+                <Field label="Material per Plate (g)" field="material_per_plate_g" type="number" value={form.material_per_plate_g} error={errors.material_per_plate_g} onChange={update} min={0} step="0.01" />
+                <Field label="Print Time per Plate (hrs)" field="print_time_per_plate_hrs" type="number" value={form.print_time_per_plate_hrs} error={errors.print_time_per_plate_hrs} onChange={update} min={0} step="0.01" />
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <p className="text-xs text-muted-foreground">
+                  Define each plate individually. Totals (pieces, material, print time) sum across plates.
+                </p>
+                {errors.plates && <p className="text-destructive text-xs">{errors.plates}</p>}
+                <div className="space-y-2">
+                  {plates.map((plate, index) => (
+                    <div key={index} className="grid grid-cols-12 gap-2 items-end p-3 border border-border rounded-md bg-muted/30">
+                      <div className="col-span-1 text-xs text-muted-foreground self-center">#{index + 1}</div>
+                      <div className="col-span-2 space-y-1">
+                        <Label htmlFor={`plate-${index}-parts`}>Parts</Label>
+                        <Input
+                          id={`plate-${index}-parts`}
+                          type="number"
+                          min={1}
+                          value={plate.parts_count}
+                          onChange={(e) => updatePlate(index, 'parts_count', Number(e.target.value))}
+                          invalid={Boolean(errors[`plate_${index}_parts_count`])}
+                        />
+                      </div>
+                      <div className="col-span-2 space-y-1">
+                        <Label htmlFor={`plate-${index}-material`}>Material (g)</Label>
+                        <Input
+                          id={`plate-${index}-material`}
+                          type="number"
+                          min={0}
+                          step="0.01"
+                          value={plate.material_g}
+                          onChange={(e) => updatePlate(index, 'material_g', Number(e.target.value))}
+                          invalid={Boolean(errors[`plate_${index}_material_g`])}
+                        />
+                      </div>
+                      <div className="col-span-2 space-y-1">
+                        <Label htmlFor={`plate-${index}-time`}>Time (hrs)</Label>
+                        <Input
+                          id={`plate-${index}-time`}
+                          type="number"
+                          min={0}
+                          step="0.01"
+                          value={plate.print_time_hrs}
+                          onChange={(e) => updatePlate(index, 'print_time_hrs', Number(e.target.value))}
+                          invalid={Boolean(errors[`plate_${index}_print_time_hrs`])}
+                        />
+                      </div>
+                      <div className="col-span-4 space-y-1">
+                        <Label htmlFor={`plate-${index}-printer`}>Printer</Label>
+                        <select
+                          id={`plate-${index}-printer`}
+                          value={plate.printer_id}
+                          onChange={(e) => updatePlate(index, 'printer_id', e.target.value)}
+                          className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+                        >
+                          <option value="">Unassigned</option>
+                          {printersData?.items?.map((printer) => (
+                            <option key={printer.id} value={printer.id}>{printer.name}</option>
+                          ))}
+                        </select>
+                      </div>
+                      <div className="col-span-1 flex justify-end">
+                        <button
+                          type="button"
+                          onClick={() => removePlate(index)}
+                          disabled={plates.length === 1}
+                          className="text-xs text-destructive hover:underline disabled:opacity-30 disabled:no-underline"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <Button type="button" variant="outline" size="sm" onClick={addPlate}>
+                  <Plus className="w-3.5 h-3.5 mr-1" /> Add plate
+                </Button>
+              </div>
+            )}
           </div>
 
           {/* Labor & Costs */}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -196,6 +196,23 @@ export interface PaginatedPrinters {
   limit: number;
 }
 
+export interface Plate {
+  id: string;
+  plate_number: number;
+  printer_id: string | null;
+  parts_count: number;
+  material_g: number;
+  print_time_hrs: number;
+}
+
+export interface PlateInput {
+  plate_number?: number | null;
+  printer_id?: string | null;
+  parts_count: number;
+  material_g: number;
+  print_time_hrs: number;
+}
+
 export interface Job {
   id: string;
   job_number: string;
@@ -203,12 +220,14 @@ export interface Job {
   customer_id: string | null;
   customer_name: string | null;
   product_name: string;
-  qty_per_plate: number;
-  num_plates: number;
+  qty_per_plate: number | null;
+  num_plates: number | null;
   material_id: string;
   total_pieces: number;
-  material_per_plate_g: number;
-  print_time_per_plate_hrs: number;
+  material_per_plate_g: number | null;
+  print_time_per_plate_hrs: number | null;
+  total_material_g: number;
+  total_print_time_hrs: number;
   labor_mins: number;
   design_time_hrs: number | null;
   electricity_cost: number;
@@ -234,6 +253,7 @@ export interface Job {
   printer: Printer | null;
   inventory_added: boolean;
   status: string;
+  plates: Plate[];
 }
 
 export interface PaginatedJobs {


### PR DESCRIPTION
## Summary

Closes #399. Introduces a `Plate` child entity on `Job` so multi-part prints record per-plate `parts_count`, `material_g`, `print_time_hrs`, and `printer_id`. Inventory accounting now reads `total_material_g` directly instead of computing `material_per_plate_g * num_plates`, which silently miscomputed for non-uniform plates.

The uniform input UX is preserved as a convenience that auto-expands to N identical plate rows server-side — no change for existing uniform-job flows.

## Changes

**Backend**
- New `plates` table + Alembic migration `20260512_01_job_plates.py`. Backfills every existing Job into N identical plate rows and populates the new `total_material_g` / `total_print_time_hrs` columns on `jobs`. Legacy `qty_per_plate` / `num_plates` / `material_per_plate_g` / `print_time_per_plate_hrs` made nullable; remain populated for uniform jobs.
- `app/services/plate_service.py` centralizes uniform→N expansion + total aggregation. All write paths (create, update, duplicate, quote-convert, discovery promote) funnel through it.
- `cost_calculator.calculate()` now accepts totals (`total_pieces`, `total_material_g`, `total_print_time_hrs`) directly; legacy uniform kwargs retained for `/jobs/calculate` preview and the Quote flow.
- `inventory_accounting_service.consume_material_receipts_for_job` reads `job.total_material_g` — single-line change, but the highest-risk piece.
- `report_service` material-usage report sums `Job.total_material_g`.
- Jobs API: POST/PUT/duplicate accept either uniform fields OR a `plates: [...]` array; mode validated via pydantic `model_validator`.

**Frontend**
- New `Plate` / `PlateInput` types; `Job.qty_per_plate` and friends now nullable.
- `JobFormPage` gets a Uniform/Mixed toggle. Mixed mode renders per-plate rows (parts, material g, print time, printer dropdown) with add/remove.
- `JobDetailPage` renders a plates table when present.

**Tests**
- 5 new backend cases covering mixed-plate create, uniform regression, mode validation, update-replaces-plates, and end-to-end mixed-plate inventory deduction.
- Existing inventory accounting test updated to set the authoritative `total_material_g`.

**Out of scope (separate follow-ups)**
- Quote schema mixed-plate input.
- CalculatorPage mixed mode.
- Per-plate timestamps / printer telemetry.

## Test plan

- [x] `python3 -m pytest backend/tests -q` — 739 passing pre-change, all green after.
- [x] `cd frontend && npm run build` — typecheck + build clean.
- [ ] Migration smoke test on a copy of prod DB: confirm plate row counts match `SUM(num_plates)` and `total_material_g` matches `material_per_plate_g * num_plates` for every backfilled job.
- [ ] Manual: create uniform job (totals match), create mixed 3-plate job across 2 printers (totals = sums, detail page lists plates), complete a mixed job with linked product and verify `MaterialReceipt.quantity_remaining_g` debited by the exact plate-material sum.

## Risk

Inventory accounting is operationally sensitive. The migration backfill is the highest-risk piece — review the parity check before deploy. Recommended: dry-run migration on staging/prod-copy first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)