### PR TITLE
fix(jobs): #399 mixed plates — pieces = min(parts) not sum

### DIFF
--- a/backend/app/api/v1/endpoints/jobs.py
+++ b/backend/app/api/v1/endpoints/jobs.py
@@ -132,7 +132,7 @@ async def create_job(body: JobCreate, user: CurrentUser, db: DB):
         raise HTTPException(status_code=409, detail=f"Job number '{job_number}' already exists")
 
     plate_rows, is_mixed = _materialize_plates(body)
-    total_pieces, total_material_g, total_print_time_hrs = aggregate_plate_totals(plate_rows)
+    total_pieces, total_material_g, total_print_time_hrs = aggregate_plate_totals(plate_rows, mixed=is_mixed)
 
     calc = CostCalculator(db)
     costs = await calc.calculate(
@@ -251,7 +251,8 @@ async def update_job(job_id: uuid.UUID, body: JobUpdate, user: CurrentUser, db: 
                 )
             )
 
-    total_pieces, total_material_g, total_print_time_hrs = aggregate_plate_totals(job.plates)
+    is_mixed_now = job.qty_per_plate is None
+    total_pieces, total_material_g, total_print_time_hrs = aggregate_plate_totals(job.plates, mixed=is_mixed_now)
     job.total_pieces = total_pieces
     job.total_material_g = total_material_g
     job.total_print_time_hrs = total_print_time_hrs
@@ -317,7 +318,8 @@ async def duplicate_job(job_id: uuid.UUID, user: CurrentUser, db: DB):
         for p in source_job.plates
     ]
 
-    total_pieces, total_material_g, total_print_time_hrs = aggregate_plate_totals(cloned_plates)
+    source_is_mixed = source_job.qty_per_plate is None
+    total_pieces, total_material_g, total_print_time_hrs = aggregate_plate_totals(cloned_plates, mixed=source_is_mixed)
 
     calc = CostCalculator(db)
     costs = await calc.calculate(

--- a/backend/app/services/plate_service.py
+++ b/backend/app/services/plate_service.py
@@ -52,15 +52,22 @@ def build_plates_from_input(plates_in: Iterable[PlateIn]) -> list[Plate]:
     return result
 
 
-def aggregate_plate_totals(plates: Iterable[Plate]) -> tuple[int, Decimal, Decimal]:
-    """Return (total_pieces, total_material_g, total_print_time_hrs) for a plate collection."""
-    total_pieces = 0
-    total_material_g = Decimal(0)
-    total_print_hrs = Decimal(0)
-    for p in plates:
-        total_pieces += int(p.parts_count)
-        total_material_g += Decimal(p.material_g)
-        total_print_hrs += Decimal(p.print_time_hrs)
+def aggregate_plate_totals(plates: Iterable[Plate], *, mixed: bool = False) -> tuple[int, Decimal, Decimal]:
+    """Return (total_pieces, total_material_g, total_print_time_hrs) for a plate collection.
+
+    Uniform jobs (`mixed=False`): each plate is an independent duplicate, so
+    total_pieces = sum(parts_count). Mixed (multi-part assembly) jobs:
+    each plate produces a different part of one finished piece, so
+    total_pieces = min(parts_count) — the number of complete assemblies.
+    Material and print time always sum (every plate runs).
+    """
+    plates_list = list(plates)
+    if not plates_list:
+        return 0, Decimal(0), Decimal(0)
+    total_material_g = sum((Decimal(p.material_g) for p in plates_list), Decimal(0))
+    total_print_hrs = sum((Decimal(p.print_time_hrs) for p in plates_list), Decimal(0))
+    parts = [int(p.parts_count) for p in plates_list]
+    total_pieces = min(parts) if mixed else sum(parts)
     return total_pieces, total_material_g, total_print_hrs
 
 

--- a/backend/tests/test_api_jobs.py
+++ b/backend/tests/test_api_jobs.py
@@ -540,8 +540,9 @@ async def test_create_job_with_mixed_plates(client, seed_settings, seed_rates, s
     )
     assert resp.status_code == 201, resp.text
     data = resp.json()
-    # Sums, not products
-    assert data["total_pieces"] == 12
+    # Mixed mode: pieces = min(parts_count) = complete assemblies
+    assert data["total_pieces"] == 2
+    # Material and time still sum across plates
     assert float(data["total_material_g"]) == pytest.approx(160.0)
     assert float(data["total_print_time_hrs"]) == pytest.approx(6.5)
     # Uniform conveniences nulled for mixed jobs
@@ -622,6 +623,7 @@ async def test_update_job_replace_plates(client, seed_settings, seed_rates, seed
     )
     assert upd.status_code == 200, upd.text
     data = upd.json()
+    # Single-plate mixed job: min == sum == 7
     assert data["total_pieces"] == 7
     assert float(data["total_material_g"]) == pytest.approx(100.0)
     assert len(data["plates"]) == 1

--- a/frontend/src/pages/JobFormPage.tsx
+++ b/frontend/src/pages/JobFormPage.tsx
@@ -180,15 +180,16 @@ export default function JobFormPage() {
     let material_per_plate_g = form.material_per_plate_g;
     let print_time_per_plate_hrs = form.print_time_per_plate_hrs;
     if (plateMode === 'mixed') {
-      const totalParts = plates.reduce((s, p) => s + (Number(p.parts_count) || 0), 0);
+      const partsCounts = plates.map((p) => Number(p.parts_count) || 0);
+      const assemblies = partsCounts.length > 0 ? Math.min(...partsCounts) : 0;
       const totalMaterial = plates.reduce((s, p) => s + (Number(p.material_g) || 0), 0);
       const totalTime = plates.reduce((s, p) => s + (Number(p.print_time_hrs) || 0), 0);
-      if (totalParts <= 0 || totalMaterial <= 0 || totalTime <= 0) {
+      if (assemblies <= 0 || totalMaterial <= 0 || totalTime <= 0) {
         setPreview(null);
         return;
       }
-      // Use a 1-plate equivalent — the math in cost_calculator only depends on totals.
-      qty_per_plate = totalParts;
+      // Mixed mode: total_pieces = min(parts) = number of complete assemblies.
+      qty_per_plate = assemblies;
       num_plates = 1;
       material_per_plate_g = totalMaterial;
       print_time_per_plate_hrs = totalTime;
@@ -566,8 +567,21 @@ export default function JobFormPage() {
             ) : (
               <div className="space-y-3">
                 <p className="text-xs text-muted-foreground">
-                  Define each plate individually. Totals (pieces, material, print time) sum across plates.
+                  Define each plate as a distinct part of one assembly. Finished pieces = the smallest parts count
+                  across plates (the complete-assembly count). Material and print time sum across plates.
                 </p>
+                {(() => {
+                  const counts = plates.map((p) => Number(p.parts_count) || 0).filter((n) => n > 0);
+                  if (counts.length < 2) return null;
+                  const lo = Math.min(...counts);
+                  const hi = Math.max(...counts);
+                  if (hi === lo) return null;
+                  return (
+                    <p className="text-amber-600 text-xs">
+                      Overproduction: some plates print {hi} parts but the limiting plate prints {lo}. {hi - lo} excess part(s) won't form complete assemblies.
+                    </p>
+                  );
+                })()}
                 {errors.plates && <p className="text-destructive text-xs">{errors.plates}</p>}
                 <div className="space-y-2">
                   {plates.map((plate, index) => (


### PR DESCRIPTION
## Summary

Follow-up to #400. Multi-part assembly jobs now compute \`total_pieces = min(plate.parts_count)\` — the number of complete assemblies — instead of summing parts across plates. Fixes incorrect cost-per-piece in the form preview and ensures inventory adds the right number of finished goods on completion.

- Plate 1: 1 part, Plate 2: 1 part → **1 finished assembly**, cost/piece = total cost.
- Plate 1: 4 of Part A, Plate 2: 4 of Part B → **4 assemblies**, cost/piece = total / 4.
- Plate 1: 4, Plate 2: 8 → 4 assemblies; the form warns about 4 excess parts.

Uniform jobs unaffected (sum semantics preserved).

## Test plan

- [x] \`pytest backend/tests/test_api_jobs.py test_inventory_accounting.py\` — green, including the existing mixed-plate cases updated for the new semantics.
- [x] \`npm run build\` — clean.
- [ ] Manual: reopen the form from the screenshot scenario and confirm cost/piece = \$17.45.

No migration needed — zero mixed-mode jobs in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)